### PR TITLE
fix: correct fyn run task resolution edge cases

### DIFF
--- a/crates/fyn/src/commands/mod.rs
+++ b/crates/fyn/src/commands/mod.rs
@@ -47,7 +47,7 @@ pub(crate) use project::format::format;
 pub(crate) use project::init::{InitKind, InitProjectKind, init};
 pub(crate) use project::lock::lock;
 pub(crate) use project::remove::remove;
-pub(crate) use project::run::{RunCommand, run};
+pub(crate) use project::run::{RunCommand, find_nearest_pyproject_path, run};
 pub(crate) use project::sync::sync;
 pub(crate) use project::tree::tree;
 pub(crate) use project::upgrade::upgrade;

--- a/crates/fyn/src/commands/project/run.rs
+++ b/crates/fyn/src/commands/project/run.rs
@@ -1793,6 +1793,7 @@ impl RunCommand {
     ///
     /// If the target matches a task defined in `[tool.fyn.tasks]`, run that
     /// task instead of searching PATH.
+    #[expect(clippy::fn_params_excessive_bools)]
     pub(crate) async fn from_args(
         command: &ExternalCommand,
         client_builder: BaseClientBuilder<'_>,
@@ -1800,6 +1801,7 @@ impl RunCommand {
         script: bool,
         gui_script: bool,
         project_dir: &std::path::Path,
+        no_project: bool,
     ) -> anyhow::Result<Self> {
         let (target, args) = command.split();
         let Some(target) = target else {
@@ -1880,12 +1882,18 @@ impl RunCommand {
             return Ok(Self::PythonScript(target.clone().into(), args.to_vec()));
         }
 
+        let metadata = target_path.metadata();
+        let is_file = metadata.as_ref().is_ok_and(std::fs::Metadata::is_file);
+        let is_dir = metadata.as_ref().is_ok_and(std::fs::Metadata::is_dir);
+
         // Check if the target matches a task in [tool.fyn.tasks] before
         // falling back to PATH lookup. Skip if the target looks like a file path.
         let target_str = target.to_string_lossy();
-        if !target_str.contains(std::path::MAIN_SEPARATOR)
+        if !no_project
+            && !target_str.contains(std::path::MAIN_SEPARATOR)
             && !target_str.contains('/')
-            && !target_str.contains('.')
+            && !is_file
+            && !is_dir
         {
             if let Some(tasks) = lookup_tasks(project_dir) {
                 if tasks.get(&target_str).is_some() {
@@ -1893,10 +1901,6 @@ impl RunCommand {
                 }
             }
         }
-
-        let metadata = target_path.metadata();
-        let is_file = metadata.as_ref().is_ok_and(std::fs::Metadata::is_file);
-        let is_dir = metadata.as_ref().is_ok_and(std::fs::Metadata::is_dir);
 
         if target.eq_ignore_ascii_case("python") {
             Ok(Self::Python(args.to_vec()))
@@ -1933,31 +1937,33 @@ impl RunCommand {
 ///
 /// Walks up from `project_dir` looking for a `pyproject.toml` with a
 /// `[tool.fyn.tasks]` section.
-fn lookup_tasks(project_dir: &Path) -> Option<fyn_workspace::pyproject::ToolfynTasks> {
+pub(crate) fn find_nearest_pyproject_path(project_dir: &Path) -> Option<PathBuf> {
     let mut dir = project_dir.to_path_buf();
     loop {
         let pyproject_path = dir.join("pyproject.toml");
         if pyproject_path.is_file() {
-            if let Ok(content) = fs_err::read_to_string(&pyproject_path) {
-                if let Ok(pyproject) =
-                    toml::from_str::<fyn_workspace::pyproject::PyProjectToml>(&content)
-                {
-                    if let Some(tool_fyn) = pyproject.tool.and_then(|t| t.fyn) {
-                        if let Some(tasks) = tool_fyn.tasks {
-                            if !tasks.is_empty() {
-                                return Some(tasks);
-                            }
-                        }
-                    }
-                }
-            }
-            // Found a pyproject.toml but no tasks — stop searching.
-            return None;
+            return Some(pyproject_path);
         }
         if !dir.pop() {
             return None;
         }
     }
+}
+
+fn lookup_tasks(project_dir: &Path) -> Option<fyn_workspace::pyproject::ToolfynTasks> {
+    let pyproject_path = find_nearest_pyproject_path(project_dir)?;
+    if let Ok(content) = fs_err::read_to_string(&pyproject_path) {
+        if let Ok(pyproject) = toml::from_str::<fyn_workspace::pyproject::PyProjectToml>(&content) {
+            if let Some(tool_fyn) = pyproject.tool.and_then(|t| t.fyn) {
+                if let Some(tasks) = tool_fyn.tasks {
+                    if !tasks.is_empty() {
+                        return Some(tasks);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 fn resolve_task_plan(
@@ -2061,7 +2067,7 @@ fn resolve_task_steps(
 }
 
 fn parse_task_command(cmd_str: &str, extra_args: &[OsString]) -> anyhow::Result<TaskCommand> {
-    let parts = shell_split(cmd_str);
+    let parts = shell_split(cmd_str)?;
     let Some((program, cmd_args)) = parts.split_first() else {
         bail!("Task command is empty");
     };
@@ -2077,31 +2083,90 @@ fn parse_task_command(cmd_str: &str, extra_args: &[OsString]) -> anyhow::Result<
 
 /// Split a command string into tokens, respecting single and double quotes.
 ///
-/// This is intentionally simple — it doesn't handle escape characters or
-/// nested quotes, but covers the common cases like `pytest -xvs`,
-/// `echo "hello world"`, and `ruff check --select 'E501'`.
-fn shell_split(s: &str) -> Vec<String> {
+/// This is intentionally shell-like rather than shell-complete: it supports
+/// quotes and backslash escapes, which covers common task forms like
+/// `pytest -xvs`, `echo "hello world"`, and `python -c "print(\"ok\")"`.
+fn shell_split(s: &str) -> anyhow::Result<Vec<String>> {
     let mut tokens = Vec::new();
     let mut current = String::new();
     let mut in_single = false;
     let mut in_double = false;
+    let mut escaped = false;
+    let mut token_started = false;
 
     for c in s.chars() {
+        if escaped {
+            current.push(c);
+            escaped = false;
+            token_started = true;
+            continue;
+        }
+
         match c {
-            '\'' if !in_double => in_single = !in_single,
-            '"' if !in_single => in_double = !in_double,
+            '\\' if !in_single => {
+                escaped = true;
+                token_started = true;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+                token_started = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                token_started = true;
+            }
             c if c.is_whitespace() && !in_single && !in_double => {
-                if !current.is_empty() {
+                if token_started {
                     tokens.push(std::mem::take(&mut current));
+                    token_started = false;
                 }
             }
-            c => current.push(c),
+            c => {
+                current.push(c);
+                token_started = true;
+            }
         }
     }
-    if !current.is_empty() {
+
+    if escaped {
+        current.push('\\');
+    }
+
+    if in_single || in_double {
+        bail!("Task command contains an unterminated quoted string");
+    }
+
+    if token_started {
         tokens.push(current);
     }
-    tokens
+
+    Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shell_split;
+
+    #[test]
+    fn shell_split_supports_escaped_quotes() {
+        assert_eq!(
+            shell_split(r#"python -c "print(\"ok\")""#).unwrap(),
+            vec!["python", "-c", r#"print("ok")"#],
+        );
+    }
+
+    #[test]
+    fn shell_split_preserves_empty_quoted_arguments() {
+        assert_eq!(
+            shell_split(r#"python -c "" "arg two""#).unwrap(),
+            vec!["python", "-c", "", "arg two"],
+        );
+    }
+
+    #[test]
+    fn shell_split_rejects_unterminated_quotes() {
+        assert!(shell_split(r#"python -c "print("ok")"#).is_err());
+    }
 }
 
 /// Returns `true` if the target is a ZIP archive containing a `__main__.py` file.

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -53,7 +53,9 @@ use fyn_static::EnvVars;
 use fyn_warnings::{warn_user, warn_user_once};
 use fyn_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
 
-use crate::commands::{ExitStatus, RunCommand, ScriptPath, ToolRunCommand};
+use crate::commands::{
+    ExitStatus, RunCommand, ScriptPath, ToolRunCommand, find_nearest_pyproject_path,
+};
 use crate::printer::Printer;
 use crate::settings::{
     CacheSettings, GlobalSettings, PipCheckSettings, PipCompileSettings, PipDownloadSettings,
@@ -250,6 +252,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             module,
             script,
             gui_script,
+            no_project,
             ..
         }) = &mut **command
         {
@@ -278,6 +281,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     *script,
                     *gui_script,
                     &project_dir,
+                    *no_project,
                 )
                 .await?,
             )
@@ -2539,8 +2543,8 @@ async fn run_project(
             // Handle --list-tasks early, before full settings resolution.
             if args.list_tasks {
                 use fyn_workspace::pyproject::PyProjectToml;
-                let pyproject_path = project_dir.join("pyproject.toml");
-                if let Ok(content) = fs_err::read_to_string(&pyproject_path) {
+                if let Some(pyproject_path) = find_nearest_pyproject_path(project_dir) {
+                    let content = fs_err::read_to_string(&pyproject_path)?;
                     if let Ok(pyproject) = toml::from_str::<PyProjectToml>(&content) {
                         if let Some(tasks) =
                             pyproject.tool.and_then(|t| t.fyn).and_then(|u| u.tasks)

--- a/crates/fyn/tests/it/run.rs
+++ b/crates/fyn/tests/it/run.rs
@@ -6854,6 +6854,81 @@ fn run_task_detailed() -> Result<()> {
     Ok(())
 }
 
+/// Dotted task names should resolve like any other task name.
+#[test]
+fn run_task_dotted_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        "test.unit" = "echo dotted task"
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("test.unit"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    dotted task
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    ");
+
+    Ok(())
+}
+
+/// Existing local files should still take precedence over same-named dotted tasks.
+#[test]
+fn run_task_dotted_name_does_not_override_local_script() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        "main.py" = "echo task wins"
+        "#
+    })?;
+
+    context.temp_dir.child("main.py").write_str(indoc! { r#"
+        print("script wins")
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("main.py"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    script wins
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    ");
+
+    Ok(())
+}
+
 /// Extra arguments passed to `cmd` tasks should not forward the task separator itself.
 #[test]
 fn run_task_cmd_strips_passthrough_separator() -> Result<()> {
@@ -6953,6 +7028,41 @@ fn run_task_cmd_forwards_option_like_args() -> Result<()> {
     Checked in [TIME]
     "
     );
+
+    Ok(())
+}
+
+/// Escaped quotes inside task commands should survive argument splitting.
+#[test]
+fn run_task_cmd_supports_escaped_quotes() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        show = "python -c \"print(\\\"ok\\\")\""
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("show"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ok
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    ");
 
     Ok(())
 }
@@ -7113,6 +7223,36 @@ fn run_task_fallback_to_path() -> Result<()> {
     Ok(())
 }
 
+/// `--no-project` should suppress task lookup and run the external command instead.
+#[test]
+fn run_task_ignored_with_no_project() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        python = "echo task python"
+        "#
+    })?;
+
+    let mut cmd = context.run();
+    cmd.arg("--no-project").arg("python").arg("--version");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Python 3.12."));
+
+    Ok(())
+}
+
 /// --list-tasks shows available tasks.
 #[test]
 fn run_list_tasks() -> Result<()> {
@@ -7146,6 +7286,47 @@ fn run_list_tasks() -> Result<()> {
     ----- stderr -----
     Available tasks:
       fmt              Format code
+      lint             ruff check .
+      test             pytest -xvs
+    ");
+
+    Ok(())
+}
+
+/// --list-tasks should search parent directories the same way task execution does.
+#[test]
+fn run_list_tasks_from_subdirectory() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        test = "pytest -xvs"
+        lint = "ruff check ."
+        "#
+    })?;
+
+    let subdir = context.temp_dir.child("nested").child("child");
+    subdir.create_dir_all()?;
+
+    let mut cmd = context.run();
+    cmd.current_dir(subdir.path()).arg("--list-tasks");
+    fyn_snapshot!(context.filters(), cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Available tasks:
       lint             ruff check .
       test             pytest -xvs
     ");


### PR DESCRIPTION
## Summary
  - respect `--no-project` during `fyn run` task resolution
  - make `fyn run --list-tasks` search parent directories like task execution does
  - allow dotted task names unless they resolve to real local files
  - fix task command parsing for escaped quotes and empty quoted args

## What Changed
  - `RunCommand::from_args` now receives `no_project` and skips task lookup when that flag is set.

  - Task discovery was unified so both task execution and `--list-tasks` use the nearest ancestor `pyproject.toml` instead of treating subdirectories differently.

  - Task resolution no longer rejects names containing `.` by default.

  - The task command parser now handles backslash-escaped quotes and empty quoted arguments, which fixes cases like `python -c "print(\"ok\")"`.

  ## Testing
  - `cargo test -p fyn shell_split --lib`
  - `cargo test -p fyn --test it run::run_task_ -- --nocapture`
  - `cargo test -p fyn --test it run::run_list_tasks -- --nocapture`
  - `cargo build -p fyn`