### PR TITLE
feat: add package-based index routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "fyn-redacted",
  "fyn-small-str",
  "fyn-warnings",
+ "glob",
  "http",
  "itertools 0.14.0",
  "jiff",

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -77,13 +77,11 @@ you ask for.
 In no particular order:
 
 1. **Centralized venv storage** — keep .venvs out of your project dirs
-2. **Glob-pattern source declarations** — `mycompany-*` all goes to your private index, borrowed
-   from how PDM does it
-3. **`pip.conf` support** — read your existing pip config
-4. **`pip wheel`**
-5. **Plugin system** eventually — custom indexes, auth providers, etc.
-6. **`fyn bundle`** — make standalone executables, like PyInstaller but built-in
-7. **Conda support** maybe — if we can do it without making a mess
+2. **`pip.conf` support** — read your existing pip config
+3. **`pip wheel`**
+4. **Plugin system** eventually — custom indexes, auth providers, etc.
+5. **`fyn bundle`** — make standalone executables, like PyInstaller but built-in
+6. **Conda support** maybe — if we can do it without making a mess
 
 ## Installation
 

--- a/crates/fyn-client/src/registry_client.rs
+++ b/crates/fyn-client/src/registry_client.rs
@@ -310,7 +310,14 @@ impl RegistryClient {
                     .map(|indexes| indexes.map(IndexMetadataRef::from))
             })
             .map(Either::Left)
-            .unwrap_or_else(|| Either::Right(self.index_urls.indexes().map(IndexMetadataRef::from)))
+            .unwrap_or_else(|| {
+                Either::Right(
+                    self.index_urls
+                        .indexes_for_package(package_name)
+                        .into_iter()
+                        .map(IndexMetadataRef::from),
+                )
+            })
     }
 
     /// Return the appropriate [`IndexStrategy`] for the given [`PackageName`].

--- a/crates/fyn-distribution-types/Cargo.toml
+++ b/crates/fyn-distribution-types/Cargo.toml
@@ -36,6 +36,7 @@ arcstr = { workspace = true }
 bitflags = { workspace = true }
 fs-err = { workspace = true }
 http = { workspace = true }
+glob = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }
 owo-colors = { workspace = true }

--- a/crates/fyn-distribution-types/src/index.rs
+++ b/crates/fyn-distribution-types/src/index.rs
@@ -1,11 +1,13 @@
 use std::path::Path;
 use std::str::FromStr;
 
+use glob::Pattern;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
 use fyn_auth::{AuthPolicy, Credentials};
+use fyn_normalize::PackageName;
 use fyn_redacted::DisplaySafeUrl;
 use fyn_small_str::SmallString;
 
@@ -23,6 +25,79 @@ pub struct IndexCacheControl {
     pub api: Option<SmallString>,
     /// Cache control header for file downloads.
     pub files: Option<SmallString>,
+}
+
+/// A glob pattern matched against normalized package names.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PackageNamePattern(Pattern);
+
+impl PackageNamePattern {
+    pub fn matches(&self, package_name: &PackageName) -> bool {
+        self.0.matches(package_name.as_str())
+    }
+}
+
+impl std::fmt::Debug for PackageNamePattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.as_str().fmt(f)
+    }
+}
+
+impl Serialize for PackageNamePattern {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.as_str().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for PackageNamePattern {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl serde::de::Visitor<'_> for Visitor {
+            type Value = PackageNamePattern;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a glob pattern string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Pattern::new(&v.to_ascii_lowercase())
+                    .map(PackageNamePattern)
+                    .map_err(serde::de::Error::custom)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Pattern::new(&v.to_ascii_lowercase())
+                    .map(PackageNamePattern)
+                    .map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_string(Visitor)
+    }
+}
+
+#[cfg(feature = "schemars")]
+impl schemars::JsonSchema for PackageNamePattern {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("PackageNamePattern")
+    }
+
+    fn json_schema(generator: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
+        <String as schemars::JsonSchema>::json_schema(generator)
+    }
 }
 
 impl IndexCacheControl {
@@ -90,6 +165,20 @@ pub struct Index {
     /// ```
     #[serde(default)]
     pub explicit: bool,
+    /// Route matching packages exclusively to this index.
+    ///
+    /// Accepts glob patterns matched against normalized package names. If any pattern matches a
+    /// package, only indexes whose `include-packages` also match will be searched for that package,
+    /// unless it has an explicit `[tool.fyn.sources]` index pin.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include_packages: Vec<PackageNamePattern>,
+    /// Exclude matching packages from this index.
+    ///
+    /// Accepts glob patterns matched against normalized package names. If no `include-packages`
+    /// patterns match a package, and an `exclude-packages` pattern matches, this index will be
+    /// skipped for that package unless it has an explicit `[tool.fyn.sources]` index pin.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_packages: Vec<PackageNamePattern>,
     /// Mark the index as the default index.
     ///
     /// By default, fyn uses PyPI as the default index, such that even if additional indexes are
@@ -190,6 +279,8 @@ impl std::fmt::Debug for Index {
             .field("name", &self.name)
             .field("url", &self.url)
             .field("explicit", &self.explicit)
+            .field("include_packages", &self.include_packages)
+            .field("exclude_packages", &self.exclude_packages)
             .field("default", &self.default)
             .field("origin", &self.origin)
             .field("format", &self.format)
@@ -210,6 +301,8 @@ impl PartialEq for Index {
             name,
             url,
             explicit,
+            include_packages,
+            exclude_packages,
             default,
             origin: _,
             format,
@@ -222,6 +315,8 @@ impl PartialEq for Index {
         *url == other.url
             && *name == other.name
             && *explicit == other.explicit
+            && *include_packages == other.include_packages
+            && *exclude_packages == other.exclude_packages
             && *default == other.default
             && *format == other.format
             && *publish_url == other.publish_url
@@ -246,6 +341,8 @@ impl Ord for Index {
             name,
             url,
             explicit,
+            include_packages,
+            exclude_packages,
             default,
             origin: _,
             format,
@@ -258,6 +355,8 @@ impl Ord for Index {
         url.cmp(&other.url)
             .then_with(|| name.cmp(&other.name))
             .then_with(|| explicit.cmp(&other.explicit))
+            .then_with(|| include_packages.cmp(&other.include_packages))
+            .then_with(|| exclude_packages.cmp(&other.exclude_packages))
             .then_with(|| default.cmp(&other.default))
             .then_with(|| format.cmp(&other.format))
             .then_with(|| publish_url.cmp(&other.publish_url))
@@ -274,6 +373,8 @@ impl std::hash::Hash for Index {
             name,
             url,
             explicit,
+            include_packages,
+            exclude_packages,
             default,
             origin: _,
             format,
@@ -286,6 +387,8 @@ impl std::hash::Hash for Index {
         url.hash(state);
         name.hash(state);
         explicit.hash(state);
+        include_packages.hash(state);
+        exclude_packages.hash(state);
         default.hash(state);
         format.hash(state);
         publish_url.hash(state);
@@ -326,6 +429,8 @@ impl Index {
             url,
             name: None,
             explicit: false,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
             default: true,
             origin: None,
             format: IndexFormat::Simple,
@@ -343,6 +448,8 @@ impl Index {
             url,
             name: None,
             explicit: false,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
             default: false,
             origin: None,
             format: IndexFormat::Simple,
@@ -360,6 +467,8 @@ impl Index {
             url,
             name: None,
             explicit: false,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
             default: false,
             origin: None,
             format: IndexFormat::Flat,
@@ -470,6 +579,22 @@ impl Index {
             IndexCacheControl::simple_api_cache_control(self.url.url())
         }
     }
+
+    /// Returns `true` if this index explicitly includes the given package.
+    pub fn includes_package(&self, package_name: &PackageName) -> bool {
+        self.include_packages
+            .iter()
+            .any(|pattern| pattern.matches(package_name))
+    }
+
+    /// Returns `true` if this index excludes the given package.
+    pub fn excludes_package(&self, package_name: &PackageName) -> bool {
+        !self.includes_package(package_name)
+            && self
+                .exclude_packages
+                .iter()
+                .any(|pattern| pattern.matches(package_name))
+    }
 }
 
 impl From<IndexUrl> for Index {
@@ -478,6 +603,8 @@ impl From<IndexUrl> for Index {
             name: None,
             url: value,
             explicit: false,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
             default: false,
             origin: None,
             format: IndexFormat::Simple,
@@ -503,6 +630,8 @@ impl FromStr for Index {
                     name: Some(name),
                     url,
                     explicit: false,
+                    include_packages: Vec::new(),
+                    exclude_packages: Vec::new(),
                     default: false,
                     origin: None,
                     format: IndexFormat::Simple,
@@ -521,6 +650,8 @@ impl FromStr for Index {
             name: None,
             url,
             explicit: false,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
             default: false,
             origin: None,
             format: IndexFormat::Simple,
@@ -623,6 +754,10 @@ struct IndexWire {
     #[serde(default)]
     explicit: bool,
     #[serde(default)]
+    include_packages: Vec<PackageNamePattern>,
+    #[serde(default)]
+    exclude_packages: Vec<PackageNamePattern>,
+    #[serde(default)]
     default: bool,
     #[serde(default)]
     format: IndexFormat,
@@ -651,10 +786,19 @@ impl<'de> Deserialize<'de> for Index {
             )));
         }
 
+        if wire.explicit && (!wire.include_packages.is_empty() || !wire.exclude_packages.is_empty())
+        {
+            return Err(serde::de::Error::custom(
+                "An index with `explicit = true` cannot specify `include-packages` or `exclude-packages`",
+            ));
+        }
+
         Ok(Self {
             name: wire.name,
             url: wire.url,
             explicit: wire.explicit,
+            include_packages: wire.include_packages,
+            exclude_packages: wire.exclude_packages,
             default: wire.default,
             origin: None,
             format: wire.format,
@@ -710,6 +854,38 @@ mod tests {
         let index: Index = toml::from_str(toml_str).unwrap();
         assert_eq!(index.name.as_ref().unwrap().as_ref(), "test-index");
         assert_eq!(index.cache_control, None);
+    }
+
+    #[test]
+    fn test_index_package_routing_patterns() {
+        let toml_str = r#"
+            name = "test-index"
+            url = "https://test.example.com/simple"
+            include-packages = ["foo-*", "bar"]
+            exclude-packages = ["baz-*"]
+        "#;
+
+        let index: Index = toml::from_str(toml_str).unwrap();
+        assert!(index.includes_package(&PackageName::from_str("foo-core").unwrap()));
+        assert!(index.includes_package(&PackageName::from_str("bar").unwrap()));
+        assert!(index.excludes_package(&PackageName::from_str("baz-util").unwrap()));
+        assert!(!index.excludes_package(&PackageName::from_str("foo-core").unwrap()));
+    }
+
+    #[test]
+    fn test_explicit_index_cannot_use_package_routing_patterns() {
+        let toml_str = r#"
+            name = "test-index"
+            url = "https://test.example.com/simple"
+            explicit = true
+            include-packages = ["foo-*"]
+        "#;
+
+        let err = toml::from_str::<Index>(toml_str).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot specify `include-packages` or `exclude-packages`")
+        );
     }
 
     #[test]

--- a/crates/fyn-distribution-types/src/index_url.rs
+++ b/crates/fyn-distribution-types/src/index_url.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, LazyLock, RwLock};
 
 use fyn_auth::RealmRef;
 use fyn_cache_key::CanonicalUrl;
+use fyn_normalize::PackageName;
 use fyn_pep508::{Scheme, VerbatimUrl, VerbatimUrlError, split_scheme};
 use fyn_redacted::DisplaySafeUrl;
 use fyn_warnings::warn_user;
@@ -561,6 +562,27 @@ impl<'a> IndexUrls {
             .filter(move |index| seen.insert(index.raw_url())) // Filter out redundant raw URLs
     }
 
+    /// Return the candidate indexes for a specific package after applying package-routing rules.
+    pub fn indexes_for_package(&'a self, package_name: &PackageName) -> Vec<&'a Index> {
+        let indexes = self.indexes().collect::<Vec<_>>();
+
+        let included = indexes
+            .iter()
+            .copied()
+            .filter(|index| index.includes_package(package_name))
+            .collect::<Vec<_>>();
+
+        if !included.is_empty() {
+            return included;
+        }
+
+        indexes
+            .into_iter()
+            .filter(|index| index.include_packages.is_empty())
+            .filter(|index| !index.excludes_package(package_name))
+            .collect()
+    }
+
     /// Return an iterator over all user-defined [`Index`] entries in order.
     ///
     /// Prioritizes the `[tool.fyn.index]` definitions over the `--extra-index-url` definitions
@@ -782,6 +804,8 @@ mod tests {
                 authenticate: fyn_auth::AuthPolicy::default(),
                 ignore_error_codes: None,
                 exclude_newer: None,
+                include_packages: Vec::new(),
+                exclude_packages: Vec::new(),
             },
             Index {
                 name: Some(IndexName::from_str("index2").unwrap()),
@@ -795,6 +819,8 @@ mod tests {
                 authenticate: fyn_auth::AuthPolicy::default(),
                 ignore_error_codes: None,
                 exclude_newer: None,
+                include_packages: Vec::new(),
+                exclude_packages: Vec::new(),
             },
         ];
 
@@ -820,6 +846,99 @@ mod tests {
     }
 
     #[test]
+    fn test_indexes_for_package_applies_package_routing() {
+        use std::str::FromStr;
+
+        use fyn_normalize::PackageName;
+
+        let indexes = vec![
+            Index {
+                name: Some(IndexName::from_str("primary").unwrap()),
+                url: IndexUrl::from_str("https://primary.example.com/simple").unwrap(),
+                cache_control: None,
+                explicit: false,
+                default: false,
+                origin: None,
+                format: IndexFormat::Simple,
+                publish_url: None,
+                authenticate: fyn_auth::AuthPolicy::default(),
+                ignore_error_codes: None,
+                exclude_newer: None,
+                include_packages: Vec::new(),
+                exclude_packages: Vec::new(),
+            },
+            Index {
+                name: Some(IndexName::from_str("routed").unwrap()),
+                url: IndexUrl::from_str("https://routed.example.com/simple").unwrap(),
+                cache_control: None,
+                explicit: false,
+                default: false,
+                origin: None,
+                format: IndexFormat::Simple,
+                publish_url: None,
+                authenticate: fyn_auth::AuthPolicy::default(),
+                ignore_error_codes: None,
+                exclude_newer: None,
+                include_packages: vec![serde_json::from_str("\"ok\"").unwrap()],
+                exclude_packages: Vec::new(),
+            },
+            Index {
+                name: Some(IndexName::from_str("excluded").unwrap()),
+                url: IndexUrl::from_str("https://excluded.example.com/simple").unwrap(),
+                cache_control: None,
+                explicit: false,
+                default: false,
+                origin: None,
+                format: IndexFormat::Simple,
+                publish_url: None,
+                authenticate: fyn_auth::AuthPolicy::default(),
+                ignore_error_codes: None,
+                exclude_newer: None,
+                include_packages: Vec::new(),
+                exclude_packages: vec![serde_json::from_str("\"blocked\"").unwrap()],
+            },
+            Index {
+                name: Some(IndexName::from_str("fallback").unwrap()),
+                url: IndexUrl::from_str("https://fallback.example.com/simple").unwrap(),
+                cache_control: None,
+                explicit: false,
+                default: true,
+                origin: None,
+                format: IndexFormat::Simple,
+                publish_url: None,
+                authenticate: fyn_auth::AuthPolicy::default(),
+                ignore_error_codes: None,
+                exclude_newer: None,
+                include_packages: Vec::new(),
+                exclude_packages: Vec::new(),
+            },
+        ];
+
+        let index_urls = IndexUrls::from_indexes(indexes);
+
+        let routed = index_urls
+            .indexes_for_package(&PackageName::from_str("ok").unwrap())
+            .into_iter()
+            .map(|index| index.name.as_ref().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(routed, vec!["routed"]);
+
+        let blocked = index_urls
+            .indexes_for_package(&PackageName::from_str("blocked").unwrap())
+            .into_iter()
+            .map(|index| index.name.as_ref().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(blocked, vec!["primary", "fallback"]);
+
+        let other = index_urls
+            .indexes_for_package(&PackageName::from_str("other").unwrap())
+            .into_iter()
+            .map(|index| index.name.as_ref().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(other, vec!["primary", "excluded", "fallback"]);
+    }
+
+    #[test]
     fn test_pytorch_default_cache_control() {
         // Test that PyTorch indexes get default cache control from the getter methods
         let indexes = vec![Index {
@@ -834,6 +953,8 @@ mod tests {
             authenticate: fyn_auth::AuthPolicy::default(),
             ignore_error_codes: None,
             exclude_newer: None,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
         }];
 
         let index_urls = IndexUrls::from_indexes(indexes.clone());
@@ -877,6 +998,8 @@ mod tests {
             authenticate: fyn_auth::AuthPolicy::default(),
             ignore_error_codes: None,
             exclude_newer: None,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
         }];
 
         let index_urls = IndexUrls::from_indexes(indexes.clone());
@@ -920,6 +1043,8 @@ mod tests {
             authenticate: fyn_auth::AuthPolicy::default(),
             ignore_error_codes: None,
             exclude_newer: None,
+            include_packages: Vec::new(),
+            exclude_packages: Vec::new(),
         }];
 
         let index_urls = IndexUrls::from_indexes(indexes.clone());

--- a/crates/fyn/src/commands/project/add.rs
+++ b/crates/fyn/src/commands/project/add.rs
@@ -1273,6 +1273,7 @@ impl PythonTarget {
 }
 
 /// Represents the destination where dependencies are added, either to a project or a script.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub(super) enum AddTarget {
     /// A PEP 723 script, with inline metadata.
@@ -1372,6 +1373,7 @@ impl AddTarget {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 enum AddTargetSnapshot {
     Script(Pep723Script, Option<Vec<u8>>),

--- a/crates/fyn/src/commands/project/export.rs
+++ b/crates/fyn/src/commands/project/export.rs
@@ -34,6 +34,7 @@ use crate::commands::{ExitStatus, OutputWriter, diagnostics};
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverSettings};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 enum ExportTarget {
     /// A PEP 723 script, with inline metadata.

--- a/crates/fyn/src/commands/project/remove.rs
+++ b/crates/fyn/src/commands/project/remove.rs
@@ -396,6 +396,7 @@ pub(crate) async fn remove(
 }
 
 /// Represents the destination where dependencies are added, either to a project or a script.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 enum RemoveTarget {
     /// A PEP 723 script, with inline metadata.

--- a/crates/fyn/src/commands/project/sync.rs
+++ b/crates/fyn/src/commands/project/sync.rs
@@ -569,6 +569,7 @@ fn identify_installation_target<'a>(
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 enum SyncTarget {
     /// Sync a project environment.

--- a/crates/fyn/tests/it/sync.rs
+++ b/crates/fyn/tests/it/sync.rs
@@ -15397,6 +15397,318 @@ async fn sync_zstd_wheel() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn sync_index_include_packages_routes_package() -> Result<()> {
+    use serde_json::json;
+    use sha2::{Digest, Sha256};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    async fn mount_simple_wheel(
+        server: &MockServer,
+        package_name: &str,
+        filename: &str,
+        wheel_bytes: Vec<u8>,
+    ) {
+        let wheel_url = format!("{}/files/{filename}", server.uri());
+        let sha256 = format!("{:x}", Sha256::digest(&wheel_bytes));
+        let simple_index = json!({
+            "meta": {
+                "api-version": "1.1"
+            },
+            "name": package_name,
+            "files": [{
+                "filename": filename,
+                "url": wheel_url,
+                "hashes": {
+                    "sha256": sha256
+                },
+                "size": wheel_bytes.len()
+            }]
+        });
+
+        Mock::given(method("GET"))
+            .and(path(format!("/files/{filename}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(wheel_bytes))
+            .mount(server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{package_name}/")))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                simple_index.to_string().into_bytes(),
+                "application/vnd.pyx.simple.v1+json",
+            ))
+            .mount(server)
+            .await;
+    }
+
+    let context = fyn_test::test_context!("3.13");
+    let primary = MockServer::start().await;
+    let routed = MockServer::start().await;
+
+    let primary_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/ok-2.0.0-py3-none-any.whl"),
+    )?;
+    let routed_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+    )?;
+
+    mount_simple_wheel(&primary, "ok", "ok-2.0.0-py3-none-any.whl", primary_wheel).await;
+    mount_simple_wheel(&routed, "ok", "ok-1.0.0-py3-none-any.whl", routed_wheel).await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! { r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["ok"]
+
+        [[tool.fyn.index]]
+        name = "primary"
+        url = "{}/simple"
+
+        [[tool.fyn.index]]
+        name = "routed"
+        url = "{}/simple"
+        default = true
+        include-packages = ["ok"]
+        "#,
+        primary.uri(),
+        routed.uri()
+    })?;
+
+    fyn_snapshot!(context.filters(), context.sync().env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_index_exclude_packages_skips_package() -> Result<()> {
+    use serde_json::json;
+    use sha2::{Digest, Sha256};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    async fn mount_simple_wheel(
+        server: &MockServer,
+        package_name: &str,
+        filename: &str,
+        wheel_bytes: Vec<u8>,
+    ) {
+        let wheel_url = format!("{}/files/{filename}", server.uri());
+        let sha256 = format!("{:x}", Sha256::digest(&wheel_bytes));
+        let simple_index = json!({
+            "meta": {
+                "api-version": "1.1"
+            },
+            "name": package_name,
+            "files": [{
+                "filename": filename,
+                "url": wheel_url,
+                "hashes": {
+                    "sha256": sha256
+                },
+                "size": wheel_bytes.len()
+            }]
+        });
+
+        Mock::given(method("GET"))
+            .and(path(format!("/files/{filename}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(wheel_bytes))
+            .mount(server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{package_name}/")))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                simple_index.to_string().into_bytes(),
+                "application/vnd.pyx.simple.v1+json",
+            ))
+            .mount(server)
+            .await;
+    }
+
+    let context = fyn_test::test_context!("3.13");
+    let excluded = MockServer::start().await;
+    let fallback = MockServer::start().await;
+
+    let excluded_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+    )?;
+    let fallback_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/ok-2.0.0-py3-none-any.whl"),
+    )?;
+
+    mount_simple_wheel(&excluded, "ok", "ok-1.0.0-py3-none-any.whl", excluded_wheel).await;
+    mount_simple_wheel(&fallback, "ok", "ok-2.0.0-py3-none-any.whl", fallback_wheel).await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! { r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["ok"]
+
+        [[tool.fyn.index]]
+        name = "excluded"
+        url = "{}/simple"
+        exclude-packages = ["ok"]
+
+        [[tool.fyn.index]]
+        name = "fallback"
+        url = "{}/simple"
+        default = true
+        "#,
+        excluded.uri(),
+        fallback.uri()
+    })?;
+
+    fyn_snapshot!(context.filters(), context.sync().env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==2.0.0
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_index_package_routing_respects_explicit_source_pin() -> Result<()> {
+    use serde_json::json;
+    use sha2::{Digest, Sha256};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    async fn mount_simple_wheel(
+        server: &MockServer,
+        package_name: &str,
+        filename: &str,
+        wheel_bytes: Vec<u8>,
+    ) {
+        let wheel_url = format!("{}/files/{filename}", server.uri());
+        let sha256 = format!("{:x}", Sha256::digest(&wheel_bytes));
+        let simple_index = json!({
+            "meta": {
+                "api-version": "1.1"
+            },
+            "name": package_name,
+            "files": [{
+                "filename": filename,
+                "url": wheel_url,
+                "hashes": {
+                    "sha256": sha256
+                },
+                "size": wheel_bytes.len()
+            }]
+        });
+
+        Mock::given(method("GET"))
+            .and(path(format!("/files/{filename}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(wheel_bytes))
+            .mount(server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("/simple/{package_name}/")))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                simple_index.to_string().into_bytes(),
+                "application/vnd.pyx.simple.v1+json",
+            ))
+            .mount(server)
+            .await;
+    }
+
+    let context = fyn_test::test_context!("3.13");
+    let routed = MockServer::start().await;
+    let pinned = MockServer::start().await;
+
+    let routed_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/ok-2.0.0-py3-none-any.whl"),
+    )?;
+    let pinned_wheel = fs_err::read(
+        context
+            .workspace_root
+            .join("test/links/ok-1.0.0-py3-none-any.whl"),
+    )?;
+
+    mount_simple_wheel(&routed, "ok", "ok-2.0.0-py3-none-any.whl", routed_wheel).await;
+    mount_simple_wheel(&pinned, "ok", "ok-1.0.0-py3-none-any.whl", pinned_wheel).await;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&formatdoc! { r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.13"
+        dependencies = ["ok"]
+
+        [tool.fyn.sources]
+        ok = {{ index = "pinned" }}
+
+        [[tool.fyn.index]]
+        name = "routed"
+        url = "{}/simple"
+        include-packages = ["ok"]
+
+        [[tool.fyn.index]]
+        name = "pinned"
+        url = "{}/simple"
+        default = true
+        "#,
+        routed.uri(),
+        pinned.uri()
+    })?;
+
+    fyn_snapshot!(context.filters(), context.sync().env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + ok==1.0.0
+    ");
+
+    Ok(())
+}
+
 #[test]
 #[cfg(not(windows))]
 fn toggle_workspace_editable() -> Result<()> {

--- a/docs/concepts/indexes.md
+++ b/docs/concepts/indexes.md
@@ -87,6 +87,31 @@ name = "pytorch-cu124"
 url = "https://download.pytorch.org/whl/cu124"
 ```
 
+## Routing package patterns to an index
+
+If you want a whole package namespace to prefer a specific index, add `include-packages` or
+`exclude-packages` to `[[tool.fyn.index]]`:
+
+```toml
+[[tool.fyn.index]]
+name = "internal"
+url = "https://packages.example.com/simple"
+include-packages = ["mycompany-*"]
+
+[[tool.fyn.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+```
+
+When a package matches `include-packages`, fyn only considers the matching indexes for that package.
+Indexes with `include-packages` are skipped for packages that don't match, and `exclude-packages`
+removes a package from an index without affecting the others.
+
+Exact `[tool.fyn.sources]` pins still take precedence over these routing rules. Routing patterns
+cannot be combined with `explicit = true`; if you want an index to be used only for specific named
+packages, keep using `[tool.fyn.sources]`.
+
 An index can be marked as `explicit = true` to prevent packages from being installed from that index
 unless explicitly pinned to it. For example, to ensure that `torch` is installed from the `pytorch`
 index, but all other packages are installed from PyPI, add the following to your `pyproject.toml`:


### PR DESCRIPTION
## Summary

Add package routing for indexes via `[[tool.fyn.index]]`:

  - `include-packages`
  - `exclude-packages`

  This allows an index to handle a package namespace like `mycompany-*` without requiring exact per-package entries in `[tool.fyn.sources]`.

## Test

  - `cargo fmt --all`
  - `cargo test -p fyn-distribution-types`
  - `cargo test -p fyn --test it sync_index_`