### PR TITLE
Add .env support to fyn shell

### DIFF
--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -4370,6 +4370,21 @@ pub struct ShellArgs {
     #[arg(value_hint = ValueHint::DirPath)]
     pub path: Option<PathBuf>,
 
+    /// Load environment variables from a `.env` file.
+    ///
+    /// Can be provided multiple times, with subsequent files overriding values defined in previous
+    /// files.
+    #[arg(long, env = EnvVars::UV_ENV_FILE, value_hint = ValueHint::FilePath)]
+    pub env_file: Vec<String>,
+
+    /// Avoid reading environment variables from a `.env` file [env: UV_NO_ENV_FILE=]
+    #[arg(
+        long,
+        env = EnvVars::UV_NO_ENV_FILE,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
+    pub no_env_file: bool,
+
     /// Avoid discovering a project or workspace.
     ///
     /// By default, fyn searches for projects in the current directory or any

--- a/crates/fyn-test/src/lib.rs
+++ b/crates/fyn-test/src/lib.rs
@@ -1321,6 +1321,22 @@ impl TestContext {
         command
     }
 
+    /// Create a `fyn shell` command with options shared across scenarios.
+    pub fn shell(&self) -> Command {
+        let mut command = self.new_command();
+        command.arg("shell");
+        self.add_shared_options(&mut command, false);
+        command
+            .env_remove(EnvVars::NU_VERSION)
+            .env_remove(EnvVars::FISH_VERSION)
+            .env_remove(EnvVars::BASH_VERSION)
+            .env_remove(EnvVars::ZSH_VERSION)
+            .env_remove(EnvVars::KSH_VERSION)
+            .env_remove(EnvVars::PS_MODULE_PATH)
+            .env_remove(EnvVars::PROMPT);
+        command
+    }
+
     /// Create a `pip install` command with options shared across scenarios.
     pub fn pip_install(&self) -> Command {
         let mut command = self.new_command();

--- a/crates/fyn/src/commands/mod.rs
+++ b/crates/fyn/src/commands/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::{fmt::Write, process::ExitCode};
 
 use anstream::AutoStream;
-use anyhow::Context;
+use anyhow::{Context, bail};
 use owo_colors::OwoColorize;
 use tracing::debug;
 
@@ -20,12 +20,13 @@ pub(crate) use cache_dir::cache_dir;
 pub(crate) use cache_prune::cache_prune;
 pub(crate) use cache_size::cache_size;
 use fyn_cache::Cache;
-use fyn_configuration::Concurrency;
+use fyn_configuration::{Concurrency, EnvFile};
 pub(crate) use fyn_console::human_readable_bytes;
 use fyn_fs::{CWD, Simplified};
 use fyn_installer::compile_tree;
 use fyn_python::PythonEnvironment;
 use fyn_scripts::Pep723Script;
+use fyn_warnings::warn_user;
 pub(crate) use help::help;
 pub(crate) use pip::check::pip_check;
 pub(crate) use pip::compile::pip_compile;
@@ -145,6 +146,91 @@ pub(super) fn elapsed(duration: Duration) -> String {
     } else {
         format!("0.{:02}ms", duration.subsec_nanos() / 10_000)
     }
+}
+
+/// Load environment variables from one or more explicit `.env` files.
+///
+/// Files are loaded in reverse order so later paths override earlier ones while still preserving
+/// values already present in the process environment.
+pub(super) fn load_explicit_env_files<'a>(
+    env_file_paths: impl DoubleEndedIterator<Item = &'a Path>,
+) -> anyhow::Result<()> {
+    for env_file_path in env_file_paths.rev() {
+        match dotenvy::from_path(env_file_path) {
+            Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                bail!(
+                    "No environment file found at: `{}`",
+                    env_file_path.simplified_display()
+                );
+            }
+            Err(dotenvy::Error::Io(err)) => {
+                bail!(
+                    "Failed to read environment file `{}`: {err}",
+                    env_file_path.simplified_display()
+                );
+            }
+            Err(dotenvy::Error::LineParse(content, position)) => {
+                warn_user!(
+                    "Failed to parse environment file `{}` at position {position}: {content}",
+                    env_file_path.simplified_display(),
+                );
+            }
+            Err(err) => {
+                warn_user!(
+                    "Failed to parse environment file `{}`: {err}",
+                    env_file_path.simplified_display(),
+                );
+            }
+            Ok(()) => {
+                debug!(
+                    "Read environment file at: `{}`",
+                    env_file_path.simplified_display()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Load environment variables from the default `.env` file in the current directory.
+///
+/// Missing files are ignored to keep default loading a no-op when no `.env` file is present.
+pub(super) fn load_default_env_file(filename: &Path) -> anyhow::Result<()> {
+    match dotenvy::from_path(filename) {
+        Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(dotenvy::Error::Io(err)) => {
+            bail!(
+                "Failed to read environment file `{}`: {err}",
+                filename.simplified_display()
+            );
+        }
+        Err(dotenvy::Error::LineParse(content, position)) => {
+            warn_user!(
+                "Failed to parse environment file `{}` at position {position}: {content}",
+                filename.simplified_display(),
+            );
+            Ok(())
+        }
+        Err(err) => {
+            warn_user!(
+                "Failed to parse environment file `{}`: {err}",
+                filename.simplified_display(),
+            );
+            Ok(())
+        }
+        Ok(()) => {
+            debug!(
+                "Read default environment file at: `{}`",
+                filename.simplified_display()
+            );
+            Ok(())
+        }
+    }
+}
+
+pub(super) fn has_explicit_env_files(env_file: &EnvFile) -> bool {
+    env_file.iter().next().is_some()
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]

--- a/crates/fyn/src/commands/project/run.rs
+++ b/crates/fyn/src/commands/project/run.rs
@@ -164,40 +164,7 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
     let sync_state = lock_state.fork();
 
     // Read from the `.env` file, if necessary.
-    for env_file_path in env_file.iter().rev().map(PathBuf::as_path) {
-        match dotenvy::from_path(env_file_path) {
-            Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
-                bail!(
-                    "No environment file found at: `{}`",
-                    env_file_path.simplified_display()
-                );
-            }
-            Err(dotenvy::Error::Io(err)) => {
-                bail!(
-                    "Failed to read environment file `{}`: {err}",
-                    env_file_path.simplified_display()
-                );
-            }
-            Err(dotenvy::Error::LineParse(content, position)) => {
-                warn_user!(
-                    "Failed to parse environment file `{}` at position {position}: {content}",
-                    env_file_path.simplified_display(),
-                );
-            }
-            Err(err) => {
-                warn_user!(
-                    "Failed to parse environment file `{}`: {err}",
-                    env_file_path.simplified_display(),
-                );
-            }
-            Ok(()) => {
-                debug!(
-                    "Read environment file at: `{}`",
-                    env_file_path.simplified_display()
-                );
-            }
-        }
-    }
+    crate::commands::load_explicit_env_files(env_file.iter().map(PathBuf::as_path))?;
 
     // Initialize any output reporters.
     let download_reporter = PythonDownloadReporter::single(printer);

--- a/crates/fyn/src/commands/shell.rs
+++ b/crates/fyn/src/commands/shell.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fmt::Write;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -7,6 +8,7 @@ use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 
 use fyn_cache::Cache;
+use fyn_configuration::EnvFile;
 use fyn_fs::Simplified;
 use fyn_python::PythonEnvironment;
 use fyn_shell::Shell;
@@ -20,6 +22,8 @@ use crate::printer::Printer;
 pub(crate) async fn shell(
     path: Option<PathBuf>,
     no_project: bool,
+    env_file: EnvFile,
+    no_env_file: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -87,6 +91,14 @@ pub(crate) async fn shell(
     let detected_shell = Shell::from_env().context(
         "Could not detect the current shell. Set the SHELL environment variable and try again.",
     )?;
+
+    if !no_env_file {
+        if crate::commands::has_explicit_env_files(&env_file) {
+            crate::commands::load_explicit_env_files(env_file.iter().map(PathBuf::as_path))?;
+        } else {
+            crate::commands::load_default_env_file(Path::new(".env"))?;
+        }
+    }
 
     // Get the scripts directory (bin on Unix, Scripts on Windows).
     let scripts = venv.scripts();

--- a/crates/fyn/src/commands/tool/run.rs
+++ b/crates/fyn/src/commands/tool/run.rs
@@ -41,7 +41,6 @@ use fyn_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use fyn_shell::runnable::WindowsRunnable;
 use fyn_static::EnvVars;
 use fyn_tool::{InstalledTools, entrypoint_paths};
-use fyn_warnings::warn_user;
 use fyn_warnings::warn_user_once;
 use fyn_workspace::WorkspaceCache;
 
@@ -140,40 +139,7 @@ pub(crate) async fn run(
 
     // Read from the `.env` file, if necessary.
     if !no_env_file {
-        for env_file_path in env_file.iter().rev().map(PathBuf::as_path) {
-            match dotenvy::from_path(env_file_path) {
-                Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
-                    bail!(
-                        "No environment file found at: `{}`",
-                        env_file_path.simplified_display()
-                    );
-                }
-                Err(dotenvy::Error::Io(err)) => {
-                    bail!(
-                        "Failed to read environment file `{}`: {err}",
-                        env_file_path.simplified_display()
-                    );
-                }
-                Err(dotenvy::Error::LineParse(content, position)) => {
-                    warn_user!(
-                        "Failed to parse environment file `{}` at position {position}: {content}",
-                        env_file_path.simplified_display(),
-                    );
-                }
-                Err(err) => {
-                    warn_user!(
-                        "Failed to parse environment file `{}`: {err}",
-                        env_file_path.simplified_display(),
-                    );
-                }
-                Ok(()) => {
-                    debug!(
-                        "Read environment file at: `{}`",
-                        env_file_path.simplified_display()
-                    );
-                }
-            }
-        }
+        crate::commands::load_explicit_env_files(env_file.iter().map(PathBuf::as_path))?;
     }
 
     let Some(command) = command else {

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -35,7 +35,7 @@ use fyn_cli::{
     WorkspaceNamespace, compat::CompatArgs,
 };
 use fyn_client::BaseClientBuilder;
-use fyn_configuration::min_stack_size;
+use fyn_configuration::{EnvFile, min_stack_size};
 use fyn_flags::EnvironmentFlags;
 use fyn_fs::{CWD, Simplified};
 #[cfg(feature = "self-update")]
@@ -1682,7 +1682,15 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         }
         Commands::Shell(args) => {
             let cache = cache.init().await?;
-            commands::shell(args.path, args.no_project, &cache, printer).await
+            commands::shell(
+                args.path,
+                args.no_project,
+                EnvFile::from_args(args.env_file, args.no_env_file),
+                args.no_env_file,
+                &cache,
+                printer,
+            )
+            .await
         }
         Commands::Project(project) => {
             Box::pin(run_project(

--- a/crates/fyn/tests/it/help.rs
+++ b/crates/fyn/tests/it/help.rs
@@ -926,6 +926,19 @@ fn help_torch_doctor_subcommand() {
 }
 
 #[test]
+fn help_shell_subcommand() {
+    let context = fyn_test::test_context_with_versions!(&[]);
+    let output = context.help().arg("shell").output().unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Activate the virtual environment in a new shell."));
+    assert!(stdout.contains("Usage: fyn shell [OPTIONS] [PATH]"));
+    assert!(stdout.contains("--env-file"));
+    assert!(stdout.contains("--no-env-file"));
+}
+
+#[test]
 fn help_unknown_subcommand() {
     let context = fyn_test::test_context_with_versions!(&[]);
 

--- a/crates/fyn/tests/it/main.rs
+++ b/crates/fyn/tests/it/main.rs
@@ -121,6 +121,9 @@ mod python_upgrade;
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod run;
 
+#[cfg(feature = "test-python")]
+mod shell;
+
 #[cfg(feature = "self-update")]
 mod self_update;
 

--- a/crates/fyn/tests/it/shell.rs
+++ b/crates/fyn/tests/it/shell.rs
@@ -1,0 +1,263 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(unix)]
+use anyhow::Result;
+#[cfg(unix)]
+use assert_fs::prelude::*;
+#[cfg(unix)]
+use fyn_test::fyn_snapshot;
+#[cfg(unix)]
+use indoc::indoc;
+
+#[cfg(unix)]
+fn install_fake_bash(context: &fyn_test::TestContext) -> Result<()> {
+    let bash = context.bin_dir.child("bash");
+    bash.write_str(indoc! {r#"
+        #!/bin/sh
+        python - <<'PY'
+        import os
+        import sys
+
+        print(os.environ.get("FYN_TEST_EMPIRE_VARIABLE"))
+        print(os.environ.get("FYN_TEST_REBEL_VARIABLE"))
+        print(os.environ.get("VIRTUAL_ENV") == sys.prefix)
+        print(os.path.basename(sys.prefix))
+        PY
+        "#})?;
+
+    let mut perms = fs_err::metadata(bash.path())?.permissions();
+    perms.set_mode(0o755);
+    fs_err::set_permissions(bash.path(), perms)?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_with_default_env_file() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    context.temp_dir.child(".env").write_str(indoc! {"
+        FYN_TEST_EMPIRE_VARIABLE=palpatine
+        FYN_TEST_REBEL_VARIABLE=leia
+    "})?;
+
+    fyn_snapshot!(context.filters(), context.shell(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    palpatine
+    leia
+    True
+    .venv
+
+    ----- stderr -----
+    success: Activated virtual environment at [VENV]/
+    Type exit to deactivate.
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_with_default_env_file_missing_is_a_noop() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    fyn_snapshot!(context.filters(), context.shell(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    None
+    None
+    True
+    .venv
+
+    ----- stderr -----
+    success: Activated virtual environment at [VENV]/
+    Type exit to deactivate.
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_with_explicit_env_file_skips_default_env_file() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    context.temp_dir.child(".env").write_str(indoc! {"
+        FYN_TEST_EMPIRE_VARIABLE=default_value
+    "})?;
+    context.temp_dir.child(".file").write_str(indoc! {"
+        FYN_TEST_EMPIRE_VARIABLE=explicit_value
+        FYN_TEST_REBEL_VARIABLE=han
+    "})?;
+
+    fyn_snapshot!(context.filters(), context.shell().arg("--env-file").arg(".file"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    explicit_value
+    han
+    True
+    .venv
+
+    ----- stderr -----
+    success: Activated virtual environment at [VENV]/
+    Type exit to deactivate.
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_with_multiple_env_files_from_environment() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    context.temp_dir.child(".env1").write_str(indoc! {"
+        FYN_TEST_EMPIRE_VARIABLE=palpatine
+        FYN_TEST_REBEL_VARIABLE=leia
+    "})?;
+    context.temp_dir.child(".env2").write_str(indoc! {"
+        FYN_TEST_REBEL_VARIABLE=obi_wan
+    "})?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .shell()
+            .env("UV_ENV_FILE", ".env1 .env2"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    palpatine
+    obi_wan
+    True
+    .venv
+
+    ----- stderr -----
+    success: Activated virtual environment at [VENV]/
+    Type exit to deactivate.
+    "
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_with_env_omitted() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    context.temp_dir.child(".env").write_str(indoc! {"
+        FYN_TEST_EMPIRE_VARIABLE=palpatine
+    "})?;
+
+    fyn_snapshot!(context.filters(), context.shell().arg("--no-env-file"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    None
+    None
+    True
+    .venv
+
+    ----- stderr -----
+    success: Activated virtual environment at [VENV]/
+    Type exit to deactivate.
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_with_malformed_default_env_file() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    context.temp_dir.child(".env").write_str(indoc! {"
+        FYN_^TEST_EMPIRE_VARIABLE=darth_vader
+    "})?;
+
+    fyn_snapshot!(context.filters(), context.shell(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    None
+    None
+    True
+    .venv
+
+    ----- stderr -----
+    warning: Failed to parse environment file `.env` at position 4: FYN_^TEST_EMPIRE_VARIABLE=darth_vader
+    success: Activated virtual environment at [VENV]/
+    Type exit to deactivate.
+    ");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_with_not_existing_explicit_env_file() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context.shell().arg("--env-file").arg(".env.development"),
+        @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No environment file found at: `.env.development`
+    "
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_preserves_existing_environment_over_env_file() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    install_fake_bash(&context)?;
+
+    context.temp_dir.child(".env").write_str(indoc! {"
+        FYN_TEST_EMPIRE_VARIABLE=palpatine
+    "})?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .shell()
+            .env("FYN_TEST_EMPIRE_VARIABLE", "darth_vader"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    darth_vader
+    None
+    True
+    .venv
+
+    ----- stderr -----
+    success: Activated virtual environment at [VENV]/
+    Type exit to deactivate.
+    "
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- add `.env` support to `fyn shell` with `--env-file` and `--no-env-file`
- load the default `.env` automatically for `fyn shell` when no explicit env file is provided, while treating a missing default file as a no-op
- reuse shared dotenv loading helpers across `run`, `tool run`, and `shell` to keep parsing and error handling consistent

## Testing

- `cargo test -p fyn --test it -- shell_`
- `cargo fmt --check`
