### PR TITLE
fix: sync uv Python variant tagging in Windows registry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,7 +250,7 @@ jobs:
           cargo nextest run \
             --cargo-profile fast-build \
             --no-default-features \
-            --features test-python,test-pypi,test-python-managed,native-auth,windows-native \
+            --features test-python,test-pypi,test-python-managed,test-windows-registry,native-auth,windows-native \
             --workspace \
             --profile ci-windows \
             --partition hash:${{ matrix.partition }}/3

--- a/crates/fyn-python/src/windows_registry.rs
+++ b/crates/fyn-python/src/windows_registry.rs
@@ -200,7 +200,18 @@ fn write_registry_entry(
 }
 
 fn registry_python_tag(key: &PythonInstallationKey) -> String {
-    format!("{}{}", key.implementation().pretty(), key.version())
+    // Include the variant's executable suffix (e.g., "t" for freethreaded) in the
+    // registry tag so that variant (freethreaded, debug, etc.) installations of the same version
+    // get distinct registry entries. This suffix can be empty.
+    //
+    // See: https://github.com/astral-sh/uv/issues/18795
+    let variant_suffix = key.variant().executable_suffix();
+    format!(
+        "{}{}{}",
+        key.implementation().pretty(),
+        key.version(),
+        variant_suffix,
+    )
 }
 
 /// Remove requested Python entries from the Windows Registry (PEP 514).

--- a/crates/fyn/Cargo.toml
+++ b/crates/fyn/Cargo.toml
@@ -209,6 +209,10 @@ test-python-managed = []
 test-slow = []
 # Includes test cases that require ecosystem packages
 test-ecosystem = []
+# Includes test cases that write to the Windows registry. These tests mutate
+# global state (the Windows registry).
+# We don't run these tests by default locally; the CI for Windows enables them.
+test-windows-registry = []
 # Build fynw binary on Windows
 windows-gui-bin = []
 

--- a/crates/fyn/tests/it/python_install.rs
+++ b/crates/fyn/tests/it/python_install.rs
@@ -1226,6 +1226,92 @@ fn python_install_freethreaded() {
     ");
 }
 
+/// Test that installing both GIL and free-threaded variants of the same Python version
+/// doesn't cause managed installation entries to disappear from `fyn python list`
+/// on Windows when registry discovery is enabled.
+///
+/// Regression test for <https://github.com/astral-sh/uv/issues/18795>.
+///
+/// IMPORTANT: this test writes to the shared `HKCU` registry. The trailing uninstall is
+/// best-effort cleanup; panics will leak entries. This is fine for now since this is the only
+/// test exercising the registry pathway, but adding more will probably require isolation.
+#[cfg(all(windows, feature = "test-windows-registry"))]
+#[test]
+fn python_install_freethreaded_and_gil_list() {
+    let context = fyn_test::test_context_with_versions!(&[])
+        .with_filtered_python_keys()
+        .with_filtered_latest_python_versions()
+        .with_managed_python_dirs()
+        .with_python_download_cache()
+        .with_filtered_python_install_bin()
+        .with_filtered_python_names()
+        .with_filtered_exe_suffix()
+        .with_collapsed_whitespace();
+
+    // Install both the GIL and free-threaded versions, with registry enabled
+    context
+        .python_install()
+        .arg("3.13")
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1")
+        .assert()
+        .success();
+    context
+        .python_install()
+        .arg("--preview")
+        .arg("3.13t")
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1")
+        .assert()
+        .success();
+
+    // List installed versions with registry discovery enabled.
+    // We remove UV_TEST_PYTHON_PATH to enable registry discovery (it's skipped when set),
+    // and use `--managed-python --only-installed` to exclude unrelated system Pythons.
+    //
+    // Both the GIL and freethreaded variants should show entries from:
+    // - The registry (patch-versioned managed directory path)
+    // - The search path (bin trampoline)
+    // - Managed discovery (minor-version junction path)
+    fyn_snapshot!(context.filters(), context.python_list()
+        .arg("3.13")
+        .arg("--only-installed")
+        .arg("--managed-python")
+        .env_remove(EnvVars::UV_TEST_PYTHON_PATH)
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.13.[LATEST]-[PLATFORM] managed/cpython-3.13.[LATEST]-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+    cpython-3.13.[LATEST]-[PLATFORM] [BIN]/[INSTALL-BIN]/[PYTHON]
+    cpython-3.13.[LATEST]-[PLATFORM] managed/cpython-3.13-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+
+    ----- stderr -----
+    ");
+
+    fyn_snapshot!(context.filters(), context.python_list()
+        .arg("3.13t")
+        .arg("--only-installed")
+        .arg("--managed-python")
+        .env_remove(EnvVars::UV_TEST_PYTHON_PATH)
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    cpython-3.13.[LATEST]+freethreaded-[PLATFORM] managed/cpython-3.13.[LATEST]+freethreaded-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+    cpython-3.13.[LATEST]+freethreaded-[PLATFORM] [BIN]/python3.13t
+    cpython-3.13.[LATEST]+freethreaded-[PLATFORM] managed/cpython-3.13+freethreaded-[PLATFORM]/[INSTALL-BIN]/[PYTHON]
+
+    ----- stderr -----
+    ");
+
+    // Clean up registry entries
+    context
+        .python_uninstall()
+        .arg("--all")
+        .env(EnvVars::UV_PYTHON_INSTALL_REGISTRY, "1")
+        .assert()
+        .success();
+}
+
 #[test]
 fn python_upgrade_not_allowed() {
     let context = fyn_test::test_context_with_versions!(&[])


### PR DESCRIPTION
 ## Summary

Sync upstream uv commit `69e1f5f1b` / PR `#19012`.

This fixes Windows PEP 514 registry tagging for Python variants. Without that, installs like `3.13` and `3.13t` can collide and one entry can disappear from `fyn python list`.

This PR also ports the upstream regression coverage:
  - adds a Windows-only integration test for installing both GIL and free-threaded variants
  - gates that test behind `test-windows-registry`
  - enables that feature in the Windows CI test job

## Test

  - `cargo fmt --all`

