### PR TITLE
fix: redact pre-signed upload URLs in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Task `env` values are applied to the spawned command. For chained tasks, parent 
 inherited by child tasks, and child task values take precedence. Extra arguments are supported for
 `cmd` tasks, but not for chained tasks.
 
+If `fyn run` cannot spawn a command, it tries to point you at the next step instead of stopping at a
+raw OS error: `fyn run --list-tasks` for likely task typos, `fyn tool run <command>` for missing
+Python-provided executables, or a path-specific hint for missing `./script`-style commands.
+
 ### Shell activation
 
 Activate the project's virtual environment in a new shell:
@@ -182,7 +186,16 @@ python: /home/user/example/.venv/bin/python3 (3.12.0)
 ```
 
 Use `--check` to fail when obvious project checks do not pass, or `--json` for scripting and editor
-integrations.
+integrations. In managed projects, `--check` also reports missing environments and `.python-version`
+pins that do not satisfy `requires-python`, and prints `hint:` lines with the suggested fix.
+
+```console
+$ fyn status --check
+...
+check: failed
+issue: environment not found
+hint: Run `fyn sync` or `fyn venv` to create the project environment.
+```
 
 ### PyTorch backend diagnosis
 
@@ -277,6 +290,9 @@ Use a specific Python version in the current directory:
 $ fyn python pin 3.11
 Pinned `.python-version` to `3.11`
 ```
+
+Use `--python-downloads-json-url <source>` when you need `fyn python pin` to resolve against a
+custom Python downloads manifest instead of the default bundled metadata.
 
 ### The pip interface
 

--- a/crates/fyn-redacted/src/lib.rs
+++ b/crates/fyn-redacted/src/lib.rs
@@ -7,6 +7,12 @@ use std::str::FromStr;
 use thiserror::Error;
 use url::Url;
 
+const SENSITIVE_QUERY_PARAMETERS: &[&str] = &[
+    "X-Amz-Credential",
+    "X-Amz-Security-Token",
+    "X-Amz-Signature",
+];
+
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum DisplaySafeUrlError {
     /// Failed to parse a URL.
@@ -19,7 +25,7 @@ pub enum DisplaySafeUrlError {
     AmbiguousAuthority(String),
 }
 
-/// A [`Url`] wrapper that redacts credentials when displaying the URL.
+/// A [`Url`] wrapper that redacts credentials and sensitive query parameters when displaying the URL.
 ///
 /// `DisplaySafeUrl` wraps the standard [`url::Url`] type, providing functionality to mask
 /// secrets by default when the URL is displayed or logged. This helps prevent accidental
@@ -246,7 +252,8 @@ impl Display for DisplaySafeUrl {
 
 impl Debug for DisplaySafeUrl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let url = &self.0;
+        let url = url_with_redacted_sensitive_query_values(&self.0);
+        let url = url.as_ref();
         // For URLs that use the `git` convention (i.e., `ssh://git@github.com/...`), avoid masking the
         // username.
         let (username, password) = if is_ssh_git_username(url) {
@@ -301,17 +308,46 @@ fn is_ssh_git_username(url: &Url) -> bool {
         && url.password().is_none()
 }
 
+fn is_sensitive_query_parameter(key: &str) -> bool {
+    SENSITIVE_QUERY_PARAMETERS
+        .iter()
+        .any(|sensitive| key.eq_ignore_ascii_case(sensitive))
+}
+
+fn url_with_redacted_sensitive_query_values(url: &Url) -> Cow<'_, Url> {
+    if !url
+        .query_pairs()
+        .any(|(key, _value)| is_sensitive_query_parameter(&key))
+    {
+        return Cow::Borrowed(url);
+    }
+
+    let query_pairs: Vec<_> = url
+        .query_pairs()
+        .map(|(key, value)| {
+            let value = if is_sensitive_query_parameter(&key) {
+                Cow::Borrowed("****")
+            } else {
+                value
+            };
+            (key, value)
+        })
+        .collect();
+
+    let mut url = url.clone();
+    url.query_pairs_mut().clear().extend_pairs(query_pairs);
+    Cow::Owned(url)
+}
+
 fn display_with_redacted_credentials(
     url: &Url,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
-    if url.password().is_none() && url.username() == "" {
-        return write!(f, "{url}");
-    }
-
+    let url = url_with_redacted_sensitive_query_values(url);
+    let url = url.as_ref();
     // For URLs that use the `git` convention (i.e., `ssh://git@github.com/...`), avoid dropping the
     // username.
-    if is_ssh_git_username(url) {
+    if is_ssh_git_username(url) || (url.username().is_empty() && url.password().is_none()) {
         return write!(f, "{url}");
     }
 
@@ -458,6 +494,69 @@ mod tests {
         assert_eq!(
             log_safe_url.displayable_with_credentials().to_string(),
             url_str
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=credential&X-Amz-Date=20260424T120000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=signature&X-Amz-Security-Token=token",
+        )
+        .unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=****&X-Amz-Date=20260424T120000Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host&X-Amz-Signature=****&X-Amz-Security-Token=****"
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values_case_insensitive() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?x-amz-credential=credential&x-amz-signature=signature&x-amz-security-token=token",
+        )
+        .unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?x-amz-credential=****&x-amz-signature=****&x-amz-security-token=****"
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values_with_percent_encoded_keys() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz%2DSignature=signature&safe=value",
+        )
+        .unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Signature=****&safe=value"
+        );
+    }
+
+    #[test]
+    fn redact_aws_presigned_query_values_in_debug() {
+        let log_safe_url = DisplaySafeUrl::parse(
+            "https://bucket.s3.amazonaws.com/dist.whl?X-Amz-Credential=credential&X-Amz-Signature=signature",
+        )
+        .unwrap();
+
+        let debug = format!("{log_safe_url:?}");
+        assert!(debug.contains(r#"query: Some("X-Amz-Credential=****&X-Amz-Signature=****")"#));
+        assert!(!debug.contains("credential"));
+        assert!(!debug.contains("signature"));
+    }
+
+    #[test]
+    fn does_not_redact_unknown_query_values() {
+        let log_safe_url =
+            DisplaySafeUrl::parse("https://bucket.s3.amazonaws.com/dist.whl?token=secret").unwrap();
+
+        assert_eq!(
+            log_safe_url.to_string(),
+            "https://bucket.s3.amazonaws.com/dist.whl?token=secret"
         );
     }
 

--- a/crates/fyn/src/commands/project/run.rs
+++ b/crates/fyn/src/commands/project/run.rs
@@ -76,6 +76,54 @@ use crate::commands::{ExitStatus, diagnostics, project};
 use crate::printer::Printer;
 use crate::settings::{FrozenSource, LockCheck, ResolverInstallerSettings, ResolverSettings};
 
+fn command_not_found_hints(
+    command: &RunCommand,
+    project_dir: &Path,
+    no_project: bool,
+) -> Vec<String> {
+    let RunCommand::External(executable, _) = command else {
+        return Vec::new();
+    };
+
+    let executable = executable.to_string_lossy();
+    let is_path_like = executable.contains(std::path::MAIN_SEPARATOR) || executable.contains('/');
+    if is_path_like {
+        return vec![
+            "Check that the requested path exists relative to the current directory.".to_string(),
+        ];
+    }
+
+    let mut hints = Vec::new();
+    if !no_project && lookup_tasks(project_dir).is_some() {
+        hints.push(
+            "If you meant to run a task, use `fyn run --list-tasks` to inspect available tasks."
+                .to_string(),
+        );
+    }
+    hints.push(format!(
+        "If `{}` is provided by a Python package, try `{}`.",
+        executable.cyan(),
+        format!("fyn tool run {executable}").green(),
+    ));
+    hints
+}
+
+fn command_not_found_error(
+    command: &RunCommand,
+    err: &io::Error,
+    project_dir: &Path,
+    no_project: bool,
+) -> anyhow::Error {
+    let mut message = format!(
+        "Failed to spawn: `{}`\n  Caused by: {err}",
+        command.display_executable()
+    );
+    for hint in command_not_found_hints(command, project_dir, no_project) {
+        let _ = write!(message, "\n\nhint: {hint}");
+    }
+    anyhow!(message)
+}
+
 /// Run a command.
 #[expect(clippy::fn_params_excessive_bools)]
 pub(crate) async fn run(
@@ -1290,10 +1338,21 @@ hint: If you are running a script with `{}` in the shebang, you may need to incl
 
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
-    // TODO(zanieb): Throw a nicer error message if the command is not found
-    let handle = process
-        .spawn()
-        .with_context(|| format!("Failed to spawn: `{}`", command.display_executable()))?;
+    let handle = match process.spawn() {
+        Ok(handle) => handle,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Err(command_not_found_error(
+                &command,
+                &err,
+                project_dir,
+                no_project,
+            ));
+        }
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("Failed to spawn: `{}`", command.display_executable()));
+        }
+    };
 
     run_to_completion(handle).await
 }

--- a/crates/fyn/tests/it/publish.rs
+++ b/crates/fyn/tests/it/publish.rs
@@ -613,6 +613,66 @@ async fn gitlab_trusted_publishing_testpypi_id_token() {
     );
 }
 
+#[tokio::test]
+async fn direct_publish_redacts_presigned_upload_url() {
+    let context = fyn_test::test_context!("3.12");
+    let server = MockServer::start().await;
+
+    let upload_url = format!(
+        "{}/s3/ok-1.0.0-py3-none-any.whl?X-Amz-Credential=credential&X-Amz-Signature=signature&X-Amz-Security-Token=token",
+        server.uri()
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/upload/reserve"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "upload_url": upload_url,
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/s3/ok-1.0.0-py3-none-any.whl"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/upload/finalize"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    fyn_snapshot!(context.filters(), context.publish()
+        .arg("--preview-features")
+        .arg("direct-publish")
+        .arg("--direct")
+        .arg("-u")
+        .arg("dummy")
+        .arg("-p")
+        .arg("dummy")
+        .arg("--publish-url")
+        .arg(format!("{}/upload", server.uri()))
+        .arg(dummy_wheel())
+        .env(EnvVars::RUST_LOG, "fyn_publish=debug"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Publishing 1 file to http://[LOCALHOST]/upload
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    DEBUG Hashing [WORKSPACE]/test/links/ok-1.0.0-py3-none-any.whl
+    DEBUG Reserving upload slot at http://[LOCALHOST]/upload/reserve
+    DEBUG Using HTTP Basic authentication
+    DEBUG Got pre-signed URL for upload: http://[LOCALHOST]/s3/ok-1.0.0-py3-none-any.whl?X-Amz-Credential=****&X-Amz-Signature=****&X-Amz-Security-Token=****
+    DEBUG S3 upload complete for ok-1.0.0-py3-none-any.whl
+    DEBUG Finalizing upload at http://[LOCALHOST]/upload/finalize
+    DEBUG Using HTTP Basic authentication
+    DEBUG Response code for http://[LOCALHOST]/upload/finalize: 200 OK
+    DEBUG Upload finalized for ok-1.0.0-py3-none-any.whl
+    "
+    );
+}
+
 /// PyPI returns `application/json` errors with a `code` field.
 #[tokio::test]
 async fn upload_error_pypi_json() {

--- a/crates/fyn/tests/it/run.rs
+++ b/crates/fyn/tests/it/run.rs
@@ -3248,6 +3248,8 @@ fn run_from_directory() -> Result<()> {
      + foo==1.0.0 (from file://[TEMP_DIR]/project)
     error: Failed to spawn: `./project/main.py`
       Caused by: [OS ERROR 2]
+
+    hint: Check that the requested path exists relative to the current directory.
     ");
 
     // Even if we write a `.python-version` file in the current directory, we should prefer the
@@ -4163,6 +4165,48 @@ fn run_script_without_build_system() -> Result<()> {
     Checked in [TIME]
     error: Failed to spawn: `entry`
       Caused by: No such file or directory (os error 2)
+
+    hint: If `entry` is provided by a Python package, try `fyn tool run entry`.
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn run_missing_command_with_tasks_shows_task_hint() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.8"
+        dependencies = []
+
+        [tool.fyn]
+        package = false
+
+        [tool.fyn.tasks]
+        test = "pytest -xvs"
+        lint = "ruff check ."
+        "#
+    })?;
+
+    fyn_snapshot!(context.filters(), context.run().arg("tesst"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Checked in [TIME]
+    error: Failed to spawn: `tesst`
+      Caused by: No such file or directory (os error 2)
+
+    hint: If you meant to run a task, use `fyn run --list-tasks` to inspect available tasks.
+
+    hint: If `tesst` is provided by a Python package, try `fyn tool run tesst`.
     ");
 
     Ok(())

--- a/docs/concepts/projects/run.md
+++ b/docs/concepts/projects/run.md
@@ -58,6 +58,28 @@ $ fyn run test -- -k my_test
 Additional CLI arguments are not supported for chained tasks; run the child task directly when you
 need to pass extra arguments.
 
+## Missing commands
+
+If task resolution succeeds but the external command still cannot be spawned, fyn augments the error
+with the most likely next step instead of only showing the raw OS error.
+
+- For projects with tasks, a missing bare command suggests `fyn run --list-tasks`.
+- For bare executables that may come from Python packages, it suggests `fyn tool run <command>`.
+- For path-like commands such as `./script`, it reminds you to check that the path exists relative
+  to the current directory.
+
+For example:
+
+```console
+$ fyn run tesst
+error: Failed to spawn: `tesst`
+  Caused by: No such file or directory (os error 2)
+
+hint: If you meant to run a task, use `fyn run --list-tasks` to inspect available tasks.
+
+hint: If `tesst` is provided by a Python package, try `fyn tool run tesst`.
+```
+
 ## Requesting additional dependencies
 
 Additional dependencies or different versions of dependencies can be requested per invocation.

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -61,6 +61,10 @@ used, though use of a version number is recommended for interoperability with ot
 A `.python-version` file can be created in the current directory with the
 [`fyn python pin`](../reference/cli.md/#fyn-python-pin) command.
 
+When resolving pins against custom managed Python metadata, `fyn python pin` accepts
+`--python-downloads-json-url <source>` and uses that catalog instead of the default bundled
+downloads list.
+
 A discovered Python pin can be upgraded to the latest compatible exact version with
 [`fyn python pin --upgrade`](../reference/cli.md/#fyn-python-pin). If a project or workspace is
 found, the upgraded version must still satisfy its `requires-python` constraint.

--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -12,7 +12,8 @@ Installing and managing Python itself.
 - `fyn python install`: Install Python versions.
 - `fyn python list`: View available Python versions.
 - `fyn python find`: Find an installed Python version.
-- `fyn python pin`: Pin the current project to use a specific Python version.
+- `fyn python pin`: Pin the current project to use a specific Python version, including custom
+  download catalogs via `--python-downloads-json-url`.
 - `fyn python uninstall`: Uninstall a Python version.
 
 See the [guide on installing Python](../guides/install-python.md) to get started.
@@ -37,9 +38,11 @@ Creating and working on Python projects, i.e., with a `pyproject.toml`.
 - `fyn sync`: Sync the project's dependencies with the environment.
 - `fyn lock`: Create a lockfile for the project's dependencies.
 - `fyn upgrade`: Upgrade all or selected project dependencies.
-- `fyn run`: Run a command in the project environment.
+- `fyn run`: Run a command in the project environment, with task- and tool-aware missing-command
+  hints.
 - `fyn shell`: Open a shell with the project environment activated.
-- `fyn status`: Inspect the current project and environment state.
+- `fyn status`: Inspect the current project and environment state, and surface actionable health
+  checks.
 - `fyn tree`: View the dependency tree for the project.
 - `fyn build`: Build the project into distribution archives.
 - `fyn publish`: Publish the project to a package index.

--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -89,6 +89,9 @@ $ fyn python list
 See the [`python list`](../concepts/python-versions.md#viewing-available-python-versions)
 documentation for more details.
 
+If you maintain your own catalog of downloadable Python builds, `fyn python install`, `find`,
+`list`, `upgrade`, and `pin` accept `--python-downloads-json-url <source>`.
+
 ## Automatic Python downloads
 
 Python does not need to be explicitly installed to use fyn. By default, fyn will automatically

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -199,10 +199,17 @@ For automation, use `--check` to fail when obvious project checks do not pass:
 
 ```console
 $ fyn status --check
+...
+check: failed
+issue: environment not found
+hint: Run `fyn sync` or `fyn venv` to create the project environment.
 ```
 
-Today, `--check` reports failure if you are not inside a managed project. When you are inside a
-managed project, it also fails if `pyproject.toml` or `fyn.lock` is missing from the workspace root.
+`--check` fails if you are not inside a managed project. In managed projects, it also fails if
+`pyproject.toml`, `fyn.lock`, or the project environment is missing, or if the discovered
+`.python-version` pin does not satisfy the project's `requires-python`. Text output includes
+`issue:` and `hint:` lines, while `--json` exposes the same data via `check.issues` and
+`check.hints`.
 
 For editor integrations, scripts, or CI tooling, use JSON output:
 
@@ -337,6 +344,10 @@ print("hello world")
 ```console
 $ fyn run example.py
 ```
+
+If `fyn run` cannot spawn the requested command, it prints a targeted hint instead of only the raw
+OS error. Depending on the command, that may mean suggesting `fyn run --list-tasks`,
+`fyn tool run <command>`, or checking that a relative path like `./script` exists.
 
 Alternatively, you can use `fyn sync` to manually update the environment and then either activate it
 yourself or open an activated shell with `fyn shell` before executing commands directly:

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,6 +102,10 @@ environment: /home/user/example/.venv
 python: /home/user/example/.venv/bin/python3 (3.12.0)
 ```
 
+Use `fyn status --check` to fail fast in CI or editor integrations. In managed projects, it also
+reports missing environments and `.python-version` pins that do not satisfy `requires-python`, and
+prints matching `hint:` lines with the next command to run.
+
 Use `fyn upgrade` to refresh all dependencies or only the packages you name:
 
 ```console
@@ -231,6 +235,9 @@ Use a specific Python version in the current directory:
 $ fyn python pin 3.11
 Pinned `.python-version` to `3.11`
 ```
+
+Use `--python-downloads-json-url <source>` when you need `fyn python pin` to resolve against a
+custom Python downloads manifest instead of the default bundled metadata.
 
 See the [installing Python guide](./guides/install-python.md) to get started.
 


### PR DESCRIPTION
Port upstream uv’s pre-signed upload URL redaction for fyn.

This updates `DisplaySafeUrl` to redact sensitive AWS-style query parameters in log-safe URL output:

  - `X-Amz-Credential`
  - `X-Amz-Signature`
  - `X-Amz-Security-Token`

Applies to both `Display` and `Debug`, including verbose direct-publish logs.

## Test Plan

  - `cargo fmt`
  - `cargo test -p fyn-redacted`
  - `cargo test -p fyn --test it direct_publish_redacts_presigned_upload_url`
  - `git diff --check`