### PR TITLE
feat: extend status with python and environment health checks

### DIFF
--- a/crates/fyn/src/commands/python/mod.rs
+++ b/crates/fyn/src/commands/python/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod find;
 pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod pin;
+pub(crate) mod pin_compat;
 pub(crate) mod shim;
 pub(crate) mod uninstall;
 pub(crate) mod update_shell;

--- a/crates/fyn/src/commands/python/pin.rs
+++ b/crates/fyn/src/commands/python/pin.rs
@@ -9,7 +9,6 @@ use tracing::debug;
 
 use fyn_cache::Cache;
 use fyn_client::BaseClientBuilder;
-use fyn_configuration::DependencyGroupsWithDefaults;
 use fyn_fs::Simplified;
 use fyn_preview::Preview;
 use fyn_python::{
@@ -21,9 +20,10 @@ use fyn_settings::PythonInstallMirrors;
 use fyn_warnings::warn_user_once;
 use fyn_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache};
 
-use crate::commands::{
-    ExitStatus, project::find_requires_python, reporters::PythonDownloadReporter,
+use super::pin_compat::{
+    assert_pin_compatible_with_project, existing_pin_compatibility_issue, project_requires_python,
 };
+use crate::commands::{ExitStatus, reporters::PythonDownloadReporter};
 use crate::printer::Printer;
 
 /// Pin to a specific Python version.
@@ -105,14 +105,16 @@ pub(crate) async fn pin(
                         install_mirrors.python_downloads_json_url.as_deref(),
                     )
                     .await?;
-                    warn_if_existing_pin_incompatible_with_project(
+                    if let Some(issue) = existing_pin_compatibility_issue(
                         pin,
                         virtual_project,
                         python_preference,
                         &download_list,
                         cache,
                         preview,
-                    );
+                    ) {
+                        warn_user_once!("{issue}");
+                    }
                 }
             }
             return Ok(ExitStatus::Success);
@@ -197,23 +199,19 @@ pub(crate) async fn pin(
         if !upgrade && let Some(virtual_project) = &virtual_project {
             if let Some(request_version) = request.as_pep440_version() {
                 assert_pin_compatible_with_project(
-                    &Pin {
-                        request: &request,
-                        version: &request_version,
-                        resolved: false,
-                        existing: false,
-                    },
+                    &request,
+                    &request_version,
+                    false,
+                    false,
                     virtual_project,
                 )?;
             } else if let Some(python) = &python {
                 // Warn if the resolved Python is incompatible with the Python requirement unless --resolved is used
                 if let Err(err) = assert_pin_compatible_with_project(
-                    &Pin {
-                        request: &request,
-                        version: python.python_version(),
-                        resolved: true,
-                        existing: false,
-                    },
+                    &request,
+                    python.python_version(),
+                    true,
+                    false,
                     virtual_project,
                 ) {
                     if resolved {
@@ -326,10 +324,9 @@ async fn resolve_upgraded_pin(
 
     let Some(download) = download_list
         .iter_matching(&upgrade_request)
-        .find(|download| {
-            requires_python.is_none_or(|requires_python| {
-                requires_python.contains(download.key().version().version())
-            })
+        .find(|download| match requires_python {
+            Some(requires_python) => requires_python.contains(download.key().version().version()),
+            None => true,
         })
     else {
         if let Some(requires_python) = requires_python {
@@ -424,132 +421,4 @@ fn exact_version_request(key: &PythonInstallationKey) -> VersionRequest {
             variant,
         )
     }
-}
-
-/// Check if pinned request is compatible with the workspace/project's `Requires-Python`.
-fn warn_if_existing_pin_incompatible_with_project(
-    pin: &PythonRequest,
-    virtual_project: &VirtualProject,
-    python_preference: PythonPreference,
-    downloads_list: &ManagedPythonDownloadList,
-    cache: &Cache,
-    preview: Preview,
-) {
-    // Check if the pinned version is compatible with the project.
-    if let Some(pin_version) = pin.as_pep440_version() {
-        if let Err(err) = assert_pin_compatible_with_project(
-            &Pin {
-                request: pin,
-                version: &pin_version,
-                resolved: false,
-                existing: true,
-            },
-            virtual_project,
-        ) {
-            warn_user_once!("{err}");
-            return;
-        }
-    }
-
-    // If there is not a version in the pinned request, attempt to resolve the pin into an
-    // interpreter to check for compatibility on the current system.
-    match PythonInstallation::find(
-        pin,
-        EnvironmentPreference::OnlySystem,
-        python_preference,
-        downloads_list,
-        cache,
-        preview,
-    ) {
-        Ok(python) => {
-            let python_version = python.python_version();
-            debug!(
-                "The pinned Python version `{}` resolves to `{}`",
-                pin, python_version
-            );
-            // Warn on incompatibilities when viewing existing pins
-            if let Err(err) = assert_pin_compatible_with_project(
-                &Pin {
-                    request: pin,
-                    version: python_version,
-                    resolved: true,
-                    existing: true,
-                },
-                virtual_project,
-            ) {
-                warn_user_once!("{err}");
-            }
-        }
-        Err(err) => {
-            warn_user_once!(
-                "Failed to resolve pinned Python version `{}`: {err}",
-                pin.to_canonical_string(),
-            );
-        }
-    }
-}
-
-/// Utility struct for representing pins in error messages.
-struct Pin<'a> {
-    request: &'a PythonRequest,
-    version: &'a fyn_pep440::Version,
-    resolved: bool,
-    existing: bool,
-}
-
-fn project_requires_python(virtual_project: &VirtualProject) -> Result<Option<RequiresPython>> {
-    // Don't factor in requires-python settings on dependency-groups
-    let groups = DependencyGroupsWithDefaults::none();
-
-    match virtual_project {
-        VirtualProject::Project(project_workspace) => {
-            debug!(
-                "Discovered project `{}` at: {}",
-                project_workspace.project_name(),
-                project_workspace.workspace().install_path().display()
-            );
-
-            Ok(find_requires_python(
-                project_workspace.workspace(),
-                &groups,
-            )?)
-        }
-        VirtualProject::NonProject(workspace) => {
-            debug!(
-                "Discovered virtual workspace at: {}",
-                workspace.install_path().display()
-            );
-            Ok(find_requires_python(workspace, &groups)?)
-        }
-    }
-}
-
-/// Checks if the pinned Python version is compatible with the workspace/project's `Requires-Python`.
-fn assert_pin_compatible_with_project(pin: &Pin, virtual_project: &VirtualProject) -> Result<()> {
-    let (requires_python, project_type) = match virtual_project {
-        VirtualProject::Project(..) => (project_requires_python(virtual_project)?, "project"),
-        VirtualProject::NonProject(..) => (project_requires_python(virtual_project)?, "workspace"),
-    };
-
-    let Some(requires_python) = requires_python else {
-        return Ok(());
-    };
-
-    if requires_python.contains(pin.version) {
-        return Ok(());
-    }
-
-    let given = if pin.existing { "pinned" } else { "requested" };
-    let resolved = if pin.resolved {
-        format!(" resolves to `{}` which ", pin.version)
-    } else {
-        String::new()
-    };
-
-    Err(anyhow::anyhow!(
-        "The {given} Python version `{}`{resolved} is incompatible with the {} `requires-python` value of `{}`.",
-        pin.request.to_canonical_string(),
-        project_type,
-        requires_python
-    ))
 }

--- a/crates/fyn/src/commands/python/pin_compat.rs
+++ b/crates/fyn/src/commands/python/pin_compat.rs
@@ -1,0 +1,136 @@
+use anyhow::Result;
+use fyn_cache::Cache;
+use fyn_configuration::DependencyGroupsWithDefaults;
+use fyn_distribution_types::RequiresPython;
+use fyn_preview::Preview;
+use fyn_python::downloads::ManagedPythonDownloadList;
+use fyn_python::{EnvironmentPreference, PythonInstallation, PythonPreference, PythonRequest};
+use fyn_workspace::VirtualProject;
+use tracing::debug;
+
+use crate::commands::project::find_requires_python;
+
+/// Utility struct for representing pins in error messages.
+struct Pin<'a> {
+    request: &'a PythonRequest,
+    version: &'a fyn_pep440::Version,
+    resolved: bool,
+    existing: bool,
+}
+
+/// Check if an existing pin is compatible with the workspace/project's `requires-python`.
+pub(crate) fn existing_pin_compatibility_issue(
+    pin: &PythonRequest,
+    virtual_project: &VirtualProject,
+    python_preference: PythonPreference,
+    downloads_list: &ManagedPythonDownloadList,
+    cache: &Cache,
+    preview: Preview,
+) -> Option<String> {
+    // Check if the pinned version is compatible with the project.
+    if let Some(pin_version) = pin.as_pep440_version() {
+        if let Err(err) =
+            assert_pin_compatible_with_project(pin, &pin_version, false, true, virtual_project)
+        {
+            return Some(err.to_string());
+        }
+    }
+
+    // If there is not a version in the pinned request, attempt to resolve the pin into an
+    // interpreter to check for compatibility on the current system.
+    match PythonInstallation::find(
+        pin,
+        EnvironmentPreference::OnlySystem,
+        python_preference,
+        downloads_list,
+        cache,
+        preview,
+    ) {
+        Ok(python) => {
+            let python_version = python.python_version();
+            debug!(
+                "The pinned Python version `{}` resolves to `{}`",
+                pin, python_version
+            );
+            assert_pin_compatible_with_project(pin, python_version, true, true, virtual_project)
+                .err()
+                .map(|err| err.to_string())
+        }
+        Err(err) => Some(format!(
+            "Failed to resolve pinned Python version `{}`: {err}",
+            pin.to_canonical_string(),
+        )),
+    }
+}
+
+pub(crate) fn project_requires_python(
+    virtual_project: &VirtualProject,
+) -> Result<Option<RequiresPython>> {
+    // Don't factor in requires-python settings on dependency-groups
+    let groups = DependencyGroupsWithDefaults::none();
+
+    match virtual_project {
+        VirtualProject::Project(project_workspace) => {
+            debug!(
+                "Discovered project `{}` at: {}",
+                project_workspace.project_name(),
+                project_workspace.workspace().install_path().display()
+            );
+
+            Ok(find_requires_python(
+                project_workspace.workspace(),
+                &groups,
+            )?)
+        }
+        VirtualProject::NonProject(workspace) => {
+            debug!(
+                "Discovered virtual workspace at: {}",
+                workspace.install_path().display()
+            );
+            Ok(find_requires_python(workspace, &groups)?)
+        }
+    }
+}
+
+/// Checks if the pinned Python version is compatible with the workspace/project's
+/// `requires-python`.
+pub(crate) fn assert_pin_compatible_with_project(
+    request: &PythonRequest,
+    version: &fyn_pep440::Version,
+    resolved: bool,
+    existing: bool,
+    virtual_project: &VirtualProject,
+) -> Result<()> {
+    let pin = Pin {
+        request,
+        version,
+        resolved,
+        existing,
+    };
+    let (requires_python, project_type) = match virtual_project {
+        VirtualProject::Project(..) => (project_requires_python(virtual_project)?, "project"),
+        VirtualProject::NonProject(..) => (project_requires_python(virtual_project)?, "workspace"),
+    };
+
+    let Some(requires_python) = requires_python else {
+        return Ok(());
+    };
+
+    if requires_python.contains(pin.version) {
+        return Ok(());
+    }
+
+    let given = if pin.existing { "pinned" } else { "requested" };
+    let resolved = if pin.resolved {
+        format!(" resolves to `{}` which ", pin.version)
+    } else {
+        String::new()
+    };
+
+    Err(anyhow::anyhow!(
+        "The {given} Python version `{}`{resolved} is incompatible with the {} `requires-python` value of `{}`.",
+        pin.request.to_canonical_string(),
+        project_type,
+        requires_python
+    ))
+}

--- a/crates/fyn/src/commands/status.rs
+++ b/crates/fyn/src/commands/status.rs
@@ -67,24 +67,27 @@ struct StatusReport {
     check: Option<StatusCheck>,
 }
 
-fn status_issues(
+#[derive(Clone, Copy)]
+struct StatusIssueInputs {
     managed_project: bool,
     pyproject_toml: bool,
     fyn_lock: bool,
     environment_found: bool,
-) -> Vec<String> {
+}
+
+fn status_issues(inputs: StatusIssueInputs) -> Vec<String> {
     let mut issues = Vec::new();
-    if !managed_project {
+    if !inputs.managed_project {
         issues.push("not inside a managed project".to_string());
         return issues;
     }
-    if !pyproject_toml {
+    if !inputs.pyproject_toml {
         issues.push("pyproject.toml not found in workspace root".to_string());
     }
-    if !fyn_lock {
+    if !inputs.fyn_lock {
         issues.push("fyn.lock not found in workspace root".to_string());
     }
-    if !environment_found {
+    if !inputs.environment_found {
         issues.push("environment not found".to_string());
     }
     issues
@@ -223,12 +226,12 @@ pub(crate) async fn status(
         None
     };
     let issues = if check {
-        let mut issues = status_issues(
+        let mut issues = status_issues(StatusIssueInputs {
             managed_project,
             pyproject_toml,
             fyn_lock,
-            environment.is_some(),
-        );
+            environment_found: environment.is_some(),
+        });
         issues.extend(
             python_pin_issues(
                 project_dir,

--- a/crates/fyn/src/commands/status.rs
+++ b/crates/fyn/src/commands/status.rs
@@ -2,15 +2,24 @@ use std::fmt::Write;
 use std::path::Path;
 
 use fyn_cache::Cache;
+use fyn_client::BaseClientBuilder;
 use fyn_fs::Simplified;
 use fyn_preview::Preview;
-use fyn_python::{EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest};
-use fyn_settings::{FilesystemOptions, PipInProjectPolicy};
-use fyn_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
+use fyn_python::downloads::ManagedPythonDownloadList;
+use fyn_python::{
+    EnvironmentPreference, PythonEnvironment, PythonPreference, PythonRequest, PythonVersionFile,
+    VersionFileDiscoveryOptions,
+};
+use fyn_settings::{FilesystemOptions, PipInProjectPolicy, PythonInstallMirrors};
+use fyn_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceCache};
 use owo_colors::OwoColorize;
 use serde::Serialize;
+use tracing::debug;
 
 use crate::commands::ExitStatus;
+use crate::commands::python::pin_compat::{
+    assert_pin_compatible_with_project, existing_pin_compatibility_issue,
+};
 use crate::printer::Printer;
 
 fn pip_in_project_policy(filesystem: Option<&FilesystemOptions>) -> PipInProjectPolicy {
@@ -58,7 +67,12 @@ struct StatusReport {
     check: Option<StatusCheck>,
 }
 
-fn status_issues(managed_project: bool, pyproject_toml: bool, fyn_lock: bool) -> Vec<String> {
+fn status_issues(
+    managed_project: bool,
+    pyproject_toml: bool,
+    fyn_lock: bool,
+    environment_found: bool,
+) -> Vec<String> {
     let mut issues = Vec::new();
     if !managed_project {
         issues.push("not inside a managed project".to_string());
@@ -70,7 +84,93 @@ fn status_issues(managed_project: bool, pyproject_toml: bool, fyn_lock: bool) ->
     if !fyn_lock {
         issues.push("fyn.lock not found in workspace root".to_string());
     }
+    if !environment_found {
+        issues.push("environment not found".to_string());
+    }
     issues
+}
+
+async fn python_pin_issues(
+    project_dir: &Path,
+    virtual_project: Option<&VirtualProject>,
+    python_preference: PythonPreference,
+    install_mirrors: &PythonInstallMirrors,
+    client_builder: &BaseClientBuilder<'_>,
+    cache: &Cache,
+    preview: Preview,
+) -> Vec<String> {
+    let Some(virtual_project) = virtual_project else {
+        return Vec::new();
+    };
+
+    let version_file =
+        match PythonVersionFile::discover(project_dir, &VersionFileDiscoveryOptions::default())
+            .await
+        {
+            Ok(version_file) => version_file,
+            Err(err) => {
+                debug!("Failed to discover Python version file: {err}");
+                return Vec::new();
+            }
+        };
+    let Some(version_file) = version_file else {
+        return Vec::new();
+    };
+
+    let pins: Vec<_> = version_file.versions().collect();
+    let download_list = if pins.is_empty() {
+        None
+    } else {
+        let client = match client_builder.clone().retries(0).build() {
+            Ok(client) => client,
+            Err(err) => {
+                debug!("Failed to create client for Python pin compatibility checks: {err}");
+                return Vec::new();
+            }
+        };
+        match ManagedPythonDownloadList::new(
+            &client,
+            install_mirrors.python_downloads_json_url.as_deref(),
+        )
+        .await
+        {
+            Ok(download_list) => Some(download_list),
+            Err(err) => {
+                debug!("Failed to load Python downloads metadata for status checks: {err}");
+                None
+            }
+        }
+    };
+
+    pins.into_iter()
+        .filter_map(|pin| {
+            download_list
+                .as_ref()
+                .and_then(|download_list| {
+                    existing_pin_compatibility_issue(
+                        pin,
+                        virtual_project,
+                        python_preference,
+                        download_list,
+                        cache,
+                        preview,
+                    )
+                })
+                .or_else(|| {
+                    pin.as_pep440_version().and_then(|pin_version| {
+                        assert_pin_compatible_with_project(
+                            pin,
+                            &pin_version,
+                            false,
+                            true,
+                            virtual_project,
+                        )
+                        .err()
+                        .map(|err| err.to_string())
+                    })
+                })
+        })
+        .collect()
 }
 
 /// Show the current project and environment status.
@@ -80,6 +180,8 @@ pub(crate) async fn status(
     project_dir: &Path,
     filesystem: Option<&FilesystemOptions>,
     python_preference: PythonPreference,
+    install_mirrors: &PythonInstallMirrors,
+    client_builder: &BaseClientBuilder<'_>,
     cache: &Cache,
     workspace_cache: &WorkspaceCache,
     printer: Printer,
@@ -107,8 +209,39 @@ pub(crate) async fn status(
         .map(|workspace| workspace.install_path().simplified_display().to_string());
     let pyproject_toml = root.join("pyproject.toml").is_file();
     let fyn_lock = root.join("fyn.lock").is_file();
+    let virtual_project = if check && managed_project {
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
+            .await
+        {
+            Ok(virtual_project) => Some(virtual_project),
+            Err(err) => {
+                debug!("Failed to discover virtual project for status checks: {err}");
+                None
+            }
+        }
+    } else {
+        None
+    };
     let issues = if check {
-        status_issues(managed_project, pyproject_toml, fyn_lock)
+        let mut issues = status_issues(
+            managed_project,
+            pyproject_toml,
+            fyn_lock,
+            environment.is_some(),
+        );
+        issues.extend(
+            python_pin_issues(
+                project_dir,
+                virtual_project.as_ref(),
+                python_preference,
+                install_mirrors,
+                client_builder,
+                cache,
+                preview,
+            )
+            .await,
+        );
+        issues
     } else {
         Vec::new()
     };

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -1527,12 +1527,20 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         }) => commands::cache_size(&cache, args.human, printer, globals.preview),
         Commands::Status(StatusArgs { check, json }) => {
             let cache = cache.init().await?;
+            let install_mirrors = environment.install_mirrors.clone().combine(
+                filesystem
+                    .as_ref()
+                    .map(|filesystem| filesystem.install_mirrors.clone())
+                    .unwrap_or_default(),
+            );
             commands::status(
                 check,
                 json,
                 &project_dir,
                 filesystem.as_ref(),
                 globals.python_preference,
+                &install_mirrors,
+                &client_builder,
                 &cache,
                 &workspace_cache,
                 printer,

--- a/crates/fyn/tests/it/status.rs
+++ b/crates/fyn/tests/it/status.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use assert_fs::prelude::*;
 
+use fyn_static::EnvVars;
 use fyn_test::fyn_snapshot;
 
 #[test]
@@ -278,4 +279,187 @@ fn status_json_check_in_unmanaged_directory() {
     ----- stderr -----
     "#
     );
+}
+
+#[test]
+fn status_check_compatible_python_pin() -> Result<()> {
+    let context = fyn_test::test_context!("3.11");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.11,<3.12"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+    context
+        .temp_dir
+        .child(".python-version")
+        .write_str("3.11")?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context.command().arg("status").arg("--check"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    current directory: [TEMP_DIR]/
+    project directory: [TEMP_DIR]/
+    managed project: yes
+    workspace root: [TEMP_DIR]/
+    pyproject.toml: yes
+    fyn.lock: yes
+    pip-in-project: warn
+    environment: [VENV]/
+    python: [VENV]/bin/python3 (3.11.[X])
+    check: ok
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn status_check_incompatible_python_pin() -> Result<()> {
+    let context = fyn_test::test_context!("3.11");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.11,<3.12"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+    context
+        .temp_dir
+        .child(".python-version")
+        .write_str("3.10")?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context.command().arg("status").arg("--check"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    current directory: [TEMP_DIR]/
+    project directory: [TEMP_DIR]/
+    managed project: yes
+    workspace root: [TEMP_DIR]/
+    pyproject.toml: yes
+    fyn.lock: yes
+    pip-in-project: warn
+    environment: [VENV]/
+    python: [VENV]/bin/python3 (3.11.[X])
+    check: failed
+    issue: The pinned Python version `3.10` is incompatible with the project `requires-python` value of `==3.11.*`.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn status_check_missing_environment() -> Result<()> {
+    let context = fyn_test::test_context_with_versions!(&[]);
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .command()
+            .env_remove(EnvVars::VIRTUAL_ENV)
+            .arg("status")
+            .arg("--check"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    current directory: [TEMP_DIR]/
+    project directory: [TEMP_DIR]/
+    managed project: yes
+    workspace root: [TEMP_DIR]/
+    pyproject.toml: yes
+    fyn.lock: yes
+    pip-in-project: warn
+    environment: not found
+    python: not found
+    check: failed
+    issue: environment not found
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn status_json_check_incompatible_python_pin() -> Result<()> {
+    let context = fyn_test::test_context!("3.11");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+        requires-python = ">=3.11,<3.12"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+    context
+        .temp_dir
+        .child(".python-version")
+        .write_str("3.10")?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context.command().arg("status").arg("--check").arg("--json"),
+        @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    {
+      "current_directory": "[TEMP_DIR]/",
+      "project_directory": "[TEMP_DIR]/",
+      "managed_project": true,
+      "workspace_root": "[TEMP_DIR]/",
+      "pyproject_toml": true,
+      "fyn_lock": true,
+      "pip_in_project": "warn",
+      "environment": {
+        "path": "[VENV]/",
+        "python": "[VENV]/bin/python3",
+        "version": "3.11.[X]"
+      },
+      "check": {
+        "passed": false,
+        "issues": [
+          "The pinned Python version `3.10` is incompatible with the project `requires-python` value of `==3.11.*`."
+        ]
+      }
+    }
+
+    ----- stderr -----
+    "#
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
 ## Summary
  - reuse Python pin compatibility checks in `status --check`
  - report incompatible `.python-version` pins in project status
  - report missing environments in `status --check`

## Testing
  - `cargo fmt --all`
  - `cargo test -p fyn --test it status`
  - `cargo test -p fyn --test it python_pin`