### PR TITLE
fix: sync uv uninstall safety and record healing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "fyn-fs",
  "fyn-git",
  "fyn-git-types",
+ "fyn-install-wheel",
  "fyn-metadata",
  "fyn-normalize",
  "fyn-pep440",

--- a/crates/fyn-audit/src/service/osv.rs
+++ b/crates/fyn-audit/src/service/osv.rs
@@ -180,6 +180,25 @@ struct QueryBatchResponse {
     results: Vec<QueryBatchResult>,
 }
 
+/// Filter for OSV queries.
+#[derive(Debug, Copy, Clone)]
+pub enum Filter {
+    /// Return all vulnerabilities.
+    All,
+    /// Return only vulnerabilities matching the `MAL-` prefix.
+    Malware,
+}
+
+impl Filter {
+    /// Returns `true` if the given vulnerability ID matches this filter.
+    fn matches(self, id: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Malware => id.starts_with("MAL-"),
+        }
+    }
+}
+
 /// Represents [OSV](https://osv.dev/), an open-source vulnerability database.
 pub struct Osv {
     base_url: DisplaySafeUrl,
@@ -208,6 +227,7 @@ impl Osv {
     pub async fn query_batch(
         &self,
         dependencies: &[types::Dependency],
+        filter: Filter,
     ) -> Result<Vec<types::Finding>, Error> {
         if dependencies.is_empty() {
             return Ok(vec![]);
@@ -253,7 +273,13 @@ impl Osv {
 
             let mut next_pending = Vec::new();
             for ((dep, _), result) in pending.iter().zip(batch_response.results.iter()) {
-                dep_vuln_ids.extend(result.vulns.iter().map(|v| (*dep, v.id.clone())));
+                dep_vuln_ids.extend(
+                    result
+                        .vulns
+                        .iter()
+                        .filter(|v| filter.matches(&v.id))
+                        .map(|v| (*dep, v.id.clone())),
+                );
                 if let Some(token) = &result.next_page_token {
                     next_pending.push((*dep, Some(token.clone())));
                 }
@@ -403,7 +429,7 @@ mod tests {
     use wiremock::matchers::{body_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use crate::service::osv::RangeType;
+    use crate::service::osv::{Filter, RangeType};
     use crate::types::{Dependency, Finding};
 
     use super::Event;
@@ -517,7 +543,7 @@ mod tests {
         ];
 
         let findings = osv
-            .query_batch(&dependencies)
+            .query_batch(&dependencies, Filter::All)
             .await
             .expect("Failed to query batch");
 
@@ -711,7 +737,7 @@ mod tests {
         ];
 
         let findings = osv
-            .query_batch(&dependencies)
+            .query_batch(&dependencies, Filter::All)
             .await
             .expect("Failed to query batch");
 
@@ -733,6 +759,72 @@ mod tests {
             server.received_requests().await.unwrap().len(),
             5,
             "Expected two querybatch requests and three vuln detail requests"
+        );
+    }
+
+    /// Ensure that `query_batch` with `Filter::Malware` only fetches `MAL-` prefixed
+    /// vulnerability IDs.
+    #[tokio::test]
+    async fn test_query_batch_malware_filter() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/v1/querybatch"))
+            .and(body_json(json!({
+                "queries": [
+                    {
+                        "package": { "name": "package-a", "ecosystem": "PyPI" },
+                        "version": "1.0.0",
+                    }
+                ]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "results": [
+                    {
+                        "vulns": [
+                            { "id": "MAL-2026-1234", "modified": "2026-01-01T00:00:00Z" },
+                            { "id": "GHSA-xxxx-yyyy", "modified": "2026-01-02T00:00:00Z" }
+                        ]
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/vulns/MAL-2026-1234"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "MAL-2026-1234",
+                "modified": "2026-01-01T00:00:00Z",
+            })))
+            .mount(&server)
+            .await;
+
+        let osv = Osv::new(
+            ClientWithMiddleware::default(),
+            Some(DisplaySafeUrl::parse(&server.uri()).unwrap()),
+            Concurrency::default(),
+        );
+
+        let dependencies = vec![Dependency::new(
+            PackageName::from_str("package-a").unwrap(),
+            Version::from_str("1.0.0").unwrap(),
+        )];
+
+        let findings = osv
+            .query_batch(&dependencies, Filter::Malware)
+            .await
+            .expect("Failed to query batch");
+
+        let [Finding::Vulnerability(vulnerability)] = findings.as_slice() else {
+            panic!("Expected exactly one vulnerability finding");
+        };
+
+        assert_eq!(vulnerability.id.as_str(), "MAL-2026-1234");
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            2,
+            "Expected one querybatch request and one vulnerability detail request"
         );
     }
 }

--- a/crates/fyn-dispatch/src/lib.rs
+++ b/crates/fyn-dispatch/src/lib.rs
@@ -380,8 +380,9 @@ impl BuildContext for BuildDispatch<'_> {
 
         // Remove any unnecessary packages.
         if !reinstalls.is_empty() {
+            let layout = venv.interpreter().layout();
             for dist_info in &reinstalls {
-                let summary = fyn_installer::uninstall(dist_info)
+                let summary = fyn_installer::uninstall(dist_info, &layout)
                     .await
                     .context("Failed to uninstall build dependencies")?;
                 debug!(

--- a/crates/fyn-distribution/Cargo.toml
+++ b/crates/fyn-distribution/Cargo.toml
@@ -28,6 +28,7 @@ fyn-flags = { workspace = true }
 fyn-fs = { workspace = true, features = ["tokio"] }
 fyn-git = { workspace = true }
 fyn-git-types = { workspace = true }
+fyn-install-wheel = { workspace = true }
 fyn-metadata = { workspace = true }
 fyn-normalize = { workspace = true }
 fyn-pep440 = { workspace = true }

--- a/crates/fyn-distribution/src/distribution_database.rs
+++ b/crates/fyn-distribution/src/distribution_database.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::{FutureExt, TryStreamExt};
-use tempfile::TempDir;
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
 use tokio::sync::Semaphore;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
@@ -25,6 +24,7 @@ use fyn_distribution_types::{
 };
 use fyn_extract::hash::Hasher;
 use fyn_fs::write_atomic;
+use fyn_install_wheel::validate_and_heal_record;
 use fyn_platform_tags::Tags;
 use fyn_pypi_types::{HashDigest, HashDigests, PyProjectToml};
 use fyn_python::PythonVariant;
@@ -442,7 +442,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         // Otherwise, unzip the wheel.
         let id = self
-            .unzip_wheel(&built_wheel.path, &built_wheel.target)
+            .unzip_wheel(&built_wheel.path, &built_wheel.target, dist)
             .await?;
 
         Ok(LocalWheel {
@@ -713,19 +713,19 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                 let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
                     .map_err(Error::CacheWrite)?;
 
-                match progress {
+                let files = match progress {
                     Some((reporter, progress)) => {
                         let mut reader = ProgressReader::new(&mut hasher, progress, &**reporter);
                         match extension {
                             WheelExtension::Whl => {
                                 fyn_extract::stream::unzip(query_url, &mut reader, temp_dir.path())
                                     .await
-                                    .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                                    .map_err(|err| Error::Extract(filename.to_string(), err))?
                             }
                             WheelExtension::WhlZst => {
                                 fyn_extract::stream::untar_zst(&mut reader, temp_dir.path())
                                     .await
-                                    .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                                    .map_err(|err| Error::Extract(filename.to_string(), err))?
                             }
                         }
                     }
@@ -733,20 +733,23 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         WheelExtension::Whl => {
                             fyn_extract::stream::unzip(query_url, &mut hasher, temp_dir.path())
                                 .await
-                                .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                                .map_err(|err| Error::Extract(filename.to_string(), err))?
                         }
                         WheelExtension::WhlZst => {
                             fyn_extract::stream::untar_zst(&mut hasher, temp_dir.path())
                                 .await
-                                .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                                .map_err(|err| Error::Extract(filename.to_string(), err))?
                         }
                     },
-                }
+                };
 
                 // If necessary, exhaust the reader to compute the hash.
                 if !hashes.is_none() {
                     hasher.finish().await.map_err(Error::HashExhaustion)?;
                 }
+
+                validate_and_heal_record(temp_dir.path(), files.iter(), dist)
+                    .map_err(Error::InstallWheelError)?;
 
                 // Persist the temporary directory to the directory store.
                 let id = self
@@ -913,51 +916,49 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     .map_err(Error::CacheWrite)?;
 
                 // If no hashes are required, parallelize the unzip operation.
-                let hashes = if hashes.is_none() {
+                let (files, hashes) = if hashes.is_none() {
                     let file = file.into_std().await;
-                    tokio::task::spawn_blocking({
-                        let target = temp_dir.path().to_owned();
-                        move || -> Result<(), fyn_extract::Error> {
-                            // Unzip the wheel into a temporary directory.
+                    let target = temp_dir.path().to_owned();
+                    let files =
+                        tokio::task::spawn_blocking(move || -> Result<_, fyn_extract::Error> {
                             match extension {
-                                WheelExtension::Whl => {
-                                    fyn_extract::unzip(file, &target)?;
-                                }
+                                WheelExtension::Whl => fyn_extract::unzip(file, &target),
                                 WheelExtension::WhlZst => {
-                                    fyn_extract::stream::untar_zst_file(file, &target)?;
+                                    fyn_extract::stream::untar_zst_file(file, &target)
                                 }
                             }
-                            Ok(())
-                        }
-                    })
-                    .await?
-                    .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                        })
+                        .await?
+                        .map_err(|err| Error::Extract(filename.to_string(), err))?;
 
-                    HashDigests::empty()
+                    (files, HashDigests::empty())
                 } else {
                     // Create a hasher for each hash algorithm.
                     let algorithms = hashes.algorithms();
                     let mut hashers = algorithms.into_iter().map(Hasher::from).collect::<Vec<_>>();
                     let mut hasher = fyn_extract::hash::HashReader::new(file, &mut hashers);
 
-                    match extension {
+                    let files = match extension {
                         WheelExtension::Whl => {
                             fyn_extract::stream::unzip(query_url, &mut hasher, temp_dir.path())
                                 .await
-                                .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                                .map_err(|err| Error::Extract(filename.to_string(), err))?
                         }
                         WheelExtension::WhlZst => {
                             fyn_extract::stream::untar_zst(&mut hasher, temp_dir.path())
                                 .await
-                                .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                                .map_err(|err| Error::Extract(filename.to_string(), err))?
                         }
-                    }
+                    };
 
                     // If necessary, exhaust the reader to compute the hash.
                     hasher.finish().await.map_err(Error::HashExhaustion)?;
 
-                    hashers.into_iter().map(HashDigest::from).collect()
+                    (files, hashers.into_iter().map(HashDigest::from).collect())
                 };
+
+                validate_and_heal_record(temp_dir.path(), files.iter(), dist)
+                    .map_err(Error::InstallWheelError)?;
 
                 // Persist the temporary directory to the directory store.
                 let id = self
@@ -1092,7 +1093,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         } else if hashes.is_none() {
             // Otherwise, unzip the wheel.
             let archive = Archive::new(
-                self.unzip_wheel(path, wheel_entry.path()).await?,
+                self.unzip_wheel(path, wheel_entry.path(), dist).await?,
                 HashDigests::empty(),
                 filename.clone(),
             );
@@ -1130,23 +1131,26 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             let mut hasher = fyn_extract::hash::HashReader::new(file, &mut hashers);
 
             // Unzip the wheel to a temporary directory.
-            match extension {
+            let files = match extension {
                 WheelExtension::Whl => {
                     fyn_extract::stream::unzip(path.display(), &mut hasher, temp_dir.path())
                         .await
-                        .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                        .map_err(|err| Error::Extract(filename.to_string(), err))?
                 }
                 WheelExtension::WhlZst => {
                     fyn_extract::stream::untar_zst(&mut hasher, temp_dir.path())
                         .await
-                        .map_err(|err| Error::Extract(filename.to_string(), err))?;
+                        .map_err(|err| Error::Extract(filename.to_string(), err))?
                 }
-            }
+            };
 
             // Exhaust the reader to compute the hash.
             hasher.finish().await.map_err(Error::HashExhaustion)?;
 
             let hashes = hashers.into_iter().map(HashDigest::from).collect();
+
+            validate_and_heal_record(temp_dir.path(), files.iter(), dist)
+                .map_err(Error::InstallWheelError)?;
 
             // Persist the temporary directory to the directory store.
             let id = self
@@ -1182,20 +1186,28 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
     }
 
     /// Unzip a wheel into the cache, returning the path to the unzipped directory.
-    async fn unzip_wheel(&self, path: &Path, target: &Path) -> Result<ArchiveId, Error> {
-        let temp_dir = tokio::task::spawn_blocking({
+    async fn unzip_wheel(
+        &self,
+        path: &Path,
+        target: &Path,
+        dist: impl std::fmt::Display,
+    ) -> Result<ArchiveId, Error> {
+        let (temp_dir, files) = tokio::task::spawn_blocking({
             let path = path.to_owned();
             let root = self.build_context.cache().root().to_path_buf();
-            move || -> Result<TempDir, Error> {
+            move || -> Result<_, Error> {
                 // Unzip the wheel into a temporary directory.
                 let temp_dir = tempfile::tempdir_in(root).map_err(Error::CacheWrite)?;
                 let reader = fs_err::File::open(&path).map_err(Error::CacheWrite)?;
-                fyn_extract::unzip(reader, temp_dir.path())
+                let files = fyn_extract::unzip(reader, temp_dir.path())
                     .map_err(|err| Error::Extract(path.to_string_lossy().into_owned(), err))?;
-                Ok(temp_dir)
+                Ok((temp_dir, files))
             }
         })
         .await??;
+
+        validate_and_heal_record(temp_dir.path(), files.iter(), dist)
+            .map_err(Error::InstallWheelError)?;
 
         // Persist the temporary directory to the directory store.
         let id = self

--- a/crates/fyn-distribution/src/error.rs
+++ b/crates/fyn-distribution/src/error.rs
@@ -12,6 +12,7 @@ use fyn_distribution_filename::{WheelFilename, WheelFilenameError};
 use fyn_distribution_types::{InstalledDist, InstalledDistError, IsBuildBackendError};
 use fyn_fs::Simplified;
 use fyn_git::GitError;
+use fyn_install_wheel::Error as InstallWheelError;
 use fyn_normalize::PackageName;
 use fyn_pep440::{Version, VersionSpecifiers};
 use fyn_platform_tags::Platform;
@@ -133,6 +134,8 @@ pub enum Error {
     MissingSubdirectory(DisplaySafeUrl, PathBuf),
     #[error("The source distribution `{0}` is missing Git LFS artifacts.")]
     MissingGitLfsArtifacts(DisplaySafeUrl, #[source] GitError),
+    #[error(transparent)]
+    InstallWheelError(#[from] InstallWheelError),
     #[error("Failed to extract static metadata from `PKG-INFO`")]
     PkgInfo(#[source] fyn_pypi_types::MetadataError),
     #[error("The source distribution is missing a `pyproject.toml` file")]

--- a/crates/fyn-extract/src/stream.rs
+++ b/crates/fyn-extract/src/stream.rs
@@ -52,7 +52,7 @@ pub async fn unzip<D: Display, R: tokio::io::AsyncRead + Unpin>(
     source_hint: D,
     reader: R,
     target: impl AsRef<Path>,
-) -> Result<(), Error> {
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     /// Ensure the file path is safe to use as a [`Path`].
     ///
     /// See: <https://docs.rs/zip/latest/zip/read/struct.ZipFile.html#method.enclosed_name>
@@ -82,6 +82,7 @@ pub async fn unzip<D: Display, R: tokio::io::AsyncRead + Unpin>(
 
     let mut directories = FxHashSet::default();
     let mut local_headers = FxHashMap::default();
+    let mut files = Vec::new();
     let mut offset = 0;
 
     while let Some(mut entry) = zip.next_with_entry().await? {
@@ -271,6 +272,8 @@ pub async fn unzip<D: Display, R: tokio::io::AsyncRead + Unpin>(
                     }
                 }
             }
+
+            files.push((relpath.clone(), actual_uncompressed_size));
 
             ComputedEntry {
                 crc32: actual_crc32,
@@ -577,7 +580,7 @@ pub async fn unzip<D: Display, R: tokio::io::AsyncRead + Unpin>(
         }
     }
 
-    Ok(())
+    Ok(files)
 }
 
 /// Unpack the given tar archive into the destination directory.
@@ -586,12 +589,13 @@ pub async fn unzip<D: Display, R: tokio::io::AsyncRead + Unpin>(
 async fn untar_in(
     mut archive: tokio_tar::Archive<&'_ mut (dyn tokio::io::AsyncRead + Unpin)>,
     dst: &Path,
-) -> std::io::Result<()> {
+) -> std::io::Result<Vec<(PathBuf, u64)>> {
     // Like `tokio-tar`, canonicalize the destination prior to unpacking.
     let dst = fs_err::tokio::canonicalize(dst).await?;
 
     // Memoize filesystem calls to canonicalize paths.
     let mut memo = FxHashSet::default();
+    let mut files = Vec::new();
 
     let mut entries = archive.entries()?;
     let mut pinned = Pin::new(&mut entries);
@@ -607,6 +611,13 @@ async fn untar_in(
                 file.path()?.display()
             );
             continue;
+        }
+
+        let entry_type = file.header().entry_type();
+        if entry_type.is_file() || entry_type.is_hard_link() {
+            let relpath = file.path()?.into_owned();
+            let size = file.header().size()?;
+            files.push((relpath, size));
         }
 
         // Unpack the file into the destination directory.
@@ -639,7 +650,7 @@ async fn untar_in(
         }
     }
 
-    Ok(())
+    Ok(files)
 }
 
 /// Unpack a `.tar.gz` archive into the target directory, without requiring `Seek`.
@@ -648,7 +659,7 @@ async fn untar_in(
 pub async fn untar_gz<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
-) -> Result<(), Error> {
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::GzipDecoder::new(reader);
 
@@ -670,7 +681,7 @@ pub async fn untar_gz<R: tokio::io::AsyncRead + Unpin>(
 pub async fn untar_bz2<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
-) -> Result<(), Error> {
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::BzDecoder::new(reader);
 
@@ -692,7 +703,7 @@ pub async fn untar_bz2<R: tokio::io::AsyncRead + Unpin>(
 pub async fn untar_zst<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
-) -> Result<(), Error> {
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::ZstdDecoder::new(reader);
 
@@ -709,13 +720,40 @@ pub async fn untar_zst<R: tokio::io::AsyncRead + Unpin>(
 }
 
 /// Unpack a `.tar.zst` archive from a file on disk into the target directory.
-pub fn untar_zst_file<R: std::io::Read>(reader: R, target: impl AsRef<Path>) -> Result<(), Error> {
+pub fn untar_zst_file<R: std::io::Read>(
+    reader: R,
+    target: impl AsRef<Path>,
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = std::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let decompressed = zstd::Decoder::new(reader).map_err(Error::Io)?;
     let mut archive = tar::Archive::new(decompressed);
     archive.set_preserve_mtime(false);
-    archive.unpack(target).map_err(Error::io_or_compression)?;
-    Ok(())
+
+    let mut files = Vec::new();
+    let dst = fs_err::canonicalize(&target).unwrap_or(target.as_ref().to_path_buf());
+
+    let mut directories = Vec::new();
+    for entry in archive.entries().map_err(Error::io_or_compression)? {
+        let mut file = entry.map_err(Error::io_or_compression)?;
+        if file.header().entry_type() == tar::EntryType::Directory {
+            directories.push(file);
+        } else {
+            let entry_type = file.header().entry_type();
+            let path = file.path().map_err(Error::io_or_compression)?.into_owned();
+            let size = file.header().size().map_err(Error::io_or_compression)?;
+            if entry_type.is_file() || entry_type.is_hard_link() {
+                files.push((path, size));
+            }
+            file.unpack_in(&dst).map_err(Error::io_or_compression)?;
+        }
+    }
+
+    directories.sort_by(|a, b| b.path_bytes().cmp(&a.path_bytes()));
+    for mut dir in directories {
+        dir.unpack_in(&dst).map_err(Error::io_or_compression)?;
+    }
+
+    Ok(files)
 }
 
 /// Unpack a `.tar.xz` archive into the target directory, without requiring `Seek`.
@@ -724,7 +762,7 @@ pub fn untar_zst_file<R: std::io::Read>(reader: R, target: impl AsRef<Path>) -> 
 pub async fn untar_xz<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
-) -> Result<(), Error> {
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     let reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
     let mut decompressed_bytes = async_compression::tokio::bufread::XzDecoder::new(reader);
 
@@ -737,8 +775,7 @@ pub async fn untar_xz<R: tokio::io::AsyncRead + Unpin>(
     .build();
     untar_in(archive, target.as_ref())
         .await
-        .map_err(Error::io_or_compression)?;
-    Ok(())
+        .map_err(Error::io_or_compression)
 }
 
 /// Unpack a `.tar` archive into the target directory, without requiring `Seek`.
@@ -747,7 +784,7 @@ pub async fn untar_xz<R: tokio::io::AsyncRead + Unpin>(
 pub async fn untar<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
-) -> Result<(), Error> {
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     let mut reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, reader);
 
     let archive =
@@ -758,8 +795,7 @@ pub async fn untar<R: tokio::io::AsyncRead + Unpin>(
             .build();
     untar_in(archive, target.as_ref())
         .await
-        .map_err(Error::io_or_compression)?;
-    Ok(())
+        .map_err(Error::io_or_compression)
 }
 
 /// Unpack a `.zip`, `.tar.gz`, `.tar.bz2`, `.tar.zst`, or `.tar.xz` archive into the target directory,
@@ -772,30 +808,17 @@ pub async fn archive<D: Display, R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     ext: SourceDistExtension,
     target: impl AsRef<Path>,
-) -> Result<(), Error> {
+) -> Result<Vec<(PathBuf, u64)>, Error> {
     match ext {
-        SourceDistExtension::Zip => {
-            unzip(source_hint, reader, target).await?;
-        }
-        SourceDistExtension::Tar => {
-            untar(reader, target).await?;
-        }
-        SourceDistExtension::Tgz | SourceDistExtension::TarGz => {
-            untar_gz(reader, target).await?;
-        }
-        SourceDistExtension::Tbz | SourceDistExtension::TarBz2 => {
-            untar_bz2(reader, target).await?;
-        }
+        SourceDistExtension::Zip => unzip(source_hint, reader, target).await,
+        SourceDistExtension::Tar => untar(reader, target).await,
+        SourceDistExtension::Tgz | SourceDistExtension::TarGz => untar_gz(reader, target).await,
+        SourceDistExtension::Tbz | SourceDistExtension::TarBz2 => untar_bz2(reader, target).await,
         SourceDistExtension::Txz
         | SourceDistExtension::TarXz
         | SourceDistExtension::Tlz
         | SourceDistExtension::TarLz
-        | SourceDistExtension::TarLzma => {
-            untar_xz(reader, target).await?;
-        }
-        SourceDistExtension::TarZst => {
-            untar_zst(reader, target).await?;
-        }
+        | SourceDistExtension::TarLzma => untar_xz(reader, target).await,
+        SourceDistExtension::TarZst => untar_zst(reader, target).await,
     }
-    Ok(())
 }

--- a/crates/fyn-extract/src/sync.rs
+++ b/crates/fyn-extract/src/sync.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 use zip::ZipArchive;
 
 /// Unzip a `.zip` archive into the target directory.
-pub fn unzip(reader: fs_err::File, target: &Path) -> Result<(), Error> {
+pub fn unzip(reader: fs_err::File, target: &Path) -> Result<Vec<(PathBuf, u64)>, Error> {
     let (reader, filename) = reader.into_parts();
 
     // Unzip in parallel.
@@ -47,17 +47,17 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<(), Error> {
             // Determine the path of the file within the wheel.
             let Some(enclosed_name) = file.enclosed_name() else {
                 warn!("Skipping unsafe file name: {}", file.name());
-                return Ok(());
+                return Ok(None);
             };
 
             // Create necessary parent directories.
-            let path = target.join(enclosed_name);
+            let path = target.join(&enclosed_name);
             if file.is_dir() {
                 let mut directories = directories.lock().unwrap();
                 if directories.insert(path.clone()) {
                     fs_err::create_dir_all(path).map_err(Error::Io)?;
                 }
-                return Ok(());
+                return Ok(None);
             }
 
             if let Some(parent) = path.parent() {
@@ -102,8 +102,9 @@ pub fn unzip(reader: fs_err::File, target: &Path) -> Result<(), Error> {
                 }
             }
 
-            Ok(())
+            Ok(Some((enclosed_name, size)))
         })
+        .filter_map(Result::transpose)
         .collect::<Result<_, Error>>()
 }
 

--- a/crates/fyn-install-wheel/src/install.rs
+++ b/crates/fyn-install-wheel/src/install.rs
@@ -14,7 +14,7 @@ use fyn_pypi_types::{DirectUrl, Metadata10};
 use crate::linker::{InstallState, LinkMode, link_wheel_files};
 use crate::wheel::{
     LibKind, WheelFile, dist_info_metadata, find_dist_info, install_data, parse_scripts,
-    read_record_file, write_installer_metadata, write_script_entrypoints,
+    read_record_file, write_installer_metadata, write_record, write_script_entrypoints,
 };
 use crate::{Error, Layout};
 
@@ -149,14 +149,7 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
     }
 
     trace!(?name, "Writing record");
-    let mut record_writer = csv::WriterBuilder::new()
-        .has_headers(false)
-        .escape(b'"')
-        .from_path(site_packages.join(format!("{dist_info_prefix}.dist-info/RECORD")))?;
-    record.sort();
-    for entry in record {
-        record_writer.serialize(entry)?;
-    }
+    write_record(site_packages, &dist_info_prefix, record)?;
 
     Ok(())
 }

--- a/crates/fyn-install-wheel/src/lib.rs
+++ b/crates/fyn-install-wheel/src/lib.rs
@@ -14,7 +14,7 @@ use fyn_pypi_types::Scheme;
 pub use install::install_wheel;
 pub use linker::{InstallState, LinkMode, link_wheel_files};
 pub use uninstall::{Uninstall, uninstall_egg, uninstall_legacy_editable, uninstall_wheel};
-pub use wheel::{LibKind, WheelFile, read_record_file};
+pub use wheel::{LibKind, WheelFile, read_record_file, validate_and_heal_record};
 
 mod install;
 mod linker;

--- a/crates/fyn-install-wheel/src/uninstall.rs
+++ b/crates/fyn-install-wheel/src/uninstall.rs
@@ -1,15 +1,21 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
+use std::fmt::Display;
 use std::path::{Component, Path, PathBuf};
 
 use fyn_fs::write_atomic_sync;
-use std::sync::{LazyLock, Mutex};
+use fyn_warnings::warn_user;
+use std::sync::{LazyLock, Mutex, OnceLock};
 use tracing::trace;
 
-use crate::Error;
 use crate::wheel::read_record_file;
+use crate::{Error, Layout};
 
 /// Uninstall the wheel represented by the given `.dist-info` directory.
-pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
+pub fn uninstall_wheel(
+    dist_info: &Path,
+    distribution: impl Display,
+    layout: &Layout,
+) -> Result<Uninstall, Error> {
     let Some(site_packages) = dist_info.parent() else {
         return Err(Error::BrokenVenv(
             "dist-info directory is not in a site-packages directory".to_string(),
@@ -39,6 +45,10 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
     let mut visited = BTreeSet::new();
     for entry in &record {
         let path = site_packages.join(&entry.path);
+
+        if !is_path_in_scheme(&entry.path, site_packages, &distribution, layout) {
+            continue;
+        }
 
         // On Windows, deleting the current executable is a special case.
         #[cfg(windows)]
@@ -148,10 +158,49 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
     })
 }
 
+static WARNED_FOR_PACKAGE: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+/// Warn and reject paths that are not part of the install scheme.
+fn is_path_in_scheme(
+    path: &str,
+    site_packages: &Path,
+    distribution: impl Display,
+    layout: &Layout,
+) -> bool {
+    let normalized = normalize_path(&site_packages.join(path));
+
+    if normalized.starts_with(&layout.scheme.data)
+        || normalized.starts_with(&layout.scheme.purelib)
+        || normalized.starts_with(&layout.scheme.platlib)
+        || normalized.starts_with(&layout.scheme.scripts)
+        || normalized.starts_with(&layout.scheme.include)
+    {
+        true
+    } else {
+        if WARNED_FOR_PACKAGE
+            .get_or_init(|| Mutex::new(HashSet::new()))
+            .lock()
+            .expect("the warning mutex should not be poisoned")
+            .insert(distribution.to_string())
+        {
+            warn_user!(
+                "Invalid RECORD entry in {} that escapes the Python environment, skipping: {}",
+                distribution,
+                path
+            );
+        }
+        false
+    }
+}
+
 /// Uninstall the egg represented by the `.egg-info` directory.
 ///
 /// See: <https://github.com/pypa/pip/blob/41587f5e0017bcd849f42b314dc8a34a7db75621/src/pip/_internal/req/req_uninstall.py#L483>
-pub fn uninstall_egg(egg_info: &Path) -> Result<Uninstall, Error> {
+pub fn uninstall_egg(
+    egg_info: &Path,
+    distribution: impl Display,
+    layout: &Layout,
+) -> Result<Uninstall, Error> {
     let mut file_count = 0usize;
     let mut dir_count = 0usize;
 
@@ -193,6 +242,10 @@ pub fn uninstall_egg(egg_info: &Path) -> Result<Uninstall, Error> {
     // Remove everything in `top_level.txt`.
     for entry in top_level {
         let path = dist_location.join(&entry);
+
+        if !is_path_in_scheme(&entry, dist_location, &distribution, layout) {
+            continue;
+        }
 
         // Remove as a directory.
         match fs_err::remove_dir_all(&path) {
@@ -346,4 +399,108 @@ fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     ret
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_fs::prelude::*;
+
+    use fyn_pypi_types::Scheme;
+
+    use crate::Layout;
+    use crate::uninstall::{uninstall_egg, uninstall_wheel};
+
+    #[test]
+    fn uninstall_record_path_traversal() {
+        let venv = assert_fs::TempDir::new().unwrap();
+        let site_packages = venv.child("lib/python3.12/site-packages");
+        let outside_dir = assert_fs::TempDir::new().unwrap();
+
+        let target_file = outside_dir.child("traversal_target.txt");
+        target_file.write_str("I should not be deleted").unwrap();
+
+        let dist_info = site_packages.child("evilpkg-0.1.0.dist-info");
+        dist_info.create_dir_all().unwrap();
+        let target_path = pathdiff::diff_paths(target_file.path(), site_packages.path()).unwrap();
+        assert!(site_packages.join(&target_path).exists());
+
+        dist_info
+            .child("RECORD")
+            .write_str(&format!(
+                "evilpkg/__init__.py,,0\n\
+                 evilpkg-0.1.0.dist-info/METADATA,,0\n\
+                 evilpkg-0.1.0.dist-info/RECORD,,\n\
+                 {},,0\n",
+                target_path.display()
+            ))
+            .unwrap();
+
+        let init_py = site_packages.child("evilpkg/__init__.py");
+        init_py.touch().unwrap();
+        let metadata = dist_info.child("METADATA");
+        metadata.touch().unwrap();
+
+        let layout = Layout {
+            sys_executable: venv.path().join("bin/python"),
+            python_version: (3, 13),
+            os_name: "posix".to_string(),
+            scheme: Scheme {
+                purelib: site_packages.to_path_buf(),
+                platlib: site_packages.to_path_buf(),
+                scripts: venv.path().join("bin"),
+                data: venv.path().to_path_buf(),
+                include: venv.path().join("include/python3.12"),
+            },
+        };
+
+        uninstall_wheel(dist_info.path(), "evilpkg 0.1.0", &layout).unwrap();
+
+        assert!(target_file.exists());
+        assert!(!metadata.exists());
+        assert!(!init_py.exists());
+    }
+
+    #[test]
+    fn uninstall_egg_info_path_traversal() {
+        let venv = assert_fs::TempDir::new().unwrap();
+        let site_packages = venv.child("lib/python3.12/site-packages");
+        let outside_dir = assert_fs::TempDir::new().unwrap();
+
+        let target_dir = outside_dir.child("traversal_target");
+        let target_file = target_dir.child("secret.txt");
+        target_file.write_str("I should not be deleted").unwrap();
+
+        let egg_info = site_packages.child("evilpkg-0.1.0.egg-info");
+        egg_info.create_dir_all().unwrap();
+        let target_path = pathdiff::diff_paths(target_dir.path(), site_packages.path()).unwrap();
+        assert!(site_packages.join(&target_path).exists());
+
+        egg_info
+            .child("top_level.txt")
+            .write_str(&format!("evilpkg\n{}\n", target_path.display()))
+            .unwrap();
+
+        let init_py = site_packages.child("evilpkg").child("__init__.py");
+        init_py.touch().unwrap();
+
+        let layout = Layout {
+            sys_executable: venv.path().join("bin/python"),
+            python_version: (3, 13),
+            os_name: "posix".to_string(),
+            scheme: Scheme {
+                purelib: site_packages.to_path_buf(),
+                platlib: site_packages.to_path_buf(),
+                scripts: venv.path().join("bin"),
+                data: venv.path().to_path_buf(),
+                include: venv.path().join("include/python3.12"),
+            },
+        };
+
+        uninstall_egg(egg_info.path(), "evilpkg 0.1.0", &layout).unwrap();
+
+        assert!(target_dir.exists());
+        assert!(target_file.exists());
+        assert!(!init_py.exists());
+        assert!(!egg_info.exists());
+    }
 }

--- a/crates/fyn-install-wheel/src/wheel.rs
+++ b/crates/fyn-install-wheel/src/wheel.rs
@@ -880,7 +880,7 @@ pub fn validate_and_heal_record<'a>(
             dist,
             files
                 .keys()
-                .map(|path| path.simplified_display())
+                .map(Simplified::simplified_display)
                 .join("`, `")
         );
     }

--- a/crates/fyn-install-wheel/src/wheel.rs
+++ b/crates/fyn-install-wheel/src/wheel.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::fmt::Display;
 use std::io;
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
@@ -6,13 +7,14 @@ use std::path::{Path, PathBuf};
 use data_encoding::BASE64URL_NOPAD;
 use fs_err as fs;
 use fs_err::{DirEntry, File};
+use itertools::Itertools;
 use mailparse::parse_headers;
 use rustc_hash::FxHashMap;
 use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use walkdir::WalkDir;
 
-use fyn_fs::{Simplified, persist_with_retry_sync, relative_to};
+use fyn_fs::{PortablePath, Simplified, normalize_path, persist_with_retry_sync, relative_to};
 use fyn_normalize::PackageName;
 use fyn_pypi_types::DirectUrl;
 use fyn_shell::escape_posix_for_single_quotes;
@@ -808,6 +810,95 @@ pub fn read_record_file(record: &mut impl Read) -> Result<Vec<RecordEntry>, Erro
             })
         })
         .collect()
+}
+
+pub(crate) fn write_record(
+    site_packages: &Path,
+    dist_info_prefix: &str,
+    mut record: Vec<RecordEntry>,
+) -> Result<(), Error> {
+    let record_file = site_packages.join(format!("{dist_info_prefix}.dist-info/RECORD"));
+    let mut record_writer = csv::WriterBuilder::new()
+        .has_headers(false)
+        .escape(b'"')
+        .from_path(record_file)?;
+    record.sort();
+    for entry in record {
+        record_writer.serialize(entry)?;
+    }
+    Ok(())
+}
+
+/// Validate the wheel `RECORD` and heal it when it doesn't match the unpacked wheel.
+pub fn validate_and_heal_record<'a>(
+    wheel_dir: &Path,
+    unpacked_wheel: impl IntoIterator<Item = &'a (PathBuf, u64)>,
+    dist: impl Display,
+) -> Result<(), Error> {
+    let mut files: BTreeMap<&Path, u64> = unpacked_wheel
+        .into_iter()
+        .map(|(path, size)| (path.as_path(), *size))
+        .collect();
+
+    let dist_info_prefix = find_dist_info(wheel_dir)?;
+    let dist_info_dir = format!("{dist_info_prefix}.dist-info");
+    let record_path = wheel_dir.join(&dist_info_dir).join("RECORD");
+    let mut record_file = File::open(&record_path)?;
+    let mut record = read_record_file(&mut record_file)?;
+
+    let mut extra_record_entries = Vec::new();
+    record.retain(|entry| {
+        let path = Path::new(&entry.path);
+        if files.remove(path).is_some() {
+            return true;
+        }
+        if files.remove(normalize_path(path).as_ref()).is_some() {
+            return true;
+        }
+        extra_record_entries.push(path.to_path_buf());
+        false
+    });
+
+    if !files.is_empty() {
+        files.remove(Path::new(&dist_info_dir).join("RECORD.jws").as_path());
+        files.remove(Path::new(&dist_info_dir).join("RECORD.p7s").as_path());
+    }
+
+    if !extra_record_entries.is_empty() {
+        debug!(
+            "RECORD contains files not in wheel archive for {}: `{}`",
+            dist,
+            extra_record_entries
+                .iter()
+                .map(Simplified::simplified_display)
+                .join("`, `")
+        );
+    }
+    if !files.is_empty() {
+        debug!(
+            "Wheel archive contains files not in RECORD for {}: `{}`",
+            dist,
+            files
+                .keys()
+                .map(|path| path.simplified_display())
+                .join("`, `")
+        );
+    }
+
+    if !extra_record_entries.is_empty() || !files.is_empty() {
+        debug!("Rewriting RECORD to match actual wheel contents for {dist}");
+        for (path, size) in files {
+            record.push(RecordEntry {
+                path: PortablePath::from(path).to_string(),
+                hash: None,
+                size: Some(size),
+            });
+        }
+
+        write_record(wheel_dir, &dist_info_prefix, record)?;
+    }
+
+    Ok(())
 }
 
 /// Parse a file with email message format such as WHEEL and METADATA

--- a/crates/fyn-installer/src/uninstall.rs
+++ b/crates/fyn-installer/src/uninstall.rs
@@ -1,18 +1,23 @@
 use fyn_distribution_types::{InstalledDist, InstalledDistKind, InstalledEggInfoFile};
+use fyn_install_wheel::Layout;
 
 /// Uninstall a package from the specified Python environment.
 pub async fn uninstall(
     dist: &InstalledDist,
+    layout: &Layout,
 ) -> Result<fyn_install_wheel::Uninstall, UninstallError> {
     let uninstall = tokio::task::spawn_blocking({
         let dist = dist.clone();
+        let layout = layout.clone();
         move || match dist.kind {
-            InstalledDistKind::Registry(_) | InstalledDistKind::Url(_) => {
-                Ok(fyn_install_wheel::uninstall_wheel(dist.install_path())?)
-            }
-            InstalledDistKind::EggInfoDirectory(_) => {
-                Ok(fyn_install_wheel::uninstall_egg(dist.install_path())?)
-            }
+            InstalledDistKind::Registry(_) | InstalledDistKind::Url(_) => Ok(
+                fyn_install_wheel::uninstall_wheel(dist.install_path(), &dist, &layout)?,
+            ),
+            InstalledDistKind::EggInfoDirectory(_) => Ok(fyn_install_wheel::uninstall_egg(
+                dist.install_path(),
+                &dist,
+                &layout,
+            )?),
             InstalledDistKind::LegacyEditable(dist) => Ok(
                 fyn_install_wheel::uninstall_legacy_editable(&dist.egg_link)?,
             ),

--- a/crates/fyn/src/commands/pip/operations.rs
+++ b/crates/fyn/src/commands/pip/operations.rs
@@ -805,9 +805,10 @@ async fn execute_plan(
     let uninstalls = extraneous.into_iter().chain(reinstalls).collect::<Vec<_>>();
     if !uninstalls.is_empty() {
         let start = std::time::Instant::now();
+        let layout = venv.interpreter().layout();
 
         for dist_info in &uninstalls {
-            match fyn_installer::uninstall(dist_info).await {
+            match fyn_installer::uninstall(dist_info, &layout).await {
                 Ok(summary) => {
                     debug!(
                         "Uninstalled {} ({} file{}, {} director{})",

--- a/crates/fyn/src/commands/pip/uninstall.rs
+++ b/crates/fyn/src/commands/pip/uninstall.rs
@@ -201,8 +201,9 @@ pub(crate) async fn pip_uninstall(
 
     // Uninstall each package.
     if !dry_run.enabled() {
+        let layout = environment.interpreter().layout();
         for distribution in &distributions {
-            let summary = fyn_installer::uninstall(distribution).await?;
+            let summary = fyn_installer::uninstall(distribution, &layout).await?;
             debug!(
                 "Uninstalled {} ({} file{}, {} director{})",
                 distribution.name(),

--- a/crates/fyn/src/commands/project/audit.rs
+++ b/crates/fyn/src/commands/project/audit.rs
@@ -233,7 +233,7 @@ pub(crate) async fn audit(
             let client = base_client.for_host(&osv_url).raw_client().clone();
             let service = osv::Osv::new(client, Some(osv_url), concurrency);
             trace!("Auditing {n} dependencies against OSV", n = auditable.len());
-            service.query_batch(&dependencies).await?
+            service.query_batch(&dependencies, osv::Filter::All).await?
         }
     };
 

--- a/crates/fyn/src/commands/project/mod.rs
+++ b/crates/fyn/src/commands/project/mod.rs
@@ -24,7 +24,7 @@ use fyn_installer::{InstallationStrategy, SatisfiesResult, SitePackages};
 use fyn_normalize::{DEV_DEPENDENCIES, DefaultGroups, ExtraName, GroupName, PackageName};
 use fyn_pep440::{TildeVersionSpecifier, Version, VersionSpecifiers};
 use fyn_pep508::MarkerTreeContents;
-use fyn_preview::{Preview, PreviewFeature};
+use fyn_preview::Preview;
 use fyn_pypi_types::{ConflictItem, ConflictKind, ConflictSet, Conflicts};
 use fyn_python::{
     BrokenLink, EnvironmentPreference, Interpreter, InvalidEnvironmentKind, PythonDownloads,
@@ -1431,10 +1431,9 @@ impl ProjectEnvironment {
             })
             .ok();
 
-        let upgradeable = preview.is_enabled(PreviewFeature::PythonUpgrade)
-            && python
-                .as_ref()
-                .is_none_or(|request| !request.includes_patch());
+        let upgradeable = python
+            .as_ref()
+            .is_none_or(|request| !request.includes_patch());
 
         match ProjectInterpreter::discover(
             workspace,

--- a/crates/fyn/tests/it/extract.rs
+++ b/crates/fyn/tests/it/extract.rs
@@ -23,7 +23,9 @@ async fn unzip(url: &str) -> anyhow::Result<(), fyn_extract::Error> {
         .into_async_read();
 
     let target = tempfile::TempDir::new().map_err(fyn_extract::Error::Io)?;
-    fyn_extract::stream::unzip(url, reader.compat(), target.path()).await
+    fyn_extract::stream::unzip(url, reader.compat(), target.path())
+        .await
+        .map(|_| ())
 }
 
 #[tokio::test]

--- a/crates/fyn/tests/it/pip_uninstall.rs
+++ b/crates/fyn/tests/it/pip_uninstall.rs
@@ -153,6 +153,64 @@ fn uninstall() -> Result<()> {
 }
 
 #[test]
+fn uninstall_record_path_traversal() -> Result<()> {
+    let context = fyn_test::test_context!("3.12").with_filter((
+        r"(\.\./)+traversal_target\.txt",
+        "[..]/traversal_target.txt",
+    ));
+
+    context
+        .init()
+        .arg("--lib")
+        .arg("evilpkg")
+        .assert()
+        .success();
+    context.pip_install().arg("./evilpkg").assert().success();
+
+    let target_file = context.temp_dir.child("traversal_target.txt");
+    target_file.write_str("I should not be deleted")?;
+
+    let canonical_temp_dir = context.temp_dir.canonicalize()?;
+    let depth = context
+        .site_packages()
+        .strip_prefix(&canonical_temp_dir)?
+        .components()
+        .count();
+    let traversal_record = format!("{}traversal_target.txt", "../".repeat(depth));
+
+    let record_file = context
+        .site_packages()
+        .join("evilpkg-0.1.0.dist-info/RECORD");
+    let record = fs_err::read_to_string(&record_file)?;
+    fs_err::write(
+        &record_file,
+        format!("{}\n{},,0\n", record.trim(), traversal_record),
+    )?;
+
+    let init_py = context.site_packages().join("evilpkg/__init__.py");
+    assert!(context.site_packages().join(&traversal_record).exists());
+    assert!(init_py.exists());
+
+    fyn_snapshot!(context.filters(), context.pip_uninstall()
+        .arg("evilpkg"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Invalid RECORD entry in evilpkg==0.1.0 (from file://[TEMP_DIR]/evilpkg) that escapes the Python environment, skipping: [..]/traversal_target.txt
+    Uninstalled 1 package in [TIME]
+     - evilpkg==0.1.0 (from file://[TEMP_DIR]/evilpkg)
+    "
+    );
+
+    assert!(target_file.exists());
+    assert!(!init_py.exists());
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "test-pypi")]
 fn missing_record() -> Result<()> {
     let context = fyn_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

Sync recent upstream uv fixes into fyn for uninstall safety, wheel `RECORD` healing, OSV filtering support, and project environment upgradeability.

This ports:
  - uninstall hardening so `RECORD` / `.egg-info` entries cannot remove files outside the Python environment
  - wheel `RECORD` validation and healing during installation / extraction
  - OSV batch filtering support for malware findings
  - removal of a stale preview-feature gate in project environment construction

  ## Changes

  - remove the stale `PreviewFeature::PythonUpgrade` gate when deciding whether a project environment is upgradeable
  - add `osv::Filter` support to OSV batch queries, including malware-only filtering
  - thread environment `Layout` through uninstall paths so uninstall only removes files within the active environment scheme
  - make archive extraction return unpacked file paths and sizes so installation can validate extracted contents against `RECORD`
  - add `validate_and_heal_record` to rewrite broken or stale `RECORD` entries based on the actual unpacked files
  - wire RECORD validation / healing into `fyn-distribution`
  - add regression coverage for uninstall path traversal and malware filtering

## Verification

  ```bash
  cargo fmt --check
  cargo test -p fyn-install-wheel
  cargo test -p fyn-audit
  cargo test -p fyn-distribution
  cargo test -p fyn --test it pip_uninstall
  cargo check -p fyn-distribution
  cargo check -p fyn-install-wheel
  cargo check -p fyn
```