### PR TITLE
chore: drop whoami dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,6 @@ dependencies = [
  "uuid",
  "walkdir",
  "which",
- "whoami",
  "windows",
  "wiremock",
  "zip",
@@ -7448,15 +7447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
-dependencies = [
- "wasi 0.14.7+wasi-0.2.4",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7619,17 +7609,6 @@ checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
  "libc",
  "regex",
-]
-
-[[package]]
-name = "whoami"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
-dependencies = [
- "libredox",
- "wasite",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,7 +337,6 @@ test-log = { version = "0.2.16", features = [
   "trace",
 ], default-features = false }
 tokio-rustls = { version = "0.26.2", default-features = false }
-whoami = { version = "2.0.0" }
 
 [patch.crates-io]
 astral_async_http_range_reader = { path = "vendor/astral_async_http_range_reader" }

--- a/crates/fyn/Cargo.toml
+++ b/crates/fyn/Cargo.toml
@@ -152,7 +152,6 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
-whoami = { workspace = true }
 wiremock = { workspace = true }
 zip = { workspace = true }
 

--- a/crates/fyn/tests/it/export.rs
+++ b/crates/fyn/tests/it/export.rs
@@ -1373,7 +1373,7 @@ fn reduce_ssh_key_file_permissions(key_file: &Path) -> Result<()> {
         Command::new("icacls")
             .arg(key_file)
             .arg("/grant:r")
-            .arg(format!("{}:R", whoami::username()?))
+            .arg(format!("{}:R", std::env::var("USERNAME")?))
             .assert()
             .success();
     }


### PR DESCRIPTION
## Summary
  - replace the single `whoami` usage in the Windows export test helper with `%USERNAME%`
  - remove `whoami` from the workspace and `fyn` manifests
  - drop the dependency from `Cargo.lock`

## Testing
  - `cargo clippy -p fyn --lib --tests -- -D warnings`