### PR TITLE
feat: support --python-downloads-json-url in python pin

### DIFF
--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -7905,6 +7905,10 @@ pub struct PythonPinArgs {
     /// Remove the Python version pin.
     #[arg(long, conflicts_with = "request", conflicts_with = "resolved")]
     pub rm: bool,
+
+    /// URL pointing to JSON of custom Python installations.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub python_downloads_json_url: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -1585,11 +1585,19 @@ impl PythonPinSettings {
             no_project,
             global,
             rm,
+            python_downloads_json_url,
         } = args;
 
         let filesystem_install_mirrors = filesystem
             .map(|fs| fs.install_mirrors.clone())
             .unwrap_or_default();
+
+        let install_mirrors = PythonInstallMirrors {
+            python_downloads_json_url,
+            ..Default::default()
+        }
+        .combine(environment.install_mirrors)
+        .combine(filesystem_install_mirrors);
 
         Self {
             request,
@@ -1598,9 +1606,7 @@ impl PythonPinSettings {
             no_project,
             global,
             rm,
-            install_mirrors: environment
-                .install_mirrors
-                .combine(filesystem_install_mirrors),
+            install_mirrors,
         }
     }
 }

--- a/crates/fyn/tests/it/help.rs
+++ b/crates/fyn/tests/it/help.rs
@@ -941,6 +941,18 @@ fn help_shell_subcommand() {
 }
 
 #[test]
+fn help_python_pin_subcommand() {
+    let context = fyn_test::test_context_with_versions!(&[]);
+    let output = context.help().arg("python").arg("pin").output().unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Pin to a specific Python version."));
+    assert!(stdout.contains("Usage: fyn python pin [OPTIONS] [REQUEST]"));
+    assert!(stdout.contains("--python-downloads-json-url"));
+}
+
+#[test]
 fn help_unknown_subcommand() {
     let context = fyn_test::test_context_with_versions!(&[]);
 

--- a/crates/fyn/tests/it/python_pin.rs
+++ b/crates/fyn/tests/it/python_pin.rs
@@ -182,6 +182,27 @@ fn python_pin() {
     }
 }
 
+#[test]
+fn python_pin_uses_python_downloads_json_url() {
+    let context = fyn_test::test_context_with_versions!(&[]).with_filtered_python_sources();
+    let metadata = context.temp_dir.child("empty-download-metadata.json");
+    metadata.write_str("{}").unwrap();
+
+    fyn_snapshot!(context.filters(), context
+        .python_pin()
+        .arg("--resolved")
+        .arg("3.12")
+        .arg("--python-downloads-json-url")
+        .arg(metadata.path()), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found for Python 3.12 in [PYTHON SOURCES]
+    ");
+}
+
 // If there is no project-level `.python-version` file, respect the global pin.
 #[test]
 fn python_pin_global_if_no_local() -> Result<()> {


### PR DESCRIPTION
## Summary
  - add `--python-downloads-json-url` to `fyn python pin`
  - wire flag through `PythonPinSettings` into existing install mirror resolution
  - add help coverage for `fyn python pin`

  ## Testing
  - `cargo fmt --all`
  - `cargo test -p fyn --test it python_pin_uses_python_downloads_json_url`
  - `cargo test -p fyn --test it help_python_pin_subcommand`
  - `cargo test -p fyn --test it python_pin`