### PR TITLE
chore: sync small upstream TLS and tooling fixes

### DIFF
--- a/crates/fyn-client/src/tls.rs
+++ b/crates/fyn-client/src/tls.rs
@@ -326,13 +326,14 @@ impl Certificates {
         }
 
         if certs.0.is_empty() {
-            warn_user_once!(
+            // Unlike `SSL_CERT_FILE`, it's plausible for this to be intentionally set to an
+            // empty directory that a user could put certificates in later.
+            warn!(
                 "Ignoring `SSL_CERT_DIR`. No valid certificates found in: {}.",
                 existing
                     .iter()
                     .map(Simplified::simplified_display)
                     .join(", ")
-                    .cyan()
             );
             return None;
         }

--- a/crates/fyn-python/fetch-download-metadata.py
+++ b/crates/fyn-python/fetch-download-metadata.py
@@ -525,6 +525,10 @@ class PyodideFinder(Finder):
 
         results = {}
         for release in releases:
+            # Skip prereleases so syncs don't track ahead of stable Pyodide builds.
+            if release.get("prerelease"):
+                continue
+
             pyodide_version = release["tag_name"]
             meta = metadata.get(pyodide_version, None)
             if meta is None:

--- a/scripts/generate-crate-readmes.py
+++ b/scripts/generate-crate-readmes.py
@@ -48,6 +48,7 @@ See fyn's crate versioning policy for details on versioning.
 
 
 REPO_URL = "https://github.com/oha/fyn"
+PRETTIER_VERSION = "3.8.3"
 
 
 def main() -> None:
@@ -148,7 +149,8 @@ def main() -> None:
 
     # Format all generated READMEs once at the end
     subprocess.run(
-        ["npx", "prettier", "--write"] + [str(path) for path in generated_paths],
+        ["npx", "--yes", f"prettier@{PRETTIER_VERSION}", "--write"]
+        + [str(path) for path in generated_paths],
         check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
  - lower the empty `SSL_CERT_DIR` case from a user-facing once-only warning to a regular warning
  - pin `prettier@3.8.3` in `scripts/generate-crate-readmes.py` to avoid interactive `npx` prompts
  - skip Pyodide prereleases in `crates/fyn-python/fetch-download-metadata.py` during Python metadata sync

  ## Verification
  - `cargo test -p fyn-client`
  - `cargo test -p fyn-python`
  - `cargo fmt --check -p fyn-client`
  - `ruff check scripts/generate-crate-readmes.py crates/fyn-python/fetch-download-metadata.py`
  - `python3 -m py_compile scripts/generate-crate-readmes.py crates/fyn-python/fetch-download-metadata.py`