### PR TITLE
fix: warn on unmatched audit ignore rules

### DIFF
--- a/crates/fyn-audit/src/types.rs
+++ b/crates/fyn-audit/src/types.rs
@@ -36,7 +36,7 @@ impl Dependency {
 /// within that bucket. For example, `CVE-2026-12345` or `PYSEC-2023-0001`.
 ///
 /// No assumptions should be made about the format of these identifiers.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VulnerabilityID(SmallString);
 
 impl VulnerabilityID {

--- a/crates/fyn/src/commands/project/audit.rs
+++ b/crates/fyn/src/commands/project/audit.rs
@@ -32,6 +32,7 @@ use fyn_scripts::Pep723Script;
 use fyn_settings::PythonInstallMirrors;
 use fyn_warnings::warn_user;
 use fyn_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
+use rustc_hash::FxHashSet;
 use tracing::trace;
 
 pub(crate) async fn audit(
@@ -239,25 +240,38 @@ pub(crate) async fn audit(
 
     reporter.on_audit_complete();
 
+    let mut matched_ignores: FxHashSet<&VulnerabilityID> = FxHashSet::default();
     let all_findings: Vec<_> = all_findings
         .into_iter()
         .filter(|finding| match finding {
             Finding::Vulnerability(vulnerability) => {
-                if ignore.iter().any(|id| vulnerability.matches(id)) {
+                if let Some(id) = ignore.iter().find(|id| vulnerability.matches(id)) {
+                    matched_ignores.insert(id);
                     return false;
                 }
-                if vulnerability.fix_versions.is_empty()
-                    && ignore_until_fixed
-                        .iter()
-                        .any(|id| vulnerability.matches(id))
+                if let Some(id) = ignore_until_fixed
+                    .iter()
+                    .find(|id| vulnerability.matches(id))
                 {
-                    return false;
+                    matched_ignores.insert(id);
+                    if vulnerability.fix_versions.is_empty() {
+                        return false;
+                    }
                 }
                 true
             }
             Finding::ProjectStatus(_) => true,
         })
         .collect();
+
+    for id in ignore.iter().chain(ignore_until_fixed.iter()) {
+        if !matched_ignores.contains(id) {
+            warn_user!(
+                "Ignored vulnerability `{}` does not match any vulnerability in the project",
+                id.as_str()
+            );
+        }
+    }
 
     let display = AuditResults {
         printer,
@@ -283,7 +297,7 @@ impl AuditResults {
 
         let vuln_banner = if !vulns.is_empty() {
             let s = if vulns.len() == 1 { "y" } else { "ies" };
-            format!("{} known vulnerabilit{}", vulns.len(), s)
+            format!("{} known vulnerabilit{s}", vulns.len())
                 .yellow()
                 .to_string()
         } else {

--- a/crates/fyn/tests/it/audit.rs
+++ b/crates/fyn/tests/it/audit.rs
@@ -532,3 +532,159 @@ async fn audit_ignore_until_fixed_config() {
     Found no known vulnerabilities and no adverse project statuses in 1 package
     ");
 }
+
+#[tokio::test]
+async fn audit_ignore_unmatched() {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}]
+        })))
+        .mount(&server)
+        .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--ignore")
+        .arg("CVE-XXXX-YYYY")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Ignored vulnerability `CVE-XXXX-YYYY` does not match any vulnerability in the project
+    Found no known vulnerabilities and no adverse project statuses in 1 package
+    ");
+}
+
+#[tokio::test]
+async fn audit_ignore_until_fixed_unmatched() {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": []}]
+        })))
+        .mount(&server)
+        .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--ignore-until-fixed")
+        .arg("CVE-XXXX-YYYY")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Ignored vulnerability `CVE-XXXX-YYYY` does not match any vulnerability in the project
+    Found no known vulnerabilities and no adverse project statuses in 1 package
+    ");
+}
+
+#[tokio::test]
+async fn audit_ignore_mixed_matched_unmatched() {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{"vulns": [{"id": "PYSEC-2023-0001"}]}]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/vulns/PYSEC-2023-0001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "PYSEC-2023-0001",
+            "modified": "2026-01-01T00:00:00Z",
+            "summary": "A test vulnerability in iniconfig",
+            "affected": [{
+                "ranges": [{
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "0"},
+                        {"fixed": "2.1.0"}
+                    ]
+                }]
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--ignore")
+        .arg("PYSEC-2023-0001")
+        .arg("--ignore")
+        .arg("CVE-DOES-NOT-EXIST")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Ignored vulnerability `CVE-DOES-NOT-EXIST` does not match any vulnerability in the project
+    Found no known vulnerabilities and no adverse project statuses in 1 package
+    ");
+}


### PR DESCRIPTION
## Summary
  - warn when `fyn audit --ignore` or `--ignore-until-fixed` doesnt match any vulnerability in the project
  - keep ignoring matched vulnerabilities. Surface only the unmatched ignore rules
  - add regression coverage for unmatched and mixed matched/unmatched ignore cases

  ## Testing
  - cargo fmt --all --check
  - cargo clippy -p fyn -p fyn-audit --all-targets -- -D warnings
  - cargo test -p fyn-audit
  - cargo test -p fyn --test it audit_ -- --test-threads=1