### PR TITLE
fix: strip task passthrough separator for cmd tasks

### DIFF
--- a/crates/fyn/src/commands/project/run.rs
+++ b/crates/fyn/src/commands/project/run.rs
@@ -1965,6 +1965,7 @@ fn resolve_task_plan(
     tasks: &fyn_workspace::pyproject::ToolfynTasks,
     extra_args: &[OsString],
 ) -> anyhow::Result<TaskPlan> {
+    let extra_args = strip_task_passthrough_sentinel(extra_args);
     let mut stack = Vec::new();
     let mut steps = Vec::new();
     resolve_task_steps(
@@ -1979,6 +1980,13 @@ fn resolve_task_plan(
         name: name.to_string(),
         steps,
     })
+}
+
+fn strip_task_passthrough_sentinel(extra_args: &[OsString]) -> &[OsString] {
+    match extra_args {
+        [first, rest @ ..] if first == "--" => rest,
+        _ => extra_args,
+    }
 }
 
 fn resolve_task_steps(

--- a/crates/fyn/tests/it/run.rs
+++ b/crates/fyn/tests/it/run.rs
@@ -6854,6 +6854,109 @@ fn run_task_detailed() -> Result<()> {
     Ok(())
 }
 
+/// Extra arguments passed to `cmd` tasks should not forward the task separator itself.
+#[test]
+fn run_task_cmd_strips_passthrough_separator() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        show = "python show_argv.py"
+        "#
+    })?;
+    context
+        .temp_dir
+        .child("show_argv.py")
+        .write_str(indoc! { r"
+        import json
+        import sys
+
+        print(json.dumps(sys.argv))
+        "
+        })?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context.run().arg("show").arg("--").arg("alpha").arg("beta"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [\"show_argv.py\", \"alpha\", \"beta\"]
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    "
+    );
+
+    Ok(())
+}
+
+/// Option-like arguments should be forwarded to `cmd` tasks without a leading literal `--`.
+#[test]
+fn run_task_cmd_forwards_option_like_args() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        show = "python show_argv.py"
+        "#
+    })?;
+    context
+        .temp_dir
+        .child("show_argv.py")
+        .write_str(indoc! { r"
+        import json
+        import sys
+
+        print(json.dumps(sys.argv))
+        "
+        })?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .run()
+            .arg("show")
+            .arg("--")
+            .arg("--tb=no")
+            .arg("-q"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [\"show_argv.py\", \"--tb=no\", \"-q\"]
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    "
+    );
+
+    Ok(())
+}
+
 /// Run a chained task and apply inherited and per-task environment variables.
 #[test]
 fn run_task_chain_with_env() -> Result<()> {


### PR DESCRIPTION

## Summary

Fix task argument passthrough for `[tool.fyn.tasks]` `cmd` tasks by consuming the task-level `--` separator before forwarding args to the child process.

## Problem

  fyn documents extra arguments for cmd tasks, e.g.:

  `fyn run test -- -k my_test`

But the task path was preserving the literal -- sentinel and appending it into the child argv. That broke pytest, which then interpret later options as positional paths.

## Changes

  - strip a single leading passthrough -- before building a task plan for cmd tasks
  - add regression coverage for:
      - positional passthrough args
      - option-like passthrough args such as --tb=no -q
  - keep existing chained-task behavior unchanged:
      - extra args are still rejected for chain tasks

## Scope

This fixes task-level passthrough behavior only. It does not implement {all-args} interpolation in task cmd strings. Still remains unsupported.

## Testing

  - cargo test -p fyn --test it run::run_task_cmd_strips_passthrough_separator -- --exact
  - cargo test -p fyn --test it run::run_task_cmd_forwards_option_like_args -- --exact
  - cargo test -p fyn --test it run::run_task_chain_rejects_extra_args -- --exact
  - cargo fmt --all
