### PR TITLE
feat: add python install-shim

### DIFF
--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -7434,6 +7434,14 @@ pub enum PythonCommand {
     /// Uninstall Python versions.
     Uninstall(PythonUninstallArgs),
 
+    /// Install a `python` shim into the Python executable directory.
+    ///
+    /// The shim resolves the appropriate interpreter for the current directory before executing
+    /// it, which makes a plain `python` command available on your shell `PATH` without pinning it
+    /// to a single managed installation.
+    #[command(name = "install-shim")]
+    InstallShim(PythonInstallShimArgs),
+
     /// Ensure that the Python executable directory is on the `PATH`.
     ///
     /// If the Python executable directory is not present on the `PATH`, fyn will attempt to add it to
@@ -7446,6 +7454,9 @@ pub enum PythonCommand {
     /// retrieved with `fyn python dir --bin`.
     #[command(alias = "ensurepath")]
     UpdateShell,
+
+    #[command(hide = true)]
+    Shim(PythonShimArgs),
 }
 
 #[derive(Args)]
@@ -7515,6 +7526,23 @@ pub struct PythonDirArgs {
     /// - `$HOME/.local/bin`
     #[arg(long, verbatim_doc_comment)]
     pub bin: bool,
+}
+
+#[derive(Args)]
+pub struct PythonInstallShimArgs {
+    /// Replace an existing shim target.
+    ///
+    /// By default, fyn refuses to replace an existing `python` executable unless it already
+    /// matches the expected shim contents.
+    #[arg(long, short)]
+    pub force: bool,
+}
+
+#[derive(Args)]
+pub struct PythonShimArgs {
+    /// Additional arguments to pass through to Python.
+    #[arg(last = true, allow_hyphen_values = true, value_hint = ValueHint::Other)]
+    pub args: Vec<OsString>,
 }
 
 #[derive(Args)]

--- a/crates/fyn-python/src/discovery.rs
+++ b/crates/fyn-python/src/discovery.rs
@@ -602,7 +602,10 @@ fn python_executables_from_search_path<'a>(
     // Split and iterate over the paths instead of using `which_all` so we can
     // check multiple names per directory while respecting the search path order and python names
     // precedence.
-    let search_dirs: Vec<_> = env::split_paths(&search_path).collect();
+    let shim_dir = env::var_os(EnvVars::UV_INTERNAL__PYTHON_SHIM_DIR).map(PathBuf::from);
+    let search_dirs: Vec<_> = env::split_paths(&search_path)
+        .filter(|dir| shim_dir.as_ref().is_none_or(|shim_dir| dir != shim_dir))
+        .collect();
     let mut seen_dirs = FxHashSet::with_capacity_and_hasher(search_dirs.len(), FxBuildHasher);
     search_dirs
         .into_iter()

--- a/crates/fyn-static/src/env_vars.rs
+++ b/crates/fyn-static/src/env_vars.rs
@@ -626,6 +626,11 @@ impl EnvVars {
     #[attr_added_in("0.9.29")]
     pub const UV_INTERNAL__PYTHONHOME: &'static str = "UV_INTERNAL__PYTHONHOME";
 
+    /// Internal marker used by the `python` shim to exclude its own directory from discovery.
+    #[attr_hidden]
+    #[attr_added_in("0.10.14")]
+    pub const UV_INTERNAL__PYTHON_SHIM_DIR: &'static str = "UV_INTERNAL__PYTHON_SHIM_DIR";
+
     /// Path to system-level configuration directory on Unix systems.
     #[attr_added_in("0.4.26")]
     pub const XDG_CONFIG_DIRS: &'static str = "XDG_CONFIG_DIRS";

--- a/crates/fyn/src/commands/mod.rs
+++ b/crates/fyn/src/commands/mod.rs
@@ -60,6 +60,8 @@ pub(crate) use python::install::install as python_install;
 pub(crate) use python::install::{PythonUpgrade, PythonUpgradeSource};
 pub(crate) use python::list::list as python_list;
 pub(crate) use python::pin::pin as python_pin;
+pub(crate) use python::shim::install_shim as python_install_shim;
+pub(crate) use python::shim::shim as python_shim;
 pub(crate) use python::uninstall::uninstall as python_uninstall;
 pub(crate) use python::update_shell::update_shell as python_update_shell;
 #[cfg(feature = "self-update")]

--- a/crates/fyn/src/commands/python/mod.rs
+++ b/crates/fyn/src/commands/python/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod find;
 pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod pin;
+pub(crate) mod shim;
 pub(crate) mod uninstall;
 pub(crate) mod update_shell;
 

--- a/crates/fyn/src/commands/python/shim.rs
+++ b/crates/fyn/src/commands/python/shim.rs
@@ -1,0 +1,295 @@
+use std::ffi::OsString;
+use std::fmt::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow, bail};
+use fyn_cache::Cache;
+use fyn_client::BaseClientBuilder;
+use fyn_configuration::DependencyGroupsWithDefaults;
+use fyn_fs::{Simplified, write_atomic_sync};
+use fyn_preview::Preview;
+use fyn_python::managed::python_executable_dir;
+use fyn_python::{EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference};
+use fyn_settings::PythonInstallMirrors;
+use fyn_shell::Shell;
+use fyn_static::EnvVars;
+use fyn_warnings::warn_user;
+use fyn_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceError};
+use owo_colors::OwoColorize;
+
+use crate::commands::ExitStatus;
+use crate::commands::project::{WorkspacePython, validate_project_requires_python};
+use crate::commands::reporters::PythonDownloadReporter;
+use crate::printer::Printer;
+
+/// Install a `python` shim into the executable directory.
+pub(crate) fn install_shim(force: bool, printer: Printer) -> Result<ExitStatus> {
+    let current_exe =
+        std::env::current_exe().context("Failed to determine the path to the fyn executable")?;
+    let shim_path = shim_path()?;
+    let shim_contents = shim_contents(&current_exe, parent_directory(&shim_path)?);
+
+    if let Some(parent) = shim_path.parent() {
+        fs_err::create_dir_all(parent)?;
+    }
+
+    match fs_err::read(&shim_path) {
+        Ok(existing) if existing == shim_contents.as_bytes() => {
+            writeln!(
+                printer.stderr(),
+                "Python shim is already installed at {}",
+                shim_path.simplified_display().cyan()
+            )?;
+            warn_if_not_on_path(parent_directory(&shim_path)?);
+            return Ok(ExitStatus::Success);
+        }
+        Ok(_) => {
+            if !force {
+                bail!(
+                    "Executable already exists at `{}` and is not the current fyn Python shim; use `--force` to replace it",
+                    shim_path.simplified_display()
+                );
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err.into()),
+    }
+
+    write_atomic_sync(&shim_path, shim_contents.as_bytes())?;
+    #[cfg(unix)]
+    ensure_executable(&shim_path)?;
+    #[cfg(not(unix))]
+    ensure_executable(&shim_path);
+
+    writeln!(
+        printer.stderr(),
+        "Installed Python shim at {}",
+        shim_path.simplified_display().cyan()
+    )?;
+    warn_if_not_on_path(parent_directory(&shim_path)?);
+
+    Ok(ExitStatus::Success)
+}
+
+/// Execute the hidden shim entrypoint.
+#[expect(clippy::too_many_arguments)]
+pub(crate) async fn shim(
+    project_dir: &Path,
+    args: Vec<OsString>,
+    no_config: bool,
+    install_mirrors: &PythonInstallMirrors,
+    client_builder: &BaseClientBuilder<'_>,
+    python_preference: PythonPreference,
+    python_downloads: PythonDownloads,
+    cache: &Cache,
+    workspace_cache: &WorkspaceCache,
+    printer: Printer,
+    preview: Preview,
+) -> Result<ExitStatus> {
+    let project =
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
+            .await
+        {
+            Ok(project) => Some(project),
+            Err(
+                WorkspaceError::MissingProject(_)
+                | WorkspaceError::MissingPyprojectToml
+                | WorkspaceError::NonWorkspace(_),
+            ) => None,
+            Err(err) => {
+                warn_user!("{err}");
+                None
+            }
+        };
+
+    let groups = DependencyGroupsWithDefaults::none();
+    let WorkspacePython {
+        source,
+        python_request,
+        requires_python,
+    } = WorkspacePython::from_request(
+        None,
+        project.as_ref().map(VirtualProject::workspace),
+        &groups,
+        project_dir,
+        no_config,
+    )
+    .await?;
+
+    let reporter = PythonDownloadReporter::single(printer);
+
+    let interpreter = PythonInstallation::find_or_download(
+        python_request.as_ref(),
+        EnvironmentPreference::Any,
+        python_preference,
+        python_downloads,
+        client_builder,
+        cache,
+        Some(&reporter),
+        install_mirrors.python_install_mirror.as_deref(),
+        install_mirrors.pypy_install_mirror.as_deref(),
+        install_mirrors.python_downloads_json_url.as_deref(),
+        preview,
+    )
+    .await?
+    .into_interpreter();
+
+    if let Some(requires_python) = requires_python {
+        if let Err(err) = validate_project_requires_python(
+            &interpreter,
+            project.as_ref().map(VirtualProject::workspace),
+            &groups,
+            &requires_python,
+            &source,
+        ) {
+            warn_user!("{err}");
+        }
+    }
+
+    exec_python(interpreter.sys_executable(), &args)
+}
+
+fn shim_path() -> Result<PathBuf> {
+    let executable_dir = python_executable_dir()?;
+    Ok(executable_dir.join(shim_filename()))
+}
+
+#[cfg(unix)]
+fn shim_filename() -> &'static str {
+    "python"
+}
+
+#[cfg(windows)]
+fn shim_filename() -> &'static str {
+    "python.cmd"
+}
+
+#[cfg(not(any(unix, windows)))]
+fn shim_filename() -> &'static str {
+    "python"
+}
+
+fn shim_contents(current_exe: &Path, shim_dir: &Path) -> String {
+    #[cfg(unix)]
+    {
+        format!(
+            "#!/bin/sh\nexport {}={}\nexec {} python shim -- \"$@\"\n",
+            EnvVars::UV_INTERNAL__PYTHON_SHIM_DIR,
+            shell_quote(shim_dir),
+            shell_quote(current_exe),
+        )
+    }
+
+    #[cfg(windows)]
+    {
+        format!(
+            "@echo off\r\nset \"{}={}\"\r\n\"{}\" python shim -- %*\r\n",
+            EnvVars::UV_INTERNAL__PYTHON_SHIM_DIR,
+            batch_quote(shim_dir),
+            batch_quote(current_exe),
+        )
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = current_exe;
+        let _ = shim_dir;
+        String::new()
+    }
+}
+
+#[cfg(unix)]
+fn ensure_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs_err::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs_err::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_executable(_path: &Path) {}
+
+#[cfg(unix)]
+fn shell_quote(path: &Path) -> String {
+    let path = path.as_os_str().to_string_lossy();
+    format!("'{}'", path.replace('\'', r#"'"'"'"#))
+}
+
+#[cfg(windows)]
+fn batch_quote(path: &Path) -> String {
+    path.as_os_str()
+        .to_string_lossy()
+        .replace('%', "%%")
+        .replace('"', "\"\"")
+}
+
+fn parent_directory(path: &Path) -> Result<&Path> {
+    path.parent().ok_or_else(|| {
+        anyhow!(
+            "Failed to determine parent directory for `{}`",
+            path.user_display()
+        )
+    })
+}
+
+fn warn_if_not_on_path(bin: &Path) {
+    if !Shell::contains_path(bin) {
+        if let Some(shell) = Shell::from_env() {
+            if let Some(command) = shell.prepend_path(bin) {
+                if shell.supports_update() {
+                    warn_user!(
+                        "`{}` is not on your PATH. To use the Python shim, run `{}` or `{}`.",
+                        bin.simplified_display().cyan(),
+                        command.green(),
+                        "fyn python update-shell".green()
+                    );
+                } else {
+                    warn_user!(
+                        "`{}` is not on your PATH. To use the Python shim, run `{}`.",
+                        bin.simplified_display().cyan(),
+                        command.green()
+                    );
+                }
+            } else {
+                warn_user!(
+                    "`{}` is not on your PATH. To use the Python shim, add the directory to your PATH.",
+                    bin.simplified_display().cyan(),
+                );
+            }
+        } else {
+            warn_user!(
+                "`{}` is not on your PATH. To use the Python shim, add the directory to your PATH.",
+                bin.simplified_display().cyan(),
+            );
+        }
+    }
+}
+
+fn exec_python(python: &Path, args: &[OsString]) -> Result<ExitStatus> {
+    let mut command = Command::new(python);
+    command.args(args);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+
+        let err = command.exec();
+        Err(err.into())
+    }
+
+    #[cfg(windows)]
+    {
+        match fyn_windows::spawn_child(&mut command, false)? {}
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = command;
+        Err(anyhow!(
+            "The Python shim is only supported on Unix and Windows"
+        ))
+    }
+}

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -2185,6 +2185,12 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             commands::python_uninstall(args.install_dir, args.targets, args.all, printer).await
         }
         Commands::Python(PythonNamespace {
+            command: PythonCommand::InstallShim(args),
+        }) => {
+            commands::python_install_shim(args.force, printer)?;
+            Ok(ExitStatus::Success)
+        }
+        Commands::Python(PythonNamespace {
             command: PythonCommand::Find(args),
         }) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
@@ -2271,6 +2277,30 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         }) => {
             commands::python_update_shell(printer).await?;
             Ok(ExitStatus::Success)
+        }
+        Commands::Python(PythonNamespace {
+            command: PythonCommand::Shim(args),
+        }) => {
+            let shim_settings = settings::PythonShimSettings::resolve(filesystem, environment);
+            show_settings!(shim_settings);
+
+            // Initialize the cache.
+            let cache = cache.init().await?;
+
+            commands::python_shim(
+                &project_dir,
+                args.args,
+                cli.top_level.no_config,
+                &shim_settings.install_mirrors,
+                &client_builder.subcommand(vec!["python".to_owned(), "shim".to_owned()]),
+                globals.python_preference,
+                globals.python_downloads,
+                &cache,
+                &workspace_cache,
+                printer,
+                globals.preview,
+            )
+            .await
         }
         Commands::Publish(args) => {
             show_settings!(args);

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -1534,6 +1534,30 @@ impl PythonFindSettings {
     }
 }
 
+/// The resolved settings to use for a `python shim` invocation.
+#[derive(Debug, Clone)]
+pub(crate) struct PythonShimSettings {
+    pub(crate) install_mirrors: PythonInstallMirrors,
+}
+
+impl PythonShimSettings {
+    /// Resolve the [`PythonShimSettings`] from the environment and workspace configuration.
+    pub(crate) fn resolve(
+        filesystem: Option<FilesystemOptions>,
+        environment: EnvironmentOptions,
+    ) -> Self {
+        let filesystem_install_mirrors = filesystem
+            .map(|fs| fs.install_mirrors.clone())
+            .unwrap_or_default();
+
+        Self {
+            install_mirrors: environment
+                .install_mirrors
+                .combine(filesystem_install_mirrors),
+        }
+    }
+}
+
 /// The resolved settings to use for a `python pin` invocation.
 #[derive(Debug, Clone)]
 pub(crate) struct PythonPinSettings {

--- a/crates/fyn/tests/it/help.rs
+++ b/crates/fyn/tests/it/help.rs
@@ -317,6 +317,7 @@ fn help_subcommand() {
       pin           Pin to a specific Python version
       dir           Show the fyn Python installation directory
       uninstall     Uninstall Python versions
+      install-shim  Install a `python` shim into the Python executable directory
       update-shell  Ensure that the Python executable directory is on the `PATH`
 
     Cache options:
@@ -775,6 +776,7 @@ fn help_flag_subcommand() {
       pin           Pin to a specific Python version
       dir           Show the fyn Python installation directory
       uninstall     Uninstall Python versions
+      install-shim  Install a `python` shim into the Python executable directory
       update-shell  Ensure that the Python executable directory is on the `PATH`
 
     Cache options:

--- a/crates/fyn/tests/it/python_install.rs
+++ b/crates/fyn/tests/it/python_install.rs
@@ -2199,6 +2199,140 @@ fn read_link(path: &Path) -> String {
 }
 
 #[test]
+fn python_install_shim_executes_managed_python() {
+    let context = fyn_test::test_context_with_versions!(&[])
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    context.python_install().arg("3.12.8").assert().success();
+
+    context
+        .command()
+        .arg("python")
+        .arg("install-shim")
+        .assert()
+        .success();
+
+    let shim = context.bin_dir.child(python_shim_name());
+    shim.assert(predicate::path::exists());
+
+    fyn_snapshot!(context.filters(), python_shim_command(&context)
+        .arg("-c")
+        .arg("import sys; print(sys.version.split()[0])"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12.8
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn python_install_shim_respects_dot_python_version() {
+    let context = fyn_test::test_context_with_versions!(&[])
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    context
+        .python_install()
+        .arg("3.12.8")
+        .arg("3.11")
+        .assert()
+        .success();
+
+    context
+        .temp_dir
+        .child(".python-version")
+        .write_str("3.11\n")
+        .unwrap();
+
+    context
+        .command()
+        .arg("python")
+        .arg("install-shim")
+        .assert()
+        .success();
+
+    fyn_snapshot!(context.filters(), python_shim_command(&context)
+        .arg("-c")
+        .arg("import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.11
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn python_install_shim_force_required() -> anyhow::Result<()> {
+    let context = fyn_test::test_context_with_versions!(&[])
+        .with_managed_python_dirs()
+        .with_empty_python_install_mirror()
+        .with_python_download_cache();
+
+    context.python_install().arg("3.12.8").assert().success();
+
+    context
+        .bin_dir
+        .child(python_shim_name())
+        .write_str("not a shim")?;
+
+    context
+        .command()
+        .arg("python")
+        .arg("install-shim")
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("use `--force` to replace it"));
+
+    context
+        .command()
+        .arg("python")
+        .arg("install-shim")
+        .arg("--force")
+        .assert()
+        .success();
+
+    fyn_snapshot!(context.filters(), python_shim_command(&context)
+        .arg("-c")
+        .arg("import sys; print(sys.version.split()[0])"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12.8
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+fn python_shim_command(context: &fyn_test::TestContext) -> Command {
+    let shim = context.bin_dir.child(python_shim_name());
+    let mut command = Command::new(shim.as_os_str());
+    context.add_shared_env(&mut command, false);
+    command.env(EnvVars::UV_CACHE_DIR, context.cache_dir.as_os_str());
+    command.current_dir(context.temp_dir.path());
+    command
+}
+
+#[cfg(unix)]
+fn python_shim_name() -> &'static str {
+    "python"
+}
+
+#[cfg(windows)]
+fn python_shim_name() -> &'static str {
+    "python.cmd"
+}
+
+#[test]
 fn python_install_unknown() {
     let context = fyn_test::test_context_with_versions!(&[])
         .with_managed_python_dirs()

--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -111,9 +111,8 @@ $ fyn venv
 
     Automatic Python downloads can be [easily disabled](../concepts/python-versions.md#disabling-automatic-python-downloads) if you want more control over when Python is downloaded.
 
-<!-- TODO(zanieb): Restore when Python shim management is added
-Note that when an automatic Python installation occurs, the `python` command will not be added to the shell. Use `fyn python install-shim` to ensure the `python` shim is installed.
--->
+Note that when an automatic Python installation occurs, the `python` command will not be added to
+the shell. Use `fyn python install-shim` to ensure the `python` shim is installed.
 
 ## Using existing Python versions
 

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -31,7 +31,8 @@ $ fyn run example.py
 Hello world
 ```
 
-<!-- TODO(zanieb): Once we have a `python` shim, note you can execute it with `python` here -->
+If you want a plain `python` command that follows fyn's interpreter resolution rules, install the
+shim with `fyn python install-shim`.
 
 Similarly, if your script depends on a module in the standard library, there's nothing more to do:
 


### PR DESCRIPTION
## Summary

This adds `fyn python install-shim`. The new command installs a `python` shim into the Python executable directory so a plain `python` invocation can follow fyn's normal interpreter resolution rules instead of being pinned to one static managed install.

## What Changed

  - added `fyn python install-shim`
  - added hidden shim execution plumbing for `python shim -- ...`
  - made the shim resolve interpreters using the existing project / workspace / `.python-version` flow
  - prevented the shim from rediscovering itself during interpreter lookup
  - required `--force` before replacing a non-matching existing shim target
  - updated Python help text and user docs for the new workflow
  - regenerated / verified the CLI reference

## Tests

  - `cargo fmt --all`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test -p fyn --test it python_install::python_install_shim`
  - `cargo test -p fyn --test it help::help_subcommand -- --exact`
  - `cargo test -p fyn --test it help::help_flag_subcommand -- --exact`
  - `cargo dev generate-cli-reference --mode check`
  - `npx prettier --check docs/guides/install-python.md docs/guides/scripts.md docs/reference/cli.md`