### PR TITLE
fix: configure logging before globals

### DIFF
--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -61,7 +61,7 @@ use crate::settings::{
     CacheSettings, GlobalSettings, PipCheckSettings, PipCompileSettings, PipDownloadSettings,
     PipFreezeSettings, PipIndexVersionsSettings, PipInstallSettings, PipListSettings,
     PipShowSettings, PipSyncSettings, PipUninstallSettings, PipUpgradeSettings, PipWheelSettings,
-    PublishSettings,
+    PublishSettings, resolve_color,
 };
 
 pub(crate) mod child;
@@ -92,6 +92,27 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         std::env::set_current_dir(directory)?;
     }
 
+    // Load environment variables not handled by Clap.
+    let environment = EnvironmentOptions::new()?;
+
+    // Configure the `tracing` crate, which controls internal logging.
+    #[cfg(feature = "tracing-durations-export")]
+    let (durations_layer, _duration_guard) =
+        logging::setup_durations(environment.tracing_durations_file.as_ref())?;
+    #[cfg(not(feature = "tracing-durations-export"))]
+    let durations_layer = None::<tracing_subscriber::layer::Identity>;
+    logging::setup_logging(
+        match cli.top_level.global_args.verbose {
+            0 => logging::Level::Off,
+            1 => logging::Level::DebugUv,
+            2 => logging::Level::TraceUv,
+            3.. => logging::Level::TraceAll,
+        },
+        durations_layer,
+        resolve_color(&cli.top_level.global_args),
+        environment.log_context.unwrap_or_default(),
+    )?;
+
     // Determine the project directory.
     //
     // If `--project` points to a `pyproject.toml` file, resolve to its parent directory,
@@ -114,9 +135,6 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         })
         .map(Cow::Owned)
         .unwrap_or_else(|| Cow::Borrowed(&*CWD));
-
-    // Load environment variables not handled by Clap
-    let environment = EnvironmentOptions::new()?;
 
     // Validate that the project directory exists if explicitly provided via --project, except for
     // `fyn init`, which creates the project directory (separate deprecation).
@@ -431,24 +449,6 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
     // Set the global flags.
     fyn_flags::init(EnvironmentFlags::from(&environment))
         .map_err(|()| anyhow::anyhow!("Flags are already initialized"))?;
-
-    // Configure the `tracing` crate, which controls internal logging.
-    #[cfg(feature = "tracing-durations-export")]
-    let (durations_layer, _duration_guard) =
-        logging::setup_durations(environment.tracing_durations_file.as_ref())?;
-    #[cfg(not(feature = "tracing-durations-export"))]
-    let durations_layer = None::<tracing_subscriber::layer::Identity>;
-    logging::setup_logging(
-        match globals.verbose {
-            0 => logging::Level::Off,
-            1 => logging::Level::DebugUv,
-            2 => logging::Level::TraceUv,
-            3.. => logging::Level::TraceAll,
-        },
-        durations_layer,
-        globals.color,
-        environment.log_context.unwrap_or_default(),
-    )?;
 
     debug!("fyn {}", fyn_cli::version::fyn_self_version());
     if let Some(config_file) = cli.top_level.config_file.as_ref() {

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -97,35 +97,13 @@ impl GlobalSettings {
     ) -> Self {
         let network_settings = NetworkSettings::resolve(args, workspace, environment);
         let python_preference = resolve_python_preference(args, workspace, environment);
+        let color = resolve_color(args);
         Self {
             required_version: workspace
                 .and_then(|workspace| workspace.globals.required_version.clone()),
             quiet: args.quiet,
             verbose: args.verbose,
-            color: if let Some(color_choice) = args.color {
-                // If `--color` is passed explicitly, use its value.
-                color_choice
-            } else if args.no_color {
-                // If `--no-color` is passed explicitly, disable color output.
-                ColorChoice::Never
-            } else if std::env::var_os(EnvVars::NO_COLOR)
-                .filter(|v| !v.is_empty())
-                .is_some()
-            {
-                // If the `NO_COLOR` is set, disable color output.
-                ColorChoice::Never
-            } else if std::env::var_os(EnvVars::FORCE_COLOR)
-                .filter(|v| !v.is_empty())
-                .is_some()
-                || std::env::var_os(EnvVars::CLICOLOR_FORCE)
-                    .filter(|v| !v.is_empty())
-                    .is_some()
-            {
-                // If `FORCE_COLOR` or `CLICOLOR_FORCE` is set, always enable color output.
-                ColorChoice::Always
-            } else {
-                ColorChoice::Auto
-            },
+            color,
             network_settings,
             concurrency: Concurrency::new(
                 environment
@@ -175,6 +153,34 @@ impl GlobalSettings {
             )
             .is_enabled(),
         }
+    }
+}
+
+/// Resolve the color choice from CLI arguments and environment variables.
+pub(crate) fn resolve_color(args: &GlobalArgs) -> ColorChoice {
+    if let Some(color_choice) = args.color {
+        // If `--color` is passed explicitly, use its value.
+        color_choice
+    } else if args.no_color {
+        // If `--no-color` is passed explicitly, disable color output.
+        ColorChoice::Never
+    } else if std::env::var_os(EnvVars::NO_COLOR)
+        .filter(|v| !v.is_empty())
+        .is_some()
+    {
+        // If the `NO_COLOR` is set, disable color output.
+        ColorChoice::Never
+    } else if std::env::var_os(EnvVars::FORCE_COLOR)
+        .filter(|v| !v.is_empty())
+        .is_some()
+        || std::env::var_os(EnvVars::CLICOLOR_FORCE)
+            .filter(|v| !v.is_empty())
+            .is_some()
+    {
+        // If `FORCE_COLOR` or `CLICOLOR_FORCE` is set, always enable color output.
+        ColorChoice::Always
+    } else {
+        ColorChoice::Auto
     }
 }
 

--- a/crates/fyn/tests/it/cache_clean.rs
+++ b/crates/fyn/tests/it/cache_clean.rs
@@ -28,6 +28,7 @@ fn clean_all() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed [N] files ([SIZE])
@@ -60,6 +61,7 @@ fn clear_all_alias() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed [N] files ([SIZE])
@@ -89,6 +91,7 @@ async fn clean_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed [N] files ([SIZE])
@@ -111,6 +114,7 @@ async fn clean_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     DEBUG Lock is busy for `[CACHE_DIR]/`
     DEBUG Cache is currently in use, proceeding due to `--force`
@@ -167,6 +171,7 @@ fn clean_package_pypi() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     DEBUG Removing dangling cache entry: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
@@ -185,6 +190,7 @@ fn clean_package_pypi() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
@@ -242,6 +248,7 @@ fn clean_package_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     DEBUG Removing dangling cache entry: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed [N] files ([SIZE])
@@ -308,6 +315,7 @@ fn clean_handles_verbatim_paths() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
     Removed 2 files

--- a/crates/fyn/tests/it/cache_prune.rs
+++ b/crates/fyn/tests/it/cache_prune.rs
@@ -34,6 +34,7 @@ fn prune_no_op() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
@@ -73,6 +74,7 @@ fn prune_stale_directory() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache bucket: [CACHE_DIR]/simple-v4
@@ -133,6 +135,7 @@ fn prune_cached_env() {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache environment: [CACHE_DIR]/environments-v2/[ENTRY]
@@ -178,6 +181,7 @@ fn prune_stale_symlink() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache archive: [CACHE_DIR]/archive-v0/[ENTRY]
@@ -208,6 +212,7 @@ async fn prune_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
@@ -227,6 +232,7 @@ async fn prune_force() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     DEBUG Lock is busy for `[CACHE_DIR]/`
     DEBUG Cache is currently in use, proceeding due to `--force`
@@ -417,6 +423,10 @@ fn prune_stale_revision() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    DEBUG Adding root workspace member: `[TEMP_DIR]/`
+    DEBUG Skipping `pyproject.toml` in `[TEMP_DIR]/` (no `[tool]` section)
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling source revision: [CACHE_DIR]/sdists-v9/[ENTRY]

--- a/crates/fyn/tests/it/lock.rs
+++ b/crates/fyn/tests/it/lock.rs
@@ -19401,6 +19401,10 @@ fn lock_explicit_default_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG Found workspace root: `[TEMP_DIR]/`
+    DEBUG Adding root workspace member: `[TEMP_DIR]/`
+    DEBUG Found workspace configuration at `[TEMP_DIR]/pyproject.toml`
+    DEBUG Searching for user configuration in: `[UV_USER_CONFIG_DIR]/fyn.toml`
     DEBUG fyn [VERSION] ([COMMIT] DATE)
     DEBUG Found workspace root: `[TEMP_DIR]/`
     DEBUG No Python version file found in workspace: [TEMP_DIR]/
@@ -19412,7 +19416,7 @@ fn lock_explicit_default_index() -> Result<()> {
     DEBUG No workspace root found, using project root
     DEBUG Resolving despite existing lockfile due to mismatched requirements for: `project==0.1.0`
       Requested: {Requirement { name: PackageName("anyio"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([]), index: None, conflict: None }, origin: None }}
-      Existing: {Requirement { name: PackageName("iniconfig"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([VersionSpecifier { operator: Equal, version: "2.0.0" }]), index: Some(IndexMetadata { url: Url(VerbatimUrl { url: DisplaySafeUrl { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("test.pypi.org")), port: None, path: "/simple", query: None, fragment: None }, given: None }), format: Simple }), conflict: None }, origin: None }}
+      Existing: {Requirement { name: PackageName("iniconfig"), extras: [], groups: [], marker: true, source: Registry { specifier: VersionSpecifiers([VersionSpecifier { operator: Equal, version: "2.0.0" }]), index: Some(IndexMetadata { url: Url(VerbatimUrl { url: DisplaySafeUrl { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("test.pypi.org")), port: None, path: "/simple", query: None, fragment: None }, given: None, expanded: false }), format: Simple }), conflict: None }, origin: None }}
     DEBUG Solving with installed Python version: 3.12.[X]
     DEBUG Solving with target Python version: >=3.12
     DEBUG Solving with exclude-newer: global: 2024-03-25T00:00:00Z


### PR DESCRIPTION
## Summary

  - configure tracing/logging before project, workspace, and config discovery
  - extract `resolve_color` so early logging uses the same CLI/env color handling as resolved global settings
  - update verbose snapshot expectations for newly visible config discovery logs

  ## Tests

  - `cargo fmt`
  - `cargo check -p fyn`
  - `cargo test -p fyn --features test-python,test-pypi cache_clean::clean_all`
  - `cargo test -p fyn --features test-python,test-pypi cache_clean::`
  - `cargo test -p fyn --features test-python,test-pypi cache_prune::`
  - `cargo test -p fyn --features test-python,test-pypi lock::lock_explicit_default_index`
  - `git diff --check`