### PR TITLE
fix: filter invalid TLS certificates from custom roots

### DIFF
--- a/crates/fyn-client/src/base_client.rs
+++ b/crates/fyn-client/src/base_client.rs
@@ -43,7 +43,7 @@ use fyn_version::version;
 use fyn_warnings::warn_user_once;
 
 use crate::middleware::OfflineMiddleware;
-use crate::tls::{Certificates, TlsConfigurationError, read_identity};
+use crate::tls::{Certificates, read_identity};
 use crate::{Connectivity, WrappedReqwestError};
 
 pub const DEFAULT_RETRIES: u32 = 3;
@@ -67,41 +67,13 @@ pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// timeout on the entire upload.
 pub const DEFAULT_READ_TIMEOUT_UPLOAD: Duration = Duration::from_mins(15);
 
-#[derive(Debug)]
-pub struct ClientBuildError(ClientBuildErrorKind);
-
 #[derive(Debug, Error)]
-enum ClientBuildErrorKind {
-    #[error(transparent)]
-    Reqwest(reqwest::Error),
-    #[error(transparent)]
-    TlsConfiguration(TlsConfigurationError),
-}
-
-impl std::fmt::Display for ClientBuildError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("failed to build HTTP client")
-    }
-}
-
-impl std::error::Error for ClientBuildError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self.0 {
-            ClientBuildErrorKind::Reqwest(error) => Some(error),
-            ClientBuildErrorKind::TlsConfiguration(error) => Some(error),
-        }
-    }
-}
+#[error("failed to build HTTP client")]
+pub struct ClientBuildError(#[source] reqwest::Error);
 
 impl From<reqwest::Error> for ClientBuildError {
     fn from(error: reqwest::Error) -> Self {
-        Self(ClientBuildErrorKind::Reqwest(error))
-    }
-}
-
-impl From<TlsConfigurationError> for ClientBuildError {
-    fn from(error: TlsConfigurationError) -> Self {
-        Self(ClientBuildErrorKind::TlsConfiguration(error))
+        Self(error)
     }
 }
 
@@ -509,7 +481,7 @@ impl<'a> BaseClientBuilder<'a> {
         // Create user agent — minimal, no system profiling.
         let user_agent_string = format!("fyn/{}", version());
 
-        let custom_certs = Certificates::from_env()?.map(|certs| certs.to_reqwest_certs());
+        let custom_certs = Certificates::from_env().map(|certs| certs.to_reqwest_certs());
 
         // Create a secure client that validates certificates.
         let raw_client = self.create_client(
@@ -1449,9 +1421,6 @@ mod tests {
 
     use anyhow::Result;
     use insta::assert_debug_snapshot;
-    use rcgen::{
-        BasicConstraints, CertificateParams, CustomExtension, DnType, IsCa, KeyPair, date_time_ymd,
-    };
     use reqwest::{Client, Method};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1715,23 +1684,6 @@ mod tests {
         Ok(())
     }
 
-    fn generate_ca_pem_with_extensions(custom_extensions: Vec<CustomExtension>) -> String {
-        let mut params = CertificateParams::default();
-        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        params.not_before = date_time_ymd(1975, 1, 1);
-        params.not_after = date_time_ymd(4096, 1, 1);
-        params
-            .distinguished_name
-            .push(DnType::OrganizationName, "fyn contributors");
-        params
-            .distinguished_name
-            .push(DnType::CommonName, "fyn-test-ca");
-        params.custom_extensions = custom_extensions;
-
-        let key = KeyPair::generate().unwrap();
-        params.self_signed(&key).unwrap().pem()
-    }
-
     #[test]
     fn test_tls_root_sources_respect_fyn_settings() {
         assert_eq!(
@@ -1766,54 +1718,6 @@ mod tests {
                 .built_in_root_certs(true)
                 .tls_root_sources(true),
             (false, true)
-        );
-    }
-
-    #[test]
-    #[allow(unsafe_code)]
-    fn test_build_returns_tls_configuration_error_for_invalid_ssl_cert_file() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let cert_path = temp_dir.path().join("invalid-ca.pem");
-
-        let mut unsupported_extension = CustomExtension::from_oid_content(
-            &[1, 2, 3, 4],
-            [vec![0x0c, 0x0b], b"unsupported".to_vec()].concat(),
-        );
-        unsupported_extension.set_criticality(true);
-        fs_err::write(
-            &cert_path,
-            generate_ca_pem_with_extensions(vec![unsupported_extension]),
-        )
-        .unwrap();
-
-        unsafe {
-            env::remove_var(EnvVars::SSL_CERT_DIR);
-            env::remove_var(EnvVars::SSL_CLIENT_CERT);
-            env::set_var(EnvVars::SSL_CERT_FILE, &cert_path);
-        }
-
-        let err = BaseClientBuilder::default()
-            .build()
-            .expect_err("invalid trust anchors should fail client construction");
-
-        unsafe {
-            env::remove_var(EnvVars::SSL_CERT_FILE);
-        }
-
-        assert_eq!(err.to_string(), "failed to build HTTP client");
-
-        let tls_error = err
-            .source()
-            .and_then(|error| error.downcast_ref::<TlsConfigurationError>())
-            .expect("expected a TLS configuration error source");
-        assert!(matches!(
-            tls_error,
-            TlsConfigurationError::UnsupportedCriticalExtension { .. }
-        ));
-        assert!(
-            tls_error
-                .to_string()
-                .contains("uses an unsupported critical extension")
         );
     }
 }

--- a/crates/fyn-client/src/tls.rs
+++ b/crates/fyn-client/src/tls.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use reqwest::{Certificate, Identity};
 use rustls_native_certs::{CertificateResult, load_certs_from_paths};
 use rustls_pki_types::CertificateDer;
-use tracing::debug;
+use tracing::{debug, warn};
 use webpki::{Error as WebPkiError, anchor_from_trusted_cert};
 use x509_parser::prelude::{FromDer, X509Certificate};
 
@@ -42,112 +42,152 @@ pub(crate) struct DiagnosticCertificate(CertificateDer<'static>);
 
 impl DiagnosticCertificate {
     fn parse(&self) -> Option<X509Certificate<'_>> {
-        let (_, certificate) = X509Certificate::from_der(self.0.as_ref()).ok()?;
-        Some(certificate)
+        match X509Certificate::from_der(self.0.as_ref()) {
+            Ok((_, certificate)) => Some(certificate),
+            Err(err) => {
+                debug!("Failed to parse certificate for improved validation message: {err:?}");
+                None
+            }
+        }
     }
 }
 
 #[derive(Debug)]
-pub(crate) enum TlsConfigurationError {
-    UnsupportedCriticalExtension {
-        source: CertificateSource,
-        certificate: DiagnosticCertificate,
-    },
-    InvalidTrustAnchor {
-        source: CertificateSource,
-        certificate: DiagnosticCertificate,
-        error: WebPkiError,
-    },
+pub(crate) struct InvalidCertificateWarning {
+    source: CertificateSource,
+    certificate: DiagnosticCertificate,
+    reason: InvalidCertificateReason,
 }
 
-impl TlsConfigurationError {
-    fn from_webpki_error(
-        source: CertificateSource,
-        error: WebPkiError,
-        cert: &CertificateDer<'_>,
-    ) -> Self {
-        let certificate = DiagnosticCertificate(cert.clone().into_owned());
+#[derive(Debug)]
+pub(crate) enum InvalidCertificateReason {
+    UnsupportedCriticalExtension,
+    BadDer,
+    BadDerTime,
+    EmptyEkuExtension,
+    ExtensionValueInvalid,
+    MalformedExtensions,
+    TrailingData,
+    UnsupportedCertVersion,
+    Other(WebPkiError),
+}
+
+impl InvalidCertificateReason {
+    fn from_webpki_error(error: WebPkiError) -> Self {
         match error {
-            WebPkiError::UnsupportedCriticalExtension => Self::UnsupportedCriticalExtension {
-                source,
-                certificate,
-            },
-            error => Self::InvalidTrustAnchor {
-                source,
-                certificate,
-                error,
-            },
+            WebPkiError::UnsupportedCriticalExtension => Self::UnsupportedCriticalExtension,
+            WebPkiError::BadDer => Self::BadDer,
+            WebPkiError::BadDerTime => Self::BadDerTime,
+            WebPkiError::EmptyEkuExtension => Self::EmptyEkuExtension,
+            WebPkiError::ExtensionValueInvalid => Self::ExtensionValueInvalid,
+            WebPkiError::MalformedExtensions => Self::MalformedExtensions,
+            WebPkiError::TrailingData(_) => Self::TrailingData,
+            WebPkiError::UnsupportedCertVersion => Self::UnsupportedCertVersion,
+            error => Self::Other(error),
+        }
+    }
+
+    fn message(&self) -> Option<&'static str> {
+        match self {
+            Self::UnsupportedCriticalExtension => None,
+            Self::BadDer => Some("malformed DER certificate"),
+            Self::BadDerTime => Some("malformed certificate time"),
+            Self::EmptyEkuExtension => Some("empty extended key usage extension"),
+            Self::ExtensionValueInvalid => Some("invalid certificate extension value"),
+            Self::MalformedExtensions => Some("malformed certificate extensions"),
+            Self::TrailingData => Some("trailing data in DER certificate"),
+            Self::UnsupportedCertVersion => Some("unsupported certificate version"),
+            Self::Other(_) => None,
         }
     }
 }
 
-impl Display for TlsConfigurationError {
+impl InvalidCertificateWarning {
+    fn new(source: CertificateSource, cert: &CertificateDer<'_>, error: WebPkiError) -> Self {
+        Self {
+            source,
+            certificate: DiagnosticCertificate(cert.clone().into_owned()),
+            reason: InvalidCertificateReason::from_webpki_error(error),
+        }
+    }
+}
+
+fn format_invalid_certificate_detail(
+    reason: &InvalidCertificateReason,
+    certificate: Option<&X509Certificate<'_>>,
+) -> Option<String> {
+    match reason {
+        InvalidCertificateReason::UnsupportedCertVersion => certificate.map(|certificate| {
+            format!(
+                "unsupported certificate version `{}`",
+                certificate.version()
+            )
+        }),
+        InvalidCertificateReason::ExtensionValueInvalid => None,
+        _ => None,
+    }
+}
+
+impl Display for InvalidCertificateWarning {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnsupportedCriticalExtension {
-                source,
-                certificate,
-            } => {
-                write!(
-                    f,
-                    "certificate in `{}` (from `{}`) uses an unsupported critical extension",
-                    source.path().simplified_display(),
-                    source.env_var()
-                )?;
-                if let Some(certificate) = certificate.parse() {
-                    let subject = certificate.subject();
-                    if subject.iter_attributes().next().is_some() {
-                        write!(f, " on certificate `{subject}`")?;
-                    }
-                    let critical_extensions = certificate
-                        .iter_extensions()
-                        .filter(|extension| extension.critical)
-                        .map(|extension| extension.oid.to_owned())
-                        .collect::<Vec<_>>();
-                    if let [critical_extension] = critical_extensions.as_slice() {
-                        write!(f, "; critical extension: `{critical_extension}`")?;
-                    } else if !critical_extensions.is_empty() {
-                        write!(
-                            f,
-                            "; critical extensions: {}",
-                            critical_extensions
-                                .iter()
-                                .map(|oid| format!("`{oid}`"))
-                                .join(", ")
-                        )?;
-                    }
-                }
-                Ok(())
+        write!(
+            f,
+            "certificate in `{}` (from `{}`) ",
+            self.source.path().simplified_display(),
+            self.source.env_var()
+        )?;
+        match &self.reason {
+            InvalidCertificateReason::UnsupportedCriticalExtension => {
+                write!(f, "uses an unsupported critical extension")?;
             }
-            Self::InvalidTrustAnchor {
-                source,
-                certificate,
-                ..
-            } => {
-                write!(
-                    f,
-                    "certificate in `{}` (from `{}`) could not be used as a trust anchor",
-                    source.path().simplified_display(),
-                    source.env_var()
-                )?;
-                if let Some(certificate) = certificate.parse() {
-                    let subject = certificate.subject();
-                    if subject.iter_attributes().next().is_some() {
-                        write!(f, " on certificate `{subject}`")?;
-                    }
-                }
-                Ok(())
+            _ => {
+                write!(f, "could not be used as a trust anchor")?;
             }
         }
-    }
-}
 
-impl std::error::Error for TlsConfigurationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::UnsupportedCriticalExtension { .. } => None,
-            Self::InvalidTrustAnchor { error, .. } => Some(error),
+        let parsed_certificate = self.certificate.parse();
+        if let Some(certificate) = parsed_certificate.as_ref() {
+            let subject = certificate.subject();
+            if subject.iter_attributes().next().is_some() {
+                // Avoid rendering empty subject DNs.
+                write!(f, " on certificate `{subject}`")?;
+            }
+            if let InvalidCertificateReason::UnsupportedCriticalExtension = &self.reason {
+                let critical_extensions = certificate
+                    .iter_extensions()
+                    .filter(|extension| extension.critical)
+                    .map(|extension| extension.oid.to_owned())
+                    .collect::<Vec<_>>();
+                if let [critical_extension] = critical_extensions.as_slice() {
+                    write!(f, "; critical extension: `{critical_extension}`")?;
+                } else if !critical_extensions.is_empty() {
+                    write!(
+                        f,
+                        "; critical extensions: {}",
+                        critical_extensions
+                            .iter()
+                            .map(|oid| format!("`{oid}`"))
+                            .join(", ")
+                    )?;
+                }
+            }
         }
+
+        let detailed_reason =
+            format_invalid_certificate_detail(&self.reason, parsed_certificate.as_ref())
+                .or_else(|| self.reason.message().map(str::to_owned))
+                .or_else(|| {
+                    if let InvalidCertificateReason::Other(error) = &self.reason {
+                        Some(format!("{error:?}"))
+                    } else {
+                        None
+                    }
+                });
+        if let Some(detailed_reason) = detailed_reason {
+            write!(f, ": {detailed_reason}")?;
+        }
+
+        Ok(())
     }
 }
 
@@ -157,34 +197,30 @@ pub(crate) struct Certificates(Vec<CertificateDer<'static>>);
 
 impl Certificates {
     /// Load custom CA certificates from `SSL_CERT_FILE` and `SSL_CERT_DIR`.
-    pub(crate) fn from_env() -> Result<Option<Self>, TlsConfigurationError> {
+    pub(crate) fn from_env() -> Option<Self> {
         let mut certs = Self::default();
         let mut has_source = false;
 
         if let Some(ssl_cert_file) = env::var_os(EnvVars::SSL_CERT_FILE)
-            && let Some(file_certs) = Self::from_ssl_cert_file(&ssl_cert_file)?
+            && let Some(file_certs) = Self::from_ssl_cert_file(&ssl_cert_file)
         {
             has_source = true;
             certs.merge(file_certs);
         }
 
         if let Some(ssl_cert_dir) = env::var_os(EnvVars::SSL_CERT_DIR)
-            && let Some(dir_certs) = Self::from_ssl_cert_dir(&ssl_cert_dir)?
+            && let Some(dir_certs) = Self::from_ssl_cert_dir(&ssl_cert_dir)
         {
             has_source = true;
             certs.merge(dir_certs);
         }
 
-        if has_source {
-            Ok(Some(certs))
-        } else {
-            Ok(None)
-        }
+        if has_source { Some(certs) } else { None }
     }
 
-    fn from_ssl_cert_file(ssl_cert_file: &OsStr) -> Result<Option<Self>, TlsConfigurationError> {
+    fn from_ssl_cert_file(ssl_cert_file: &OsStr) -> Option<Self> {
         if ssl_cert_file.is_empty() {
-            return Ok(None);
+            return None;
         }
 
         let file = PathBuf::from(ssl_cert_file);
@@ -197,44 +233,44 @@ impl Certificates {
                         file.simplified_display().cyan()
                     );
                 }
-                let certs = Self::from(result);
+                let certs = Self::from(result)
+                    .filter_invalid(&CertificateSource::SslCertFile(file.clone()));
                 if certs.0.is_empty() {
                     warn_user_once!(
-                        "Ignoring `SSL_CERT_FILE`. No certificates found in: {}.",
+                        "Ignoring `SSL_CERT_FILE`. No valid certificates found in: {}.",
                         file.simplified_display().cyan()
                     );
-                    return Ok(None);
+                    return None;
                 }
-                certs.validate_trust_anchors(CertificateSource::SslCertFile(file))?;
-                Ok(Some(certs))
+                Some(certs)
             }
             Ok(_) => {
                 warn_user_once!(
                     "Ignoring invalid `SSL_CERT_FILE`. Path is not a file: {}.",
                     file.simplified_display().cyan()
                 );
-                Ok(None)
+                None
             }
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 warn_user_once!(
                     "Ignoring invalid `SSL_CERT_FILE`. Path does not exist: {}.",
                     file.simplified_display().cyan()
                 );
-                Ok(None)
+                None
             }
             Err(err) => {
                 warn_user_once!(
                     "Ignoring invalid `SSL_CERT_FILE`. Path is not accessible: {} ({err}).",
                     file.simplified_display().cyan()
                 );
-                Ok(None)
+                None
             }
         }
     }
 
-    fn from_ssl_cert_dir(ssl_cert_dir: &OsStr) -> Result<Option<Self>, TlsConfigurationError> {
+    fn from_ssl_cert_dir(ssl_cert_dir: &OsStr) -> Option<Self> {
         if ssl_cert_dir.is_empty() {
-            return Ok(None);
+            return None;
         }
 
         let (existing, missing): (Vec<_>, Vec<_>) =
@@ -254,7 +290,7 @@ impl Certificates {
                     .join(", ")
                     .cyan()
             );
-            return Ok(None);
+            return None;
         }
 
         if !missing.is_empty() {
@@ -282,49 +318,43 @@ impl Certificates {
                     dir.simplified_display().cyan()
                 );
             }
-            let dir_certs = Self::from(result);
+            let dir_certs =
+                Self::from(result).filter_invalid(&CertificateSource::SslCertDir(dir.clone()));
             if !dir_certs.0.is_empty() {
-                dir_certs.validate_trust_anchors(CertificateSource::SslCertDir(dir.clone()))?;
                 certs.merge(dir_certs);
             }
         }
 
         if certs.0.is_empty() {
             warn_user_once!(
-                "Ignoring `SSL_CERT_DIR`. No certificates found in: {}.",
+                "Ignoring `SSL_CERT_DIR`. No valid certificates found in: {}.",
                 existing
                     .iter()
                     .map(Simplified::simplified_display)
                     .join(", ")
                     .cyan()
             );
-            return Ok(None);
+            return None;
         }
 
-        Ok(Some(certs))
+        Some(certs)
     }
 
     fn from_paths(file: Option<&Path>, dir: Option<&Path>) -> CertificateResult {
         load_certs_from_paths(file, dir)
     }
 
-    fn validate_trust_anchors(
-        &self,
-        source: CertificateSource,
-    ) -> Result<(), TlsConfigurationError> {
-        for cert in &self.0 {
+    fn filter_invalid(mut self, source: &CertificateSource) -> Self {
+        self.0.retain(|cert| {
             if let Err(error) = anchor_from_trusted_cert(cert) {
-                debug!(
-                    "Failed to validate certificate from `{}` ({}): {error}",
-                    source.env_var(),
-                    source.path().simplified_display()
-                );
-                return Err(TlsConfigurationError::from_webpki_error(
-                    source, error, cert,
-                ));
+                let warning = InvalidCertificateWarning::new((*source).clone(), cert, error);
+                warn!("Ignoring invalid certificate: {warning}");
+                return false;
             }
-        }
-        Ok(())
+
+            true
+        });
+        self
     }
 
     fn dedup(&mut self) {
@@ -383,13 +413,13 @@ pub(crate) fn read_identity(ssl_client_cert: &OsStr) -> Result<Identity, Certifi
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
     use std::ffi::OsString;
 
     use rcgen::{
         BasicConstraints, CertificateParams, CustomExtension, DnType, IsCa, KeyPair,
         KeyUsagePurpose, date_time_ymd,
     };
+    use rustls_pki_types::pem::PemObject;
 
     use super::*;
 
@@ -423,13 +453,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing_file = dir.path().join("missing.pem");
 
-        let certs = Certificates::from_ssl_cert_file(missing_file.as_os_str()).unwrap();
+        let certs = Certificates::from_ssl_cert_file(missing_file.as_os_str());
         assert!(certs.is_none());
     }
 
     #[test]
     fn test_from_ssl_cert_file_empty_value_returns_none() {
-        let certs = Certificates::from_ssl_cert_file(OsString::new().as_os_str()).unwrap();
+        let certs = Certificates::from_ssl_cert_file(OsString::new().as_os_str());
         assert!(certs.is_none());
     }
 
@@ -439,13 +469,13 @@ mod tests {
         let cert_path = dir.path().join("empty.pem");
         fs_err::write(&cert_path, "not a certificate").unwrap();
 
-        let certs = Certificates::from_ssl_cert_file(cert_path.as_os_str()).unwrap();
+        let certs = Certificates::from_ssl_cert_file(cert_path.as_os_str());
         assert!(certs.is_none());
     }
 
     #[test]
     fn test_from_ssl_cert_dir_empty_value_returns_none() {
-        let certs = Certificates::from_ssl_cert_dir(OsString::new().as_os_str()).unwrap();
+        let certs = Certificates::from_ssl_cert_dir(OsString::new().as_os_str());
         assert!(certs.is_none());
     }
 
@@ -455,7 +485,7 @@ mod tests {
         let missing_dir = dir.path().join("missing-dir");
         let cert_dirs = std::env::join_paths([&missing_dir]).unwrap();
 
-        let certs = Certificates::from_ssl_cert_dir(cert_dirs.as_os_str()).unwrap();
+        let certs = Certificates::from_ssl_cert_dir(cert_dirs.as_os_str());
         assert!(certs.is_none());
     }
 
@@ -464,12 +494,12 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cert_dirs = std::env::join_paths([dir.path()]).unwrap();
 
-        let certs = Certificates::from_ssl_cert_dir(cert_dirs.as_os_str()).unwrap();
+        let certs = Certificates::from_ssl_cert_dir(cert_dirs.as_os_str());
         assert!(certs.is_none());
     }
 
     #[test]
-    fn test_from_ssl_cert_file_unsupported_critical_extension_returns_error() {
+    fn test_from_ssl_cert_file_unsupported_critical_extension_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         let cert_path = dir.path().join("unsupported-critical.pem");
         let mut unsupported_extension = CustomExtension::from_oid_content(
@@ -483,18 +513,12 @@ mod tests {
         )
         .unwrap();
 
-        let err = Certificates::from_ssl_cert_file(cert_path.as_os_str()).unwrap_err();
-        assert!(matches!(
-            err,
-            TlsConfigurationError::UnsupportedCriticalExtension { .. }
-        ));
-        let display = err.to_string();
-        assert!(display.contains("SSL_CERT_FILE"));
-        assert!(display.contains("unsupported critical extension"));
+        let certs = Certificates::from_ssl_cert_file(cert_path.as_os_str());
+        assert!(certs.is_none());
     }
 
     #[test]
-    fn test_from_ssl_cert_file_invalid_trust_anchor_returns_error() {
+    fn test_from_ssl_cert_file_invalid_trust_anchor_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         let cert_path = dir.path().join("invalid-anchor.pem");
         let duplicate_basic_constraints =
@@ -505,13 +529,67 @@ mod tests {
         )
         .unwrap();
 
-        let err = Certificates::from_ssl_cert_file(cert_path.as_os_str()).unwrap_err();
-        assert!(matches!(
-            err,
-            TlsConfigurationError::InvalidTrustAnchor { .. }
-        ));
-        assert!(err.to_string().contains("trust anchor"));
-        assert!(err.source().is_some());
+        let certs = Certificates::from_ssl_cert_file(cert_path.as_os_str());
+        assert!(certs.is_none());
+    }
+
+    #[test]
+    fn test_invalid_certificate_warning_formats_specific_trust_anchor_reason() {
+        let duplicate_basic_constraints =
+            CustomExtension::from_oid_content(&[2, 5, 29, 19], vec![0x30, 0x00]);
+        let cert_pem = generate_ca_pem_with_extensions(vec![duplicate_basic_constraints]);
+        let cert = CertificateDer::pem_slice_iter(cert_pem.as_bytes())
+            .next()
+            .unwrap()
+            .unwrap();
+
+        let warning = InvalidCertificateWarning::new(
+            CertificateSource::SslCertFile(PathBuf::from("invalid-anchor.pem")),
+            &cert,
+            WebPkiError::ExtensionValueInvalid,
+        );
+        let display = warning.to_string();
+
+        assert!(display.contains("SSL_CERT_FILE"));
+        assert!(display.contains("trust anchor"));
+        assert!(display.contains("invalid certificate extension value"));
+    }
+
+    #[test]
+    fn test_from_ssl_cert_file_bundle_ignores_invalid_trust_anchor() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("bundle.pem");
+        let duplicate_basic_constraints =
+            CustomExtension::from_oid_content(&[2, 5, 29, 19], vec![0x30, 0x00]);
+        fs_err::write(
+            &cert_path,
+            format!(
+                "{}\n{}",
+                generate_ca_pem_with_extensions(vec![duplicate_basic_constraints]),
+                generate_cert_pem()
+            ),
+        )
+        .unwrap();
+
+        let certs = Certificates::from_ssl_cert_file(cert_path.as_os_str()).unwrap();
+        assert_eq!(certs.iter().count(), 1);
+    }
+
+    #[test]
+    fn test_from_ssl_cert_dir_ignores_invalid_trust_anchor() {
+        let dir = tempfile::tempdir().unwrap();
+        let duplicate_basic_constraints =
+            CustomExtension::from_oid_content(&[2, 5, 29, 19], vec![0x30, 0x00]);
+        fs_err::write(
+            dir.path().join("invalid.pem"),
+            generate_ca_pem_with_extensions(vec![duplicate_basic_constraints]),
+        )
+        .unwrap();
+        fs_err::write(dir.path().join("valid.pem"), generate_cert_pem()).unwrap();
+
+        let cert_dirs = std::env::join_paths([dir.path()]).unwrap();
+        let certs = Certificates::from_ssl_cert_dir(cert_dirs.as_os_str()).unwrap();
+        assert_eq!(certs.iter().count(), 1);
     }
 
     #[test]

--- a/crates/fyn-client/tests/it/http_util.rs
+++ b/crates/fyn-client/tests/it/http_util.rs
@@ -13,8 +13,8 @@ use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder;
 use rcgen::{
-    BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
-    Issuer, KeyPair, KeyUsagePurpose, SanType, date_time_ymd,
+    BasicConstraints, Certificate, CertificateParams, CustomExtension, DnType,
+    ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType, date_time_ymd,
 };
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::WebPkiClientVerifier;
@@ -88,6 +88,14 @@ pub(crate) fn generate_self_signed_certs() -> Result<SelfSigned> {
 ///
 /// Use sparingly as generation of these certs is a very slow operation.
 pub(crate) fn generate_self_signed_certs_with_ca() -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
+    generate_self_signed_certs_with_ca_extensions(vec![])
+}
+
+/// Generates a self-signed root CA with custom extensions, plus a server and client certificate
+/// issued by this CA.
+pub(crate) fn generate_self_signed_certs_with_ca_extensions(
+    custom_extensions: Vec<CustomExtension>,
+) -> Result<(SelfSigned, SelfSigned, SelfSigned)> {
     // Generate the CA
     let mut ca_params = CertificateParams::default();
     ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained); // root cert
@@ -105,6 +113,7 @@ pub(crate) fn generate_self_signed_certs_with_ca() -> Result<(SelfSigned, SelfSi
     ca_params
         .subject_alt_names
         .push(SanType::DnsName("uv-test-ca".try_into()?));
+    ca_params.custom_extensions = custom_extensions;
     let ca_private_key = KeyPair::generate()?;
     let ca_public_cert = ca_params.self_signed(&ca_private_key)?;
     let ca_cert_issuer = Issuer::new(ca_params, &ca_private_key);

--- a/crates/fyn-client/tests/it/ssl_certs.rs
+++ b/crates/fyn-client/tests/it/ssl_certs.rs
@@ -1,6 +1,8 @@
+use std::net::SocketAddr;
 use std::str::FromStr;
 
 use anyhow::Result;
+use rcgen::CustomExtension;
 use rustls::AlertDescription;
 use url::Url;
 
@@ -12,8 +14,61 @@ use fyn_static::EnvVars;
 
 use crate::http_util::{
     generate_self_signed_certs, generate_self_signed_certs_with_ca,
-    start_https_mtls_user_agent_server, start_https_user_agent_server, test_cert_dir,
+    generate_self_signed_certs_with_ca_extensions, start_https_mtls_user_agent_server,
+    start_https_user_agent_server, test_cert_dir,
 };
+
+async fn send_request(
+    addr: SocketAddr,
+) -> Result<Result<reqwest::Response, reqwest_middleware::Error>> {
+    let url = DisplaySafeUrl::from_str(&format!("https://{addr}"))?;
+    let cache = Cache::temp()?.init().await?;
+    let client =
+        RegistryClientBuilder::new(BaseClientBuilder::default().no_retry_delay(true), cache)
+            .build()
+            .expect("failed to build registry client");
+
+    Ok(client
+        .cached_client()
+        .uncached()
+        .for_host(&url)
+        .get(Url::from(url))
+        .send()
+        .await)
+}
+
+fn assert_connect_error(error: reqwest_middleware::Error) {
+    let reqwest_middleware::Error::Middleware(middleware_error) = error else {
+        panic!("expected middleware error");
+    };
+
+    let reqwest_error = middleware_error
+        .chain()
+        .find_map(|err| {
+            err.downcast_ref::<reqwest_middleware::Error>().map(|err| {
+                if let reqwest_middleware::Error::Reqwest(inner) = err {
+                    inner
+                } else {
+                    panic!("expected reqwest error")
+                }
+            })
+        })
+        .expect("expected reqwest error");
+    assert!(reqwest_error.is_connect());
+}
+
+fn duplicate_basic_constraints_extension() -> CustomExtension {
+    CustomExtension::from_oid_content(&[2, 5, 29, 19], vec![0x30, 0x00])
+}
+
+fn unsupported_critical_extension() -> CustomExtension {
+    let mut extension = CustomExtension::from_oid_content(
+        &[1, 2, 3, 4],
+        [vec![0x0c, 0x0b], b"unsupported".to_vec()].concat(),
+    );
+    extension.set_criticality(true);
+    extension
+}
 
 // SAFETY: This test is meant to run with single thread configuration
 #[tokio::test]
@@ -34,28 +89,24 @@ async fn ssl_env_vars() -> Result<()> {
         tempfile::TempDir::new_in(cert_dir).expect("Failed to create test cert directory");
     let does_not_exist_cert_dir = cert_dir.path().join("does_not_exist");
 
-    // Generate self-signed standalone cert
-    let standalone_server_cert = generate_self_signed_certs()?;
-    let standalone_public_pem_path = cert_dir.path().join("standalone_public.pem");
-    let standalone_private_pem_path = cert_dir.path().join("standalone_private.pem");
-
     // Generate self-signed CA, server, and client certs
     let (ca_cert, server_cert, client_cert) = generate_self_signed_certs_with_ca()?;
+    let (invalid_ca_cert, invalid_server_cert, _) =
+        generate_self_signed_certs_with_ca_extensions(vec![
+            duplicate_basic_constraints_extension(),
+        ])?;
+    let (unsupported_ca_cert, unsupported_server_cert, _) =
+        generate_self_signed_certs_with_ca_extensions(vec![unsupported_critical_extension()])?;
     let ca_public_pem_path = cert_dir.path().join("ca_public.pem");
     let ca_private_pem_path = cert_dir.path().join("ca_private.pem");
     let server_public_pem_path = cert_dir.path().join("server_public.pem");
     let server_private_pem_path = cert_dir.path().join("server_private.pem");
     let client_combined_pem_path = cert_dir.path().join("client_combined.pem");
+    let invalid_ca_public_pem_path = cert_dir.path().join("invalid_ca_public.pem");
+    let unsupported_ca_public_pem_path = cert_dir.path().join("unsupported_ca_public.pem");
+    let bundle_ca_pem_path = cert_dir.path().join("bundle_ca.pem");
 
     // Persist the certs in PKCS8 format as the env vars expect a path on disk
-    fs_err::write(
-        standalone_public_pem_path.as_path(),
-        standalone_server_cert.public.pem(),
-    )?;
-    fs_err::write(
-        standalone_private_pem_path.as_path(),
-        standalone_server_cert.private.serialize_pem(),
-    )?;
     fs_err::write(ca_public_pem_path.as_path(), ca_cert.public.pem())?;
     fs_err::write(
         ca_private_pem_path.as_path(),
@@ -75,6 +126,18 @@ async fn ssl_env_vars() -> Result<()> {
             client_cert.private.serialize_pem()
         ),
     )?;
+    fs_err::write(
+        invalid_ca_public_pem_path.as_path(),
+        invalid_ca_cert.public.pem(),
+    )?;
+    fs_err::write(
+        unsupported_ca_public_pem_path.as_path(),
+        unsupported_ca_cert.public.pem(),
+    )?;
+    fs_err::write(
+        bundle_ca_pem_path.as_path(),
+        format!("{}\n{}", invalid_ca_cert.public.pem(), ca_cert.public.pem()),
+    )?;
 
     // ** Set SSL_CERT_FILE to non-existent location
     // ** Then verify our request fails to establish a connection
@@ -82,6 +145,7 @@ async fn ssl_env_vars() -> Result<()> {
     unsafe {
         std::env::set_var(EnvVars::SSL_CERT_FILE, does_not_exist_cert_dir.as_os_str());
     }
+    let standalone_server_cert = generate_self_signed_certs()?;
     let (server_task, addr) = start_https_user_agent_server(&standalone_server_cert).await?;
     let url = DisplaySafeUrl::from_str(&format!("https://{addr}"))?;
     let cache = Cache::temp()?.init().await?;
@@ -134,16 +198,13 @@ async fn ssl_env_vars() -> Result<()> {
     };
     assert!(expected_err);
 
-    // ** Set SSL_CERT_FILE to our public certificate
+    // ** Set SSL_CERT_FILE to our CA certificate
     // ** Then verify our request successfully establishes a connection
 
     unsafe {
-        std::env::set_var(
-            EnvVars::SSL_CERT_FILE,
-            standalone_public_pem_path.as_os_str(),
-        );
+        std::env::set_var(EnvVars::SSL_CERT_FILE, ca_public_pem_path.as_os_str());
     }
-    let (server_task, addr) = start_https_user_agent_server(&standalone_server_cert).await?;
+    let (server_task, addr) = start_https_user_agent_server(&server_cert).await?;
     let url = DisplaySafeUrl::from_str(&format!("https://{addr}"))?;
     let cache = Cache::temp()?.init().await?;
     let client =
@@ -163,6 +224,56 @@ async fn ssl_env_vars() -> Result<()> {
         std::env::remove_var(EnvVars::SSL_CERT_FILE);
     }
 
+    // ** Set SSL_CERT_FILE to a bundle containing both invalid and valid roots
+    // ** Then verify the valid certificate remains trusted
+
+    unsafe {
+        std::env::set_var(EnvVars::SSL_CERT_FILE, bundle_ca_pem_path.as_os_str());
+    }
+    let (server_task, addr) = start_https_user_agent_server(&server_cert).await?;
+    let response = send_request(addr).await?;
+    assert!(response.is_ok());
+    let _ = server_task.await?;
+    unsafe {
+        std::env::remove_var(EnvVars::SSL_CERT_FILE);
+    }
+
+    // ** Set SSL_CERT_FILE to an invalid trust anchor
+    // ** Then verify the client falls back to webpki roots
+
+    unsafe {
+        std::env::set_var(
+            EnvVars::SSL_CERT_FILE,
+            invalid_ca_public_pem_path.as_os_str(),
+        );
+    }
+    let (server_task, addr) = start_https_user_agent_server(&invalid_server_cert).await?;
+    let response = send_request(addr).await?;
+    let error = response.expect_err("request should fail after falling back to webpki roots");
+    assert_connect_error(error);
+    let _ = server_task.await;
+    unsafe {
+        std::env::remove_var(EnvVars::SSL_CERT_FILE);
+    }
+
+    // ** Set SSL_CERT_FILE to a certificate with an unsupported critical extension
+    // ** Then verify the client falls back to webpki roots
+
+    unsafe {
+        std::env::set_var(
+            EnvVars::SSL_CERT_FILE,
+            unsupported_ca_public_pem_path.as_os_str(),
+        );
+    }
+    let (server_task, addr) = start_https_user_agent_server(&unsupported_server_cert).await?;
+    let response = send_request(addr).await?;
+    let error = response.expect_err("request should fail after falling back to webpki roots");
+    assert_connect_error(error);
+    let _ = server_task.await;
+    unsafe {
+        std::env::remove_var(EnvVars::SSL_CERT_FILE);
+    }
+
     // ** Set SSL_CERT_DIR to our cert dir as well as some other dir that does not exist
     // ** Then verify our request still successfully establishes a connection
 
@@ -175,7 +286,7 @@ async fn ssl_env_vars() -> Result<()> {
             ])?,
         );
     }
-    let (server_task, addr) = start_https_user_agent_server(&standalone_server_cert).await?;
+    let (server_task, addr) = start_https_user_agent_server(&server_cert).await?;
     let url = DisplaySafeUrl::from_str(&format!("https://{addr}"))?;
     let cache = Cache::temp()?.init().await?;
     let client =
@@ -201,6 +312,7 @@ async fn ssl_env_vars() -> Result<()> {
     unsafe {
         std::env::set_var(EnvVars::SSL_CERT_DIR, does_not_exist_cert_dir.as_os_str());
     }
+    let standalone_server_cert = generate_self_signed_certs()?;
     let (server_task, addr) = start_https_user_agent_server(&standalone_server_cert).await?;
     let url = DisplaySafeUrl::from_str(&format!("https://{addr}"))?;
     let cache = Cache::temp()?.init().await?;


### PR DESCRIPTION
## Summary
  - filter invalid SSL_CERT_FILE and SSL_CERT_DIR certificates instead of failing client construction
  - improve invalid certificate diagnostics to match upstream behavior

## Testing
  - cargo test -p fyn-client
  - cargo clippy -p fyn-client --all-targets -- -D warnings
  - cargo fmt --all --check"