### PR TITLE
fix: sync uv lock fork marker normalization

### DIFF
--- a/crates/fyn-resolver/src/lock/mod.rs
+++ b/crates/fyn-resolver/src/lock/mod.rs
@@ -349,19 +349,16 @@ impl Lock {
             // If there are multiple distributions for the same package, include the markers of all
             // forks that included the current distribution.
             //
-            // Normalize with a simplify/complexify round-trip through `requires-python` to
-            // match markers deserialized from the lockfile (which get complexified on read).
+            // Canonicalize the subset of fork markers that selected this distribution to
+            // match the form persisted in `fyn.lock`.
             let fork_markers = if duplicates.contains(dist.name()) {
-                resolution
+                let fork_markers = resolution
                     .fork_markers
                     .iter()
                     .filter(|fork_markers| !fork_markers.is_disjoint(dist.marker))
-                    .map(|marker| {
-                        let simplified =
-                            SimplifiedMarkerTree::new(&requires_python, marker.combined());
-                        UniversalMarker::from_combined(simplified.into_marker(&requires_python))
-                    })
-                    .collect()
+                    .copied()
+                    .collect::<Vec<_>>();
+                canonicalize_universal_markers(&fork_markers, &requires_python)
             } else {
                 vec![]
             };
@@ -465,18 +462,12 @@ impl Lock {
             fork_strategy: resolution.options.fork_strategy,
             exclude_newer: resolution.options.exclude_newer.clone().into(),
         };
-        // Normalize fork markers with a simplify/complexify round-trip through
-        // `requires-python`. This ensures markers from the resolver (which don't include
-        // `requires-python` bounds) match markers deserialized from the lockfile (which get
-        // complexified on read).
-        let fork_markers = resolution
-            .fork_markers
-            .iter()
-            .map(|marker| {
-                let simplified = SimplifiedMarkerTree::new(&requires_python, marker.combined());
-                UniversalMarker::from_combined(simplified.into_marker(&requires_python))
-            })
-            .collect();
+        // Canonicalize the top-level fork markers to match what is persisted in
+        // `fyn.lock`. In particular, conflict-only fork markers can serialize to
+        // nothing at the top level, and `fyn lock --check` should compare against
+        // that canonical form rather than the raw resolver output.
+        let fork_markers =
+            canonicalize_universal_markers(&resolution.fork_markers, &requires_python);
         let lock = Self::new(
             VERSION,
             REVISION,
@@ -6324,6 +6315,36 @@ fn simplified_universal_markers(
     markers: &[UniversalMarker],
     requires_python: &RequiresPython,
 ) -> Vec<String> {
+    canonical_marker_trees(markers, requires_python)
+        .into_iter()
+        .filter_map(MarkerTree::try_to_string)
+        .collect()
+}
+
+/// Canonicalize universal markers to match the form persisted in `fyn.lock`.
+///
+/// When the PEP 508 portions of the markers are disjoint, the lockfile stores
+/// only those simplified PEP 508 markers. Otherwise, it stores the simplified
+/// combined markers (including conflict markers). Markers that serialize to
+/// `true` are omitted.
+fn canonicalize_universal_markers(
+    markers: &[UniversalMarker],
+    requires_python: &RequiresPython,
+) -> Vec<UniversalMarker> {
+    canonical_marker_trees(markers, requires_python)
+        .into_iter()
+        .map(|marker| {
+            let simplified = SimplifiedMarkerTree::new(requires_python, marker);
+            UniversalMarker::from_combined(simplified.into_marker(requires_python))
+        })
+        .collect()
+}
+
+/// Return the simplified marker trees that would be persisted in `fyn.lock`.
+fn canonical_marker_trees(
+    markers: &[UniversalMarker],
+    requires_python: &RequiresPython,
+) -> Vec<MarkerTree> {
     let mut pep508_only = vec![];
     let mut seen = FxHashSet::default();
     for marker in markers {
@@ -6350,7 +6371,7 @@ fn simplified_universal_markers(
     };
     markers
         .into_iter()
-        .filter_map(MarkerTree::try_to_string)
+        .filter(|marker| !marker.is_true())
         .collect()
 }
 

--- a/crates/fyn/tests/it/lock.rs
+++ b/crates/fyn/tests/it/lock.rs
@@ -4641,6 +4641,104 @@ fn lock_upgrade_dry_run_multi_version() -> Result<()> {
     Ok(())
 }
 
+/// `--check --refresh` should not report changes when the lockfile is already
+/// canonical for workspace conflicts.
+///
+/// Regression test for: <https://github.com/astral-sh/uv/issues/18553>
+#[test]
+fn lock_check_refresh_workspace_conflicts() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "workspace-demo"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-a"]
+
+        [project.optional-dependencies]
+        prod = ["package-a[prod]"]
+        non-prod = ["package-a[non-prod]"]
+
+        [tool.fyn.workspace]
+        members = ["packages/package-a"]
+
+        [tool.fyn.sources]
+        package-a = { workspace = true }
+
+        [tool.fyn]
+        conflicts = [
+            [
+                { extra = "prod" },
+                { extra = "non-prod" },
+            ],
+        ]
+        "#,
+    )?;
+
+    let package_dir = context.temp_dir.child("packages").child("package-a");
+    package_dir.create_dir_all()?;
+    package_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [project.optional-dependencies]
+        prod = ["sortedcontainers==2.3.0"]
+        non-prod = ["sortedcontainers==2.4.0"]
+
+        [tool.fyn]
+        conflicts = [
+            [
+                { extra = "prod" },
+                { extra = "non-prod" },
+            ],
+        ]
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.lock(), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    let lock = context.read("fyn.lock");
+
+    fyn_snapshot!(context.filters(), context.lock().arg("--refresh"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    assert_eq!(lock, context.read("fyn.lock"));
+
+    fyn_snapshot!(context.filters(), context.lock().arg("--check").arg("--refresh"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Respect the locked version in an existing lockfile.
 #[test]
 fn lock_preference() -> Result<()> {


### PR DESCRIPTION
## Summary

Sync the upstream uv fix for canonicalizing persisted fork markers before lock equality checks. This avoids spurious lockfile differences when the resolver output is semantically equivalent to the canonical form persisted in `fyn.lock`.

## Changes

  - canonicalize top-level fork markers before lock construction
  - canonicalize per-package fork markers for duplicated distributions
  - split marker canonicalization into helper functions that match the persisted `fyn.lock` form
  - omit marker trees that simplify to `true`

## Verification

  ```bash
  cargo fmt --check
  cargo test -p fyn --test it lock::lock_check_refresh_workspace_conflicts -- --exact
  cargo test -p fyn --test it lock::lock_upgrade_dry_run_multi_version -- --exact
  cargo test -p fyn-resolver
  cargo check -p fyn-resolver
  cargo check -p fyn
  cargo clippy -p fyn-resolver -- -D warnings
  cargo clippy -p fyn --test it -- -D warnings
```