### PR TITLE
feat: add task chaining and improve docs discoverability

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,33 +1,33 @@
-# Publish the fyn documentation.
+# Publish the fyn documentation to the `gh-pages` branch.
 #
-# Assumed to run as a subworkflow of .github/workflows/release.yml; specifically, as a post-announce
-# job within `cargo-dist`.
-name: mkdocs
+# This repo's documentation source of truth lives in `docs/` and is built with MkDocs. We publish
+# the generated site to a dedicated branch so it can be served by GitHub Pages.
+name: publish-docs
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "The commit SHA, tag, or branch to publish. Uses the default branch if not specified."
-        default: ""
-        type: string
   workflow_call:
     inputs:
       plan:
-        required: true
+        required: false
         type: string
 
-permissions: {}
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-docs
+  cancel-in-progress: true
 
 jobs:
   mkdocs:
     runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ (inputs.plan != '' && fromJson(inputs.plan).announcement_tag) || inputs.ref }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -43,33 +43,6 @@ jobs:
           cargo dev generate-cli-reference
           cargo dev generate-env-vars-reference
 
-      - name: "Set docs display name"
-        run: |
-          version="${VERSION}"
-          # if version is missing, use 'latest'
-          if [ -z "$version" ]; then
-            echo "Using 'latest' as version"
-            version="latest"
-          fi
-
-          # Use version as display name for now
-          display_name="$version"
-
-          echo "DISPLAY_NAME=$display_name" >> $GITHUB_ENV
-
-      - name: "Set branch name"
-        run: |
-          version="${VERSION}"
-          display_name="${DISPLAY_NAME}"
-          timestamp="$(date +%s)"
-
-          # create branch_display_name from display_name by replacing all
-          # characters disallowed in git branch names with hyphens
-          branch_display_name="$(echo "$display_name" | tr -c '[:alnum:]._' '-' | tr -s '-')"
-
-          echo "BRANCH_NAME=update-docs-$branch_display_name-$timestamp" >> $GITHUB_ENV
-          echo "TIMESTAMP=$timestamp" >> $GITHUB_ENV
-
       - name: "Install fyn"
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
@@ -78,64 +51,23 @@ jobs:
       - name: "Build docs"
         run: cargo run --bin fyn -- run --isolated --only-group docs mkdocs build --strict -f mkdocs.yml
 
-      - name: "Clone docs repo"
-        run: |
-          version="${VERSION}"
-          git clone https://${ASTRAL_DOCS_PAT}@github.com/astral-sh/docs.git astral-docs
+      - name: "Publish docs"
         env:
-          ASTRAL_DOCS_PAT: ${{ secrets.ASTRAL_DOCS_PAT }}
-
-      - name: "Copy docs"
-        run: rm -rf astral-docs/site/fyn && mkdir -p astral-docs/site && cp -r site/fyn astral-docs/site/
-
-      - name: "Commit docs"
-        working-directory: astral-docs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          branch_name="${BRANCH_NAME}"
+          remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-          git config user.name "astral-docs-bot"
-          git config user.email "176161322+astral-docs-bot@users.noreply.github.com"
+          rm -rf deploy
+          mkdir -p deploy
+          cp -R site/. deploy/
+          touch deploy/.nojekyll
 
-          git checkout -b $branch_name
-          git add site/fyn
-          git commit -m "Update fyn documentation for $version"
-
-      - name: "Create Pull Request"
-        working-directory: astral-docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.ASTRAL_DOCS_PAT }}
-        run: |
-          version="${VERSION}"
-          display_name="${DISPLAY_NAME}"
-          branch_name="${BRANCH_NAME}"
-
-          # set the PR title
-          pull_request_title="Update fyn documentation for $display_name"
-
-          # Delete any existing pull requests that are open for this version
-          # by checking against pull_request_title because the new PR will
-          # supersede the old one.
-          gh pr list --state open --json title --jq '.[] | select(.title == "$pull_request_title") | .number' | \
-            xargs -I {} gh pr close {}
-
-          # push the branch to GitHub
-          git push origin $branch_name
-
-          # create the PR
-          gh pr create --base main --head $branch_name \
-            --title "$pull_request_title" \
-            --body "Automated documentation update for $display_name" \
-            --label "documentation"
-
-      - name: "Merge Pull Request"
-        if: ${{ inputs.plan != '' && !fromJson(inputs.plan).announcement_tag_is_implicit }}
-        working-directory: astral-docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.ASTRAL_DOCS_PAT }}
-        run: |
-          branch_name="${BRANCH_NAME}"
-
-          # auto-merge the PR if the build was triggered by a release. Manual builds should be reviewed by a human.
-          # give the PR a few seconds to be created before trying to auto-merge it
-          sleep 10
-          gh pr merge --squash $branch_name
+          cd deploy
+          git init
+          git checkout --orphan gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add --all
+          git commit -m "Publish docs for ${GITHUB_SHA}"
+          git remote add origin "${remote}"
+          git push --force origin gh-pages

--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ See the command line reference with `fyn help`.
 
 ## Documentation
 
-The docs source of truth lives in
-[`docs/`](https://github.com/oha/fyn/tree/main/docs). If a hosted docs site is not available yet,
-you can read the same material directly on GitHub.
+The docs source of truth lives in [`docs/`](https://github.com/oha/fyn/tree/main/docs). If a hosted
+docs site is not available yet, you can read the same material directly on GitHub.
 
 Start here:
 
@@ -393,16 +392,16 @@ the table below for some of the larger user-visible differences:
 
 | Area                          | uv                                    | fyn                                           |
 | ----------------------------- | ------------------------------------- | --------------------------------------------- |
-| Config namespace and lockfile | `[tool.uv]`, `uv.lock`                | `[tool.fyn]`, `fyn.lock` |
-| Package index User-Agent      | `uv/<version>` plus LineHaul metadata | Minimal `fyn/<version>`  |
-| Task runner                   | No `[tool.uv.tasks]`                  | `[tool.fyn.tasks]`       |
-| `shell` command               | No `uv shell`                         | `fyn shell`              |
-| `upgrade` command             | No `uv upgrade`                       | `fyn upgrade`            |
-| `status` command              | No `uv status`                        | `fyn status`             |
-| `torch doctor` command        | No `uv torch doctor`                  | `fyn torch doctor`       |
+| Config namespace and lockfile | `[tool.uv]`, `uv.lock`                | `[tool.fyn]`, `fyn.lock`                      |
+| Package index User-Agent      | `uv/<version>` plus LineHaul metadata | Minimal `fyn/<version>`                       |
+| Task runner                   | No `[tool.uv.tasks]`                  | `[tool.fyn.tasks]`                            |
+| `shell` command               | No `uv shell`                         | `fyn shell`                                   |
+| `upgrade` command             | No `uv upgrade`                       | `fyn upgrade`                                 |
+| `status` command              | No `uv status`                        | `fyn status`                                  |
+| `torch doctor` command        | No `uv torch doctor`                  | `fyn torch doctor`                            |
 | Managed-project `pip` policy  | No `pip-in-project` setting           | `pip-in-project`: `warn`, `error`, or `allow` |
-| Cache size limit              | No `UV_CACHE_MAX_SIZE`                | `UV_CACHE_MAX_SIZE`      |
-| Custom lockfile name          | No `UV_LOCKFILE`                      | `UV_LOCKFILE`            |
+| Cache size limit              | No `UV_CACHE_MAX_SIZE`                | `UV_CACHE_MAX_SIZE`                           |
+| Custom lockfile name          | No `UV_LOCKFILE`                      | `UV_LOCKFILE`                                 |
 
 ## Acknowledgements
 
@@ -412,6 +411,9 @@ for their support.
 
 fyn started as a fork of [uv](https://github.com/astral-sh/uv) by Astral and still shares
 substantial ancestry with it.
+
+Some of fyn's workflow UX, especially around task-running and future workflow ergonomics, has also
+been informed by [Hatch](https://github.com/pypa/hatch).
 
 fyn's Git implementation is based on [Cargo](https://github.com/rust-lang/cargo).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An extremely fast Python package and project manager, written in Rust.
 **fyn** is an independent community fork of [uv](https://github.com/astral-sh/uv). It started on
 uv's foundation, but it now has its own commands, settings, defaults, and behavior, alongside
 reduced package-index request metadata, added features, and long-standing bug fixes. See
-[MANIFESTO.md](MANIFESTO.md) for the full story.
+[MANIFESTO.md](https://github.com/oha/fyn/blob/main/MANIFESTO.md) for the full story.
 
 ## Highlights
 
@@ -49,7 +49,23 @@ Or build from source:
 cargo install --path crates/fyn
 ```
 
-See the command line reference documentation with `fyn help`.
+See the command line reference with `fyn help`.
+
+## Documentation
+
+The docs source of truth lives in
+[`docs/`](https://github.com/oha/fyn/tree/main/docs). If a hosted docs site is not available yet,
+you can read the same material directly on GitHub.
+
+Start here:
+
+- [Documentation home](https://github.com/oha/fyn/blob/main/docs/README.md)
+- [Getting started](https://github.com/oha/fyn/blob/main/docs/getting-started/first-steps.md)
+- [Working on projects](https://github.com/oha/fyn/blob/main/docs/guides/projects.md)
+- [Running scripts](https://github.com/oha/fyn/blob/main/docs/guides/scripts.md)
+- [Command reference](https://github.com/oha/fyn/blob/main/docs/reference/cli.md)
+
+For CLI-specific help, use `fyn help` or `fyn help <command>`.
 
 ## Features
 
@@ -87,7 +103,7 @@ Define tasks in your `pyproject.toml` and run them with `fyn run`:
 
 ```toml
 [tool.fyn.tasks]
-test = "pytest -xvs"
+test = { cmd = "pytest -xvs", env = { PYTHONWARNINGS = "error" } }
 lint = "ruff check ."
 format = { cmd = "ruff format .", description = "Format code" }
 check = { chain = ["lint", "test"], description = "Lint then test" }
@@ -96,6 +112,9 @@ check = { chain = ["lint", "test"], description = "Lint then test" }
 ```console
 $ fyn run test
 # runs pytest -xvs
+
+$ fyn run check
+# runs lint, then test
 
 $ fyn run test -- -k mytest
 # extra args are passed through
@@ -107,6 +126,10 @@ Available tasks:
   lint     ruff check .
   test     pytest -xvs
 ```
+
+Task `env` values are applied to the spawned command. For chained tasks, parent `env` values are
+inherited by child tasks, and child task values take precedence. Extra arguments are supported for
+`cmd` tasks, but not for chained tasks.
 
 ### Shell activation
 
@@ -347,7 +370,8 @@ fynx ruff check .
 ## Contributing
 
 We are passionate about supporting contributors of all levels of experience and would love to see
-you get involved in the project. See the [contributing guide](CONTRIBUTING.md) to get started.
+you get involved in the project. See the
+[contributing guide](https://github.com/oha/fyn/blob/main/CONTRIBUTING.md) to get started.
 
 ## FAQ
 
@@ -364,11 +388,11 @@ behavior. Projects still need `[tool.uv]` renamed to `[tool.fyn]` and `uv.lock` 
 
 #### What's different from uv?
 
-See [MANIFESTO.md](MANIFESTO.md) for the fuller comparison, or the table below for some of the
-larger user-visible differences:
+See [MANIFESTO.md](https://github.com/oha/fyn/blob/main/MANIFESTO.md) for the fuller comparison, or
+the table below for some of the larger user-visible differences:
 
-| Area                          | uv                                    | fyn                      |
-| ----------------------------- | ------------------------------------- | ------------------------ | ----- | ------ |
+| Area                          | uv                                    | fyn                                           |
+| ----------------------------- | ------------------------------------- | --------------------------------------------- |
 | Config namespace and lockfile | `[tool.uv]`, `uv.lock`                | `[tool.fyn]`, `fyn.lock` |
 | Package index User-Agent      | `uv/<version>` plus LineHaul metadata | Minimal `fyn/<version>`  |
 | Task runner                   | No `[tool.uv.tasks]`                  | `[tool.fyn.tasks]`       |
@@ -376,7 +400,7 @@ larger user-visible differences:
 | `upgrade` command             | No `uv upgrade`                       | `fyn upgrade`            |
 | `status` command              | No `uv status`                        | `fyn status`             |
 | `torch doctor` command        | No `uv torch doctor`                  | `fyn torch doctor`       |
-| Managed-project `pip` policy  | No `pip-in-project` setting           | `pip-in-project = warn   | error | allow` |
+| Managed-project `pip` policy  | No `pip-in-project` setting           | `pip-in-project`: `warn`, `error`, or `allow` |
 | Cache size limit              | No `UV_CACHE_MAX_SIZE`                | `UV_CACHE_MAX_SIZE`      |
 | Custom lockfile name          | No `UV_LOCKFILE`                      | `UV_LOCKFILE`            |
 

--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -98,7 +98,7 @@ const STYLES: Styles = Styles::styled()
 
 #[derive(Parser)]
 #[command(name = "fyn", author, long_version = crate::version::uv_self_version())]
-#[command(about = "An extremely fast Python package manager.")]
+#[command(about = "An extremely fast Python package and project manager.")]
 #[command(
     after_help = "Use `fyn help` for more details.",
     after_long_help = "",

--- a/crates/fyn/Cargo.toml
+++ b/crates/fyn/Cargo.toml
@@ -5,7 +5,7 @@ description = "A Python package and project manager"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
-documentation = "https://github.com/oha/fyn"
+documentation = "https://github.com/oha/fyn/blob/main/docs/README.md"
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }

--- a/crates/fyn/src/commands/project/run.rs
+++ b/crates/fyn/src/commands/project/run.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::env::VarError;
 use std::ffi::OsString;
 use std::fmt::Write;
@@ -1249,9 +1250,6 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
         return Ok(ExitStatus::Error);
     };
 
-    debug!("Running `{command}`");
-    let mut process = command.as_command(interpreter);
-
     // Construct the `PATH` environment variable.
     let new_path = std::env::join_paths(
         ephemeral_env
@@ -1282,18 +1280,13 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
                     .flat_map(std::env::split_paths),
             ),
     )?;
-    process.env(EnvVars::PATH, new_path);
-
-    // Increment recursion depth counter.
-    process.env(
-        EnvVars::UV_RUN_RECURSION_DEPTH,
-        (recursion_depth + 1).to_string(),
-    );
-
-    // Ensure `VIRTUAL_ENV` is set.
-    if interpreter.is_virtualenv() {
-        process.env(EnvVars::VIRTUAL_ENV, interpreter.sys_prefix().as_os_str());
+    if let RunCommand::Task(plan) = &command {
+        return execute_task_plan(plan, interpreter, &new_path, recursion_depth, printer).await;
     }
+
+    debug!("Running `{command}`");
+    let mut process = command.as_command(interpreter);
+    configure_run_process(&mut process, interpreter, &new_path, recursion_depth);
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
@@ -1303,6 +1296,54 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
         .with_context(|| format!("Failed to spawn: `{}`", command.display_executable()))?;
 
     run_to_completion(handle).await
+}
+
+fn configure_run_process(
+    process: &mut Command,
+    interpreter: &Interpreter,
+    new_path: &OsString,
+    recursion_depth: u32,
+) {
+    process.env(EnvVars::PATH, new_path);
+    process.env(
+        EnvVars::UV_RUN_RECURSION_DEPTH,
+        (recursion_depth + 1).to_string(),
+    );
+    if interpreter.is_virtualenv() {
+        process.env(EnvVars::VIRTUAL_ENV, interpreter.sys_prefix().as_os_str());
+    }
+}
+
+async fn execute_task_plan(
+    plan: &TaskPlan,
+    interpreter: &Interpreter,
+    new_path: &OsString,
+    recursion_depth: u32,
+    printer: Printer,
+) -> anyhow::Result<ExitStatus> {
+    let show_step_names = plan.steps.len() > 1;
+    for step in &plan.steps {
+        if show_step_names {
+            writeln!(printer.stderr(), "Running task `{}`", step.name.cyan())?;
+        }
+
+        debug!("Running task step `{}` for task `{}`", step.name, plan.name);
+
+        let mut process = step.command.as_command(interpreter);
+        configure_run_process(&mut process, interpreter, new_path, recursion_depth);
+        process.envs(step.env.iter());
+
+        let handle = process
+            .spawn()
+            .with_context(|| format!("Failed to spawn: `{}`", step.command.display_executable()))?;
+
+        let status = run_to_completion(handle).await?;
+        if !matches!(status, ExitStatus::Success | ExitStatus::External(0)) {
+            return Ok(status);
+        }
+    }
+
+    Ok(ExitStatus::Success)
 }
 
 /// Returns `true` if we can skip creating an additional ephemeral environment in `fyn run`.
@@ -1382,6 +1423,41 @@ fn can_skip_ephemeral(
 }
 
 #[derive(Debug)]
+pub(crate) struct TaskPlan {
+    name: String,
+    steps: Vec<TaskStep>,
+}
+
+#[derive(Debug)]
+struct TaskStep {
+    name: String,
+    command: TaskCommand,
+    env: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct TaskCommand {
+    executable: OsString,
+    args: Vec<OsString>,
+}
+
+impl TaskCommand {
+    fn display_executable(&self) -> Cow<'_, str> {
+        self.executable.to_string_lossy()
+    }
+
+    fn as_command(&self, interpreter: &Interpreter) -> Command {
+        let mut process = if cfg!(windows) {
+            WindowsRunnable::from_script_path(interpreter.scripts(), &self.executable).into()
+        } else {
+            Command::new(&self.executable)
+        };
+        process.args(&self.args);
+        process
+    }
+}
+
+#[derive(Debug)]
 pub(crate) enum RunCommand {
     /// Execute `python`.
     Python(Vec<OsString>),
@@ -1404,6 +1480,8 @@ pub(crate) enum RunCommand {
     PythonGuiStdin(Vec<u8>, Vec<OsString>),
     /// Execute a Python script provided via a remote URL.
     PythonRemote(DisplaySafeUrl, tempfile::NamedTempFile, Vec<OsString>),
+    /// Execute a resolved task plan.
+    Task(TaskPlan),
     /// Execute an external command.
     External(OsString, Vec<OsString>),
     /// Execute an empty command (in practice, `python` with no arguments).
@@ -1438,6 +1516,7 @@ impl RunCommand {
                     Cow::Borrowed("python -c")
                 }
             }
+            Self::Task(plan) => Cow::Borrowed(plan.name.as_str()),
             Self::External(executable, _) => executable.to_string_lossy(),
         }
     }
@@ -1556,6 +1635,7 @@ impl RunCommand {
 
                 process
             }
+            Self::Task(..) => unreachable!("task plans are executed separately"),
             Self::External(executable, args) => {
                 let mut process = if cfg!(windows) {
                     WindowsRunnable::from_script_path(interpreter.scripts(), executable).into()
@@ -1581,6 +1661,7 @@ impl RunCommand {
             | Self::PythonStdin(..)
             | Self::PythonGuiStdin(..)
             | Self::PythonRemote(..)
+            | Self::Task(..)
             | Self::External(..)
             | Self::Empty => None,
         };
@@ -1636,6 +1717,7 @@ impl std::fmt::Display for RunCommand {
                 write!(f, "pythonw -c")?;
                 Ok(())
             }
+            Self::Task(plan) => write!(f, "task {}", plan.name),
             Self::External(executable, args) => {
                 write!(f, "{}", executable.to_string_lossy())?;
                 for arg in args {
@@ -1805,8 +1887,10 @@ impl RunCommand {
             && !target_str.contains('/')
             && !target_str.contains('.')
         {
-            if let Some(task) = lookup_task(&target_str, project_dir) {
-                return task_to_command(&task, args);
+            if let Some(tasks) = lookup_tasks(project_dir) {
+                if tasks.get(&target_str).is_some() {
+                    return Ok(Self::Task(resolve_task_plan(&target_str, &tasks, args)?));
+                }
             }
         }
 
@@ -1845,11 +1929,11 @@ impl RunCommand {
     }
 }
 
-/// Look up a task by name from the nearest `pyproject.toml`.
+/// Look up the task table from the nearest `pyproject.toml`.
 ///
 /// Walks up from `project_dir` looking for a `pyproject.toml` with a
-/// `[tool.fyn.tasks]` section that contains the given name.
-fn lookup_task(name: &str, project_dir: &Path) -> Option<fyn_workspace::pyproject::TaskDefinition> {
+/// `[tool.fyn.tasks]` section.
+fn lookup_tasks(project_dir: &Path) -> Option<fyn_workspace::pyproject::ToolfynTasks> {
     let mut dir = project_dir.to_path_buf();
     loop {
         let pyproject_path = dir.join("pyproject.toml");
@@ -1860,14 +1944,14 @@ fn lookup_task(name: &str, project_dir: &Path) -> Option<fyn_workspace::pyprojec
                 {
                     if let Some(tool_fyn) = pyproject.tool.and_then(|t| t.fyn) {
                         if let Some(tasks) = tool_fyn.tasks {
-                            if let Some(task) = tasks.get(name) {
-                                return Some(task.clone());
+                            if !tasks.is_empty() {
+                                return Some(tasks);
                             }
                         }
                     }
                 }
             }
-            // Found a pyproject.toml but no matching task — stop searching.
+            // Found a pyproject.toml but no tasks — stop searching.
             return None;
         }
         if !dir.pop() {
@@ -1876,41 +1960,111 @@ fn lookup_task(name: &str, project_dir: &Path) -> Option<fyn_workspace::pyprojec
     }
 }
 
-/// Convert a [`TaskDefinition`] into a [`RunCommand`].
-fn task_to_command(
-    task: &fyn_workspace::pyproject::TaskDefinition,
+fn resolve_task_plan(
+    name: &str,
+    tasks: &fyn_workspace::pyproject::ToolfynTasks,
     extra_args: &[OsString],
-) -> anyhow::Result<RunCommand> {
+) -> anyhow::Result<TaskPlan> {
+    let mut stack = Vec::new();
+    let mut steps = Vec::new();
+    resolve_task_steps(
+        name,
+        tasks,
+        &BTreeMap::new(),
+        extra_args,
+        &mut stack,
+        &mut steps,
+    )?;
+    Ok(TaskPlan {
+        name: name.to_string(),
+        steps,
+    })
+}
+
+fn resolve_task_steps(
+    name: &str,
+    tasks: &fyn_workspace::pyproject::ToolfynTasks,
+    inherited_env: &BTreeMap<String, String>,
+    extra_args: &[OsString],
+    stack: &mut Vec<String>,
+    steps: &mut Vec<TaskStep>,
+) -> anyhow::Result<()> {
     use fyn_workspace::pyproject::TaskDefinition;
 
-    let cmd_str = match task {
-        TaskDefinition::Cmd(cmd) => cmd.clone(),
+    if let Some(position) = stack.iter().position(|task_name| task_name == name) {
+        let mut cycle = stack[position..].to_vec();
+        cycle.push(name.to_string());
+        bail!("Task cycle detected: {}", cycle.join(" -> "));
+    }
+
+    let task = tasks
+        .get(name)
+        .ok_or_else(|| anyhow!("Task `{name}` was referenced but is not defined"))?;
+
+    stack.push(name.to_string());
+
+    match task {
+        TaskDefinition::Cmd(cmd) => {
+            steps.push(TaskStep {
+                name: name.to_string(),
+                command: parse_task_command(cmd, extra_args)?,
+                env: inherited_env.clone(),
+            });
+        }
         TaskDefinition::Detailed(detailed) => {
-            if let Some(ref cmd) = detailed.cmd {
-                cmd.clone()
-            } else if detailed.chain.is_some() {
-                // Chain tasks are handled at a higher level; for now, just run
-                // the first task's command. Full chain support is in step 3.
-                anyhow::bail!("Chain tasks are not yet fully supported; use individual task names");
-            } else {
-                anyhow::bail!("Task has no `cmd` or `chain` defined");
+            let mut merged_env = inherited_env.clone();
+            if let Some(env) = &detailed.env {
+                merged_env.extend(env.clone());
+            }
+
+            match (&detailed.cmd, &detailed.chain) {
+                (Some(_), Some(_)) => {
+                    bail!("Task `{name}` cannot define both `cmd` and `chain`");
+                }
+                (Some(cmd), None) => {
+                    steps.push(TaskStep {
+                        name: name.to_string(),
+                        command: parse_task_command(cmd, extra_args)?,
+                        env: merged_env,
+                    });
+                }
+                (None, Some(chain)) => {
+                    if !extra_args.is_empty() {
+                        bail!(
+                            "Cannot pass additional arguments to chain task `{name}`; run the child task directly instead"
+                        );
+                    }
+                    if chain.is_empty() {
+                        bail!("Task `{name}` defines an empty `chain`");
+                    }
+                    for child in chain {
+                        resolve_task_steps(child, tasks, &merged_env, &[], stack, steps)?;
+                    }
+                }
+                (None, None) => {
+                    bail!("Task `{name}` has no `cmd` or `chain` defined");
+                }
             }
         }
-    };
+    }
 
-    // Split the command string into program + args, respecting single and
-    // double quotes so that e.g. `echo "hello world"` doesn't get split into
-    // three tokens.
-    let parts = shell_split(&cmd_str);
+    stack.pop();
+    Ok(())
+}
 
+fn parse_task_command(cmd_str: &str, extra_args: &[OsString]) -> anyhow::Result<TaskCommand> {
+    let parts = shell_split(cmd_str);
     let Some((program, cmd_args)) = parts.split_first() else {
-        anyhow::bail!("Task command is empty");
+        bail!("Task command is empty");
     };
 
     let mut all_args: Vec<OsString> = cmd_args.iter().map(OsString::from).collect();
     all_args.extend_from_slice(extra_args);
 
-    Ok(RunCommand::External(OsString::from(program), all_args))
+    Ok(TaskCommand {
+        executable: OsString::from(program),
+        args: all_args,
+    })
 }
 
 /// Split a command string into tokens, respecting single and double quotes.

--- a/crates/fyn/tests/it/run.rs
+++ b/crates/fyn/tests/it/run.rs
@@ -6854,6 +6854,126 @@ fn run_task_detailed() -> Result<()> {
     Ok(())
 }
 
+/// Run a chained task and apply inherited and per-task environment variables.
+#[test]
+fn run_task_chain_with_env() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        first = { cmd = "python first.py", env = { OVERRIDE = "first", FIRST_ONLY = "yes" } }
+        second = { cmd = "python second.py" }
+        check = { chain = ["first", "second"], env = { CHAIN_VALUE = "chain", OVERRIDE = "root" } }
+        "#
+    })?;
+    context.temp_dir.child("first.py").write_str(indoc! { r#"
+        import os
+
+        print(f"first|{os.getenv('CHAIN_VALUE')}|{os.getenv('OVERRIDE')}|{os.getenv('FIRST_ONLY')}")
+        "#
+    })?;
+    context.temp_dir.child("second.py").write_str(indoc! { r#"
+        import os
+
+        print(f"second|{os.getenv('CHAIN_VALUE')}|{os.getenv('OVERRIDE')}|{os.getenv('FIRST_ONLY')}")
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("check"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    first|chain|first|yes
+    second|chain|root|None
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    Running task `first`
+    Running task `second`
+    ");
+
+    Ok(())
+}
+
+/// Passing extra arguments to a chain task is rejected.
+#[test]
+fn run_task_chain_rejects_extra_args() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        first = "python -V"
+        check = { chain = ["first"] }
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("check").arg("--").arg("extra"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Cannot pass additional arguments to chain task `check`; run the child task directly instead
+    ");
+
+    Ok(())
+}
+
+/// Task cycles are rejected with a clear error.
+#[test]
+fn run_task_cycle_detected() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        a = { chain = ["b"] }
+        b = { chain = ["a"] }
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("a"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Task cycle detected: a -> b -> a
+    ");
+
+    Ok(())
+}
+
 /// Unknown name falls back to PATH lookup (existing behavior).
 #[test]
 fn run_task_fallback_to_path() -> Result<()> {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# fyn documentation
+
+This directory is the source of truth for fyn's documentation. The published MkDocs site uses
+[index.md](./index.md) as its home page; this README exists so the `docs/` directory also has a
+useful landing page when people browse the repository on GitHub.
+
+## Start here
+
+- [Install fyn](./getting-started/installation.md)
+- [First steps](./getting-started/first-steps.md)
+- [Working on projects](./guides/projects.md)
+- [Running scripts](./guides/scripts.md)
+- [Using tools](./guides/tools.md)
+- [Command reference](./reference/cli.md)
+- [Settings reference](./reference/settings.md)
+
+## Documentation map
+
+- [Getting started](./getting-started/index.md)
+- [Guides](./guides/index.md)
+- [Concepts](./concepts/index.md)
+- [Reference](./reference/index.md)
+- [RFCs](./rfcs/index.md)
+
+## Preview locally
+
+```console
+$ cargo run --bin fyn -- run --isolated --only-group docs mkdocs serve -f mkdocs.yml
+```

--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -22,6 +22,42 @@ $ # Running a `bash` script that requires the project to be available
 $ fyn run bash scripts/foo.sh
 ```
 
+## Running project tasks
+
+Projects can define named tasks in `pyproject.toml` under `[tool.fyn.tasks]` and invoke them with
+`fyn run <name>`:
+
+```toml title="pyproject.toml"
+[tool.fyn.tasks]
+test = { cmd = "pytest -q", env = { PYTHONWARNINGS = "error" } }
+lint = "ruff check ."
+check = { chain = ["lint", "test"], description = "Run lint and tests" }
+```
+
+```console
+$ fyn run test
+$ fyn run check
+$ fyn run --list-tasks
+```
+
+Tasks support two forms:
+
+- a command string, such as `test = "pytest -q"`
+- a table with `cmd`, `chain`, `description`, and `env`
+
+Chained tasks run their child tasks in sequence and stop on the first failure. Task `env` values
+are applied to the spawned command. If a chained task defines `env`, those values are inherited by
+its child tasks, and any child task values override the parent values.
+
+Additional CLI arguments are supported for `cmd` tasks:
+
+```console
+$ fyn run test -- -k my_test
+```
+
+Additional CLI arguments are not supported for chained tasks; run the child task directly when you
+need to pass extra arguments.
+
 ## Requesting additional dependencies
 
 Additional dependencies or different versions of dependencies can be requested per invocation.

--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -45,9 +45,9 @@ Tasks support two forms:
 - a command string, such as `test = "pytest -q"`
 - a table with `cmd`, `chain`, `description`, and `env`
 
-Chained tasks run their child tasks in sequence and stop on the first failure. Task `env` values
-are applied to the spawned command. If a chained task defines `env`, those values are inherited by
-its child tasks, and any child task values override the parent values.
+Chained tasks run their child tasks in sequence and stop on the first failure. Task `env` values are
+applied to the spawned command. If a chained task defines `env`, those values are inherited by its
+child tasks, and any child task values override the parent values.
 
 Additional CLI arguments are supported for `cmd` tasks:
 

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -5,7 +5,7 @@ command:
 
 ```console
 $ fyn
-An extremely fast Python package manager.
+An extremely fast Python package and project manager.
 
 Usage: fyn [OPTIONS] <COMMAND>
 

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -235,6 +235,42 @@ directory:
 $ fyn shell --no-project
 ```
 
+## Defining project tasks
+
+Use `[tool.fyn.tasks]` to define repeatable project commands in `pyproject.toml`:
+
+```toml title="pyproject.toml"
+[tool.fyn.tasks]
+test = { cmd = "pytest -q", env = { PYTHONWARNINGS = "error" } }
+lint = "ruff check ."
+check = { chain = ["lint", "test"], description = "Run lint and tests" }
+```
+
+Then run them with `fyn run`:
+
+```console
+$ fyn run test
+$ fyn run check
+$ fyn run --list-tasks
+```
+
+String tasks run a single command. Table tasks can define:
+
+- `cmd`: a command to execute
+- `chain`: a list of other task names to run in order
+- `description`: text shown by `fyn run --list-tasks`
+- `env`: environment variables applied to that task
+
+If a chained task defines `env`, those variables are inherited by child tasks, and child values
+override the parent values. Extra arguments are supported for `cmd` tasks:
+
+```console
+$ fyn run test -- -k my_test
+```
+
+Extra arguments are not supported for chained tasks; run the child task directly when you need to
+pass additional flags.
+
 ## Viewing your version
 
 The `fyn version` command can be used to read your package's version.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,18 @@
 
 An extremely fast Python package and project manager, written in Rust.
 
+## Start here
+
+Pick the path that matches how you use fyn:
+
+- New to fyn: [installation](./getting-started/installation.md),
+  [first steps](./getting-started/first-steps.md), and [getting help](./getting-started/help.md)
+- Working on a project: [projects guide](./guides/projects.md)
+- Running scripts: [scripts guide](./guides/scripts.md)
+- Using developer tools: [tools guide](./guides/tools.md)
+- Looking for flags or config details: [CLI reference](./reference/cli.md),
+  [settings](./reference/settings.md), and [environment variables](./reference/environment.md)
+
 <p align="center">
   <img alt="Shows a bar chart with benchmark results." src="https://github.com/astral-sh/uv/assets/1309177/629e59c0-9c6e-4013-9ad4-adb2bcf5080d#only-light">
 </p>

--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -108,15 +108,38 @@ document$.subscribe(function () {
       "concepts/authentication/third-party/#hugging-face-support",
   };
 
-  // The prefix for the site, see `site_dir` in `mkdocs.yml`
-  let site_dir = "uv";
+  const docRoots = new Set([
+    "concepts",
+    "getting-started",
+    "guides",
+    "pip",
+    "reference",
+    "rfcs",
+  ]);
+
+  function get_site_prefix(pathname) {
+    const segments = pathname.split("/").filter(Boolean);
+    const first = segments[0];
+
+    if (!first || docRoots.has(first) || first.endsWith(".html")) {
+      return "";
+    }
+
+    return first;
+  }
+
+  function prefix_path(path, prefix) {
+    return prefix ? "/" + prefix + "/" + path : "/" + path;
+  }
+
+  const site_prefix = get_site_prefix(window.location.pathname);
 
   function get_path() {
     var path = window.location.pathname;
 
     // Trim the site prefix
-    if (path.startsWith("/" + site_dir + "/")) {
-      path = path.slice(site_dir.length + 2);
+    if (site_prefix && path.startsWith("/" + site_prefix + "/")) {
+      path = path.slice(site_prefix.length + 2);
     }
 
     // Always include a trailing `/`
@@ -135,6 +158,6 @@ document$.subscribe(function () {
 
   let path = get_path();
   if (path && redirect_maps.hasOwnProperty(path)) {
-    window.location.replace("/" + site_dir + "/" + redirect_maps[path]);
+    window.location.replace(prefix_path(redirect_maps[path], site_prefix));
   }
 })();

--- a/docs/rfcs/0001-selective-hatch-ux.md
+++ b/docs/rfcs/0001-selective-hatch-ux.md
@@ -213,8 +213,8 @@ templating framework.
 
 ### Why this is useful
 
-This makes `fyn init` generate something closer to what people actually keep after the first
-commit. It reduces the current pattern of:
+This makes `fyn init` generate something closer to what people actually keep after the first commit.
+It reduces the current pattern of:
 
 1. `fyn init`
 2. hand-edit `pyproject.toml`
@@ -248,8 +248,8 @@ Tasks and workflows should serve different jobs:
 
 ### Design principle
 
-This should be a small workflow layer on top of `fyn`'s existing resolver and environment
-machinery, not a new environment framework.
+This should be a small workflow layer on top of `fyn`'s existing resolver and environment machinery,
+not a new environment framework.
 
 This RFC intentionally does not use the name `envs` for the new feature, because `fyn` already uses
 `tool.fyn.environments` for resolver marker scoping.
@@ -327,9 +327,8 @@ $ fyn run --workflow docs -- mkdocs serve
 - It uses the same index/auth/config machinery as the rest of `fyn`.
 - Target parsing prefers workflow syntax only when the prefix matches a declared workflow name.
   Otherwise, existing `fyn run` target resolution rules continue to apply.
-- The workflow cache key must include at least:
-  project root, workflow name, Python request, normalized dependency list, and a hash of the
-  workflow config table.
+- The workflow cache key must include at least: project root, workflow name, Python request,
+  normalized dependency list, and a hash of the workflow config table.
 
 ### Why this is useful
 
@@ -493,8 +492,8 @@ Only begin this phase if:
 ## Open Questions
 
 1. Should `fyn init --tests` add a `test` dependency group, `dev` group, or plain dependencies?
-2. Should workflow environments be stored in the cache, under project-local metadata, or behind an internal
-   abstraction with no user-visible promise yet?
+2. Should workflow environments be stored in the cache, under project-local metadata, or behind an
+   internal abstraction with no user-visible promise yet?
 3. Should `--list-tasks` eventually gain awareness of `<workflow>:<script>` targets, or remain
    task-only?
 

--- a/docs/rfcs/0001-selective-hatch-ux.md
+++ b/docs/rfcs/0001-selective-hatch-ux.md
@@ -1,0 +1,508 @@
+# RFC 0001: Selective Hatch-Inspired UX for `fyn`
+
+Status: Draft
+
+Author: Codex
+
+Last updated: 2026-04-13
+
+## Summary
+
+`fyn` should not copy Hatch wholesale.
+
+`fyn` should copy only the workflow UX where both `fyn` and `uv` are still thin:
+
+1. Make the existing task runner actually match its documented surface.
+2. Make `fyn init` generate more useful project scaffolds.
+3. Add a small named workflow layer for lint/docs/test/typecheck tasks.
+4. Explicitly defer matrices and any plugin architecture.
+
+This RFC is intentionally narrow. The goal is to improve common daily workflows for real users
+without turning `fyn` into a second Hatch.
+
+## Why This Exists
+
+Recent upstream `uv` already covers much more surface than older comparisons imply, including
+project initialization, version management, formatting, and auditing.
+
+That means the remaining gap is not core package-management capability. The remaining gap is
+workflow ergonomics:
+
+- repeatable project tasks
+- useful scaffolding for new projects
+- isolated named workflows for docs/lint/test/typecheck work
+
+Those are the areas where Hatch is still meaningfully ahead.
+
+## Problem
+
+`fyn` currently has a workflow story, but parts of it are incomplete or too thin:
+
+- `fyn` documents chained tasks, but the runtime still errors on `chain` tasks.
+- Task definitions also document `env`, but the runtime does not appear to apply it.
+- `fyn init` is already solid for app/lib/package creation, but common follow-up steps still need
+  hand editing.
+- `tool.fyn.environments` already exists, but it is resolver scoping, not named workflow
+  environments.
+
+This creates two problems:
+
+1. Users still reach for shell scripts, Makefiles, or external tools for routine workflows.
+2. `fyn` already advertises a richer UX than it fully delivers.
+
+## Product Thesis
+
+`fyn` should be the fastest Python package/project manager that also covers the most common
+developer workflows directly, with simple declarative config and without a plugin framework.
+
+## Target Users
+
+This RFC is aimed at the users who will get immediate value:
+
+- Solo Python application developers who want repeatable local commands without adding another tool.
+- Library maintainers who need docs, lint, test, and release workflows that are isolated and
+  reproducible.
+- Small teams standardizing a `pyproject.toml`-first workflow.
+- Monorepo/workspace users who want per-project workflow config without inventing their own task
+  conventions.
+
+This RFC is not primarily aimed at:
+
+- users who want a general plugin platform
+- users who want arbitrary build hooks inside the package manager
+- users who need a full CI matrix DSL on day one
+
+## Goals
+
+- Close the gap between documented and actual task-runner behavior.
+- Make `fyn init` generate projects that are useful without immediate manual cleanup.
+- Support common detached workflows with minimal new concepts.
+- Preserve `fyn`'s run-centric UX.
+- Avoid introducing a generic extension platform.
+
+## Non-Goals
+
+- Reproducing Hatch's plugin architecture.
+- Reproducing Hatch's environment inheritance model.
+- Adding build hooks, metadata hooks, publisher plugins, or version-source plugins.
+- Adding a full matrix/filter/collector system in the first iteration.
+- Adding new top-level commands like `fyn test` or `fyn fmt` in this RFC.
+
+## Proposal
+
+## Part 1: Finish the Task Runner
+
+### Current state
+
+`[tool.fyn.tasks]` already supports:
+
+- string tasks
+- `description`
+- `chain`
+- `env`
+
+But only simple command execution is working consistently today.
+
+### Proposed behavior
+
+Implement the documented task surface in full:
+
+```toml
+[tool.fyn.tasks]
+lint = "ruff check ."
+test = { cmd = "pytest -q", env = { PYTHONWARNINGS = "error" } }
+check = { chain = ["lint", "test"], description = "Run lint and tests" }
+```
+
+#### `cmd`
+
+- Executes exactly as today.
+
+#### `env`
+
+- Merges into the child process environment for that task.
+- If a chain task has `env`, that environment is inherited by child tasks.
+- Child task `env` values override parent chain values.
+- Effective precedence is: process environment, then chain-task `env`, then leaf-task `env`.
+
+#### `chain`
+
+- Executes tasks sequentially in the declared order.
+- Stops on first failure.
+- Prints which child task is currently running.
+- Rejects cycles with a clear error.
+
+#### Extra CLI args
+
+Initial version:
+
+- Extra args continue to work for `cmd` tasks.
+- Extra args are rejected for `chain` tasks with a clear error message.
+
+Rationale:
+
+- this avoids ambiguous behavior
+- it solves the main usefulness gap immediately
+- it keeps the first implementation small and predictable
+
+### Why this is useful
+
+This is the highest-value, lowest-risk change in the entire RFC:
+
+- it fixes a current doc/runtime mismatch
+- it removes immediate need for Makefiles or shell wrappers in many projects
+- it creates a better foundation for scaffolded projects and workflows later
+
+## Part 2: Make `fyn init` More Useful
+
+### Current state
+
+`fyn init` already handles:
+
+- app vs lib
+- package vs non-package
+- build backend selection
+- script initialization
+- workspace integration
+
+That base is good. The gap is common workflow scaffolding after the project exists.
+
+### Proposed additions
+
+Add a small set of high-value presets:
+
+- `--cli`
+- `--tests`
+
+These should be non-interactive first. If an interactive mode is added later, it should only be a
+selector for these same presets, not a separate scaffolding model.
+
+### Proposed semantics
+
+#### `--cli`
+
+For application projects:
+
+- creates a packaged app layout
+- adds a `[project.scripts]` entrypoint
+- generates a `main()`-style executable module if one does not already exist
+
+This should be an ergonomic shortcut over the existing `--app --package` flow.
+
+#### `--tests`
+
+- creates a `tests/` directory
+- adds a minimal example test
+- adds a test dependency group or equivalent project dependency declaration
+- adds useful default tasks, e.g.:
+
+```toml
+[tool.fyn.tasks]
+test = "pytest -q"
+```
+
+### Explicit follow-up, not v1
+
+Possible later preset:
+
+- `--ci github`
+
+This should only be considered after the base presets prove useful. It is less universal than
+`--cli` and `--tests`, and it should remain plain file generation rather than the start of a
+templating framework.
+
+### Why this is useful
+
+This makes `fyn init` generate something closer to what people actually keep after the first
+commit. It reduces the current pattern of:
+
+1. `fyn init`
+2. hand-edit `pyproject.toml`
+3. add tests
+4. add tasks
+5. add CI
+
+into a smaller, more direct path.
+
+## Part 3: Add Minimal Named Workflows
+
+### Problem this solves
+
+Many projects want isolated environments for:
+
+- linting
+- documentation
+- type checking
+- integration tests with extra tooling
+
+Today, these workflows usually become:
+
+- ad hoc shell scripts
+- external task runners
+- hand-maintained local virtual environments
+
+Tasks and workflows should serve different jobs:
+
+- tasks are project commands that run in the project environment
+- workflows are detached toolchain environments for repo maintenance tasks
+
+### Design principle
+
+This should be a small workflow layer on top of `fyn`'s existing resolver and environment
+machinery, not a new environment framework.
+
+This RFC intentionally does not use the name `envs` for the new feature, because `fyn` already uses
+`tool.fyn.environments` for resolver marker scoping.
+
+### Proposed config
+
+Add a new table:
+
+```toml
+[tool.fyn.workflows.lint]
+python = "3.12"
+dependencies = ["ruff>=0.7"]
+env = { RUFF_OUTPUT_FORMAT = "full" }
+
+[tool.fyn.workflows.lint.scripts]
+check = "ruff check ."
+format = "ruff format ."
+
+[tool.fyn.workflows.docs]
+python = "3.12"
+dependencies = ["mkdocs-material", "mkdocs-redirects"]
+
+[tool.fyn.workflows.docs.scripts]
+serve = "mkdocs serve"
+build = "mkdocs build --strict"
+```
+
+### Version 1 semantics
+
+Named workflows are intentionally limited:
+
+- they resolve to detached cached environments
+- they do not install the current project
+- they do not inherit from each other
+- they do not support matrices
+- they do not define custom environment types
+
+Supported fields in v1:
+
+- `python`
+- `dependencies`
+- `env`
+- `scripts`
+
+Optional future field, but not required in v1:
+
+- `description`
+
+Explicitly deferred in v1:
+
+- dependency-group support
+- extras support
+
+### CLI shape
+
+To preserve `fyn`'s run-centric UX, do not add a top-level `fyn env` namespace in v1.
+
+Instead:
+
+- `fyn run <workflow>:<script>`
+- `fyn run --workflow <workflow> -- <command>...`
+
+Examples:
+
+```console
+$ fyn run lint:check
+$ fyn run lint:format
+$ fyn run --workflow docs -- mkdocs serve
+```
+
+### Behavior
+
+- The workflow environment is created and cached automatically on first use.
+- It is updated when its config or dependency inputs change.
+- It uses the same index/auth/config machinery as the rest of `fyn`.
+- Target parsing prefers workflow syntax only when the prefix matches a declared workflow name.
+  Otherwise, existing `fyn run` target resolution rules continue to apply.
+- The workflow cache key must include at least:
+  project root, workflow name, Python request, normalized dependency list, and a hash of the
+  workflow config table.
+
+### Why this is useful
+
+This is the smallest meaningful piece of Hatch worth borrowing after tasks:
+
+- it covers real workflows people already have
+- it keeps project `.venv` focused on the project itself
+- it replaces many one-off shell scripts
+- it avoids a separate tool for common docs/lint/typecheck workflows
+
+## Deferred: Matrix UX
+
+Matrix UX is useful, but it should be explicitly deferred.
+
+Examples of deferred matrix behavior:
+
+- `python = ["3.11", "3.12", "3.13"]`
+- include/exclude filters
+- env inheritance with matrix axes
+- dedicated `test` command semantics
+
+### Why defer it
+
+- it adds a lot of behavior surface quickly
+- it is less useful until workflows exist
+- it risks recreating too much of Hatch's model
+
+The right sequence is:
+
+1. make tasks real
+2. make init useful
+3. make workflows useful
+4. then evaluate matrices from real user demand
+
+## Explicitly Rejected
+
+The following are out of scope for this RFC:
+
+- Hatch-style build hooks
+- metadata hooks
+- version-source plugins
+- publisher plugins
+- environment collectors
+- full environment inheritance
+- custom environment types
+- a new plugin API for `fyn`
+
+These are expensive to maintain and do not solve the most common user pain first.
+
+## User-Facing Examples
+
+### Example: small library
+
+```toml
+[project]
+name = "acme-lib"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.fyn.tasks]
+test = "pytest -q"
+check = { chain = ["test"] }
+
+[tool.fyn.workflows.lint]
+python = "3.12"
+dependencies = ["ruff>=0.7"]
+
+[tool.fyn.workflows.lint.scripts]
+check = "ruff check ."
+format = "ruff format ."
+```
+
+```console
+$ fyn run check
+$ fyn run lint:check
+$ fyn run lint:format
+```
+
+### Example: docs workflow
+
+```toml
+[tool.fyn.workflows.docs]
+python = "3.12"
+dependencies = ["mkdocs-material", "mkdocs-redirects"]
+
+[tool.fyn.workflows.docs.scripts]
+serve = "mkdocs serve"
+build = "mkdocs build --strict"
+```
+
+```console
+$ fyn run docs:serve
+$ fyn run docs:build
+```
+
+## Implementation Plan
+
+### Phase 1: Task runner parity
+
+Scope:
+
+- implement `chain`
+- implement `env`
+- add task-runner tests
+- align docs with actual behavior
+
+Success criteria:
+
+- all documented task examples work
+- `chain` no longer errors
+- `env` affects the launched child process
+
+### Phase 2: Better init presets
+
+Scope:
+
+- add `--cli`
+- add `--tests`
+- scaffold matching tasks where appropriate
+
+Success criteria:
+
+- a new project can be initialized with a useful local workflow in one command
+
+### Phase 3: Minimal named workflows
+
+Scope:
+
+- add config parsing for `tool.fyn.workflows`
+- add `fyn run <workflow>:<script>`
+- add `fyn run --workflow <workflow> -- <command>...`
+- cache and invalidate workflow environments correctly
+
+Success criteria:
+
+- docs/lint/typecheck workflows can run in isolated named workflows without external tooling
+
+### Phase 4: Reassess matrices
+
+Only begin this phase if:
+
+- workflows are being used
+- users are asking for multi-Python or multi-axis workflows
+- the implementation pressure is coming from real use cases, not tool envy
+
+## Risks
+
+- scope creep toward a full Hatch clone
+- confusing overlap between tasks and workflow scripts
+- surprising storage/update behavior for workflow environments
+- over-scaffolding `init` with too many opinionated choices
+
+## Mitigations
+
+- keep v1 of workflows detached and simple
+- keep `run` as the central UX instead of multiplying top-level commands
+- add only a few scaffold presets with strong defaults
+- explicitly reject plugin work in this track
+
+## Open Questions
+
+1. Should `fyn init --tests` add a `test` dependency group, `dev` group, or plain dependencies?
+2. Should workflow environments be stored in the cache, under project-local metadata, or behind an internal
+   abstraction with no user-visible promise yet?
+3. Should `--list-tasks` eventually gain awareness of `<workflow>:<script>` targets, or remain
+   task-only?
+
+## Recommendation
+
+Adopt this RFC in order, with one hard rule:
+
+do not start workflows or matrices until task-runner parity is complete.
+
+That sequencing gives users immediate value, removes a current mismatch in the product surface, and
+keeps `fyn` focused on useful workflow UX rather than architectural imitation.

--- a/docs/rfcs/index.md
+++ b/docs/rfcs/index.md
@@ -2,7 +2,7 @@
 
 Design proposals and product/engineering notes for prospective `fyn` changes.
 
-These documents are not guaranteed to describe shipped behavior. They are planning documents used
-to scope and review future work.
+These documents are not guaranteed to describe shipped behavior. They are planning documents used to
+scope and review future work.
 
 - [RFC 0001: Selective Hatch-Inspired UX for `fyn`](./0001-selective-hatch-ux.md)

--- a/docs/rfcs/index.md
+++ b/docs/rfcs/index.md
@@ -1,0 +1,8 @@
+# RFCs
+
+Design proposals and product/engineering notes for prospective `fyn` changes.
+
+These documents are not guaranteed to describe shipped behavior. They are planning documents used
+to scope and review future work.
+
+- [RFC 0001: Selective Hatch-Inspired UX for `fyn`](./0001-selective-hatch-ux.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,8 +38,8 @@ theme:
 repo_url: https://github.com/oha/fyn
 repo_name: fyn
 site_author: fyn contributors
-site_url: https://github.com/oha/fyn
-site_dir: site/fyn
+site_url: https://oha.github.io/fyn/
+site_dir: site
 site_description: fyn is an extremely fast Python package and project manager, written in Rust.
 markdown_extensions:
   - admonition
@@ -61,6 +61,7 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.tabbed:
       alternate_style: true
+exclude_docs: README.md
 plugins:
   - search
   - git-revision-date-localized:
@@ -266,6 +267,9 @@ nav:
           - Python support: reference/policies/python.md
           - Rust support: reference/policies/rust.md
           - License: reference/policies/license.md
+  - RFCs:
+      - rfcs/index.md
+      - RFC 0001: rfcs/0001-selective-hatch-ux.md
 validation:
   omitted_files: warn
   absolute_links: warn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ readme = "README.md"
 
 [project.urls]
 Repository = "https://github.com/oha/fyn"
+Documentation = "https://github.com/oha/fyn/blob/main/docs/README.md"
 Changelog = "https://github.com/oha/fyn/blob/main/CHANGELOG.md"
 Releases = "https://github.com/oha/fyn/releases"
 


### PR DESCRIPTION
## Summary
- add real `[tool.fyn.tasks]` chaining support with task env inheritance, cycle detection, and integration coverage
- document project tasks clearly in the README and project docs, and add RFC 0001 for the narrowed Hatch-inspired UX roadmap
- make docs easier to find and publish by adding a GitHub-friendly `docs/README.md`, fixing docs metadata/entry points, and replacing the stale Astral-specific docs publish workflow

## Verification
- cargo dev generate-options-reference
- cargo dev generate-cli-reference
- cargo dev generate-env-vars-reference
- cargo run --bin fyn -- run --isolated --only-group docs mkdocs build --strict -f mkdocs.yml
- cargo test -p fyn --test it run_task_
- cargo test -p fyn --test it run_list_tasks
- cargo fmt --all --check
