### PR TITLE
feat: improve run missing-command diagnostics

### DIFF
--- a/crates/fyn/src/commands/project/run.rs
+++ b/crates/fyn/src/commands/project/run.rs
@@ -76,6 +76,54 @@ use crate::commands::{ExitStatus, diagnostics, project};
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverInstallerSettings, ResolverSettings};
 
+fn command_not_found_hints(
+    command: &RunCommand,
+    project_dir: &Path,
+    no_project: bool,
+) -> Vec<String> {
+    let RunCommand::External(executable, _) = command else {
+        return Vec::new();
+    };
+
+    let executable = executable.to_string_lossy();
+    let is_path_like = executable.contains(std::path::MAIN_SEPARATOR) || executable.contains('/');
+    if is_path_like {
+        return vec![
+            "Check that the requested path exists relative to the current directory.".to_string(),
+        ];
+    }
+
+    let mut hints = Vec::new();
+    if !no_project && lookup_tasks(project_dir).is_some() {
+        hints.push(
+            "If you meant to run a task, use `fyn run --list-tasks` to inspect available tasks."
+                .to_string(),
+        );
+    }
+    hints.push(format!(
+        "If `{}` is provided by a Python package, try `{}`.",
+        executable.cyan(),
+        format!("fyn tool run {executable}").green(),
+    ));
+    hints
+}
+
+fn command_not_found_error(
+    command: &RunCommand,
+    err: &io::Error,
+    project_dir: &Path,
+    no_project: bool,
+) -> anyhow::Error {
+    let mut message = format!(
+        "Failed to spawn: `{}`\n  Caused by: {err}",
+        command.display_executable()
+    );
+    for hint in command_not_found_hints(command, project_dir, no_project) {
+        let _ = write!(message, "\n\nhint: {hint}");
+    }
+    anyhow!(message)
+}
+
 /// Run a command.
 #[expect(clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -1290,10 +1338,21 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
-    // TODO(zanieb): Throw a nicer error message if the command is not found
-    let handle = process
-        .spawn()
-        .with_context(|| format!("Failed to spawn: `{}`", command.display_executable()))?;
+    let handle = match process.spawn() {
+        Ok(handle) => handle,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Err(command_not_found_error(
+                &command,
+                &err,
+                project_dir,
+                no_project,
+            ));
+        }
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("Failed to spawn: `{}`", command.display_executable()));
+        }
+    };
 
     run_to_completion(handle).await
 }

--- a/crates/fyn/tests/it/run.rs
+++ b/crates/fyn/tests/it/run.rs
@@ -3248,6 +3248,8 @@ fn run_from_directory() -> Result<()> {
      + foo==1.0.0 (from file://[TEMP_DIR]/project)
     error: Failed to spawn: `./project/main.py`
       Caused by: [OS ERROR 2]
+
+    hint: Check that the requested path exists relative to the current directory.
     ");
 
     // Even if we write a `.python-version` file in the current directory, we should prefer the
@@ -4163,6 +4165,48 @@ fn run_script_without_build_system() -> Result<()> {
     Checked in [TIME]
     error: Failed to spawn: `entry`
       Caused by: No such file or directory (os error 2)
+
+    hint: If `entry` is provided by a Python package, try `fyn tool run entry`.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn run_missing_command_with_tasks_shows_task_hint() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        test = "pytest -xvs"
+        lint = "ruff check ."
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("tesst"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    error: Failed to spawn: `tesst`
+      Caused by: No such file or directory (os error 2)
+
+    hint: If you meant to run a task, use `fyn run --list-tasks` to inspect available tasks.
+
+    hint: If `tesst` is provided by a Python package, try `fyn tool run tesst`.
     ");
 
     Ok(())


### PR DESCRIPTION
## Summary
  - improve `fyn run` diagnostics
  - suggest `fyn run --list-tasks` when the project defines tasks and the requested command may be a mistyped task
  - suggest `fyn tool run <command>` for bare executables
  - add a path-specific hint for missing path-like commands such as `./script`

## Testing
  - `cargo fmt --all`
  - `cargo clippy -p fyn --lib --tests -- -D warnings`
  - `cargo test -p fyn --test it 'run::run_missing_command_with_tasks_shows_task_hint' --
  --exact`
  - `cargo test -p fyn --test it 'run::run_script_without_build_system' -- --exact`
  - `cargo test -p fyn --test it 'run::run_script_explicit_directory' -- --exact`