### PR TITLE
test: guard fyn-build compatibility versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,6 +2043,7 @@ dependencies = [
  "fyn-platform-tags",
  "fyn-preview",
  "fyn-pypi-types",
+ "fyn-version",
  "fyn-warnings",
  "globset",
  "indexmap",

--- a/crates/fyn-build-backend/Cargo.toml
+++ b/crates/fyn-build-backend/Cargo.toml
@@ -24,6 +24,7 @@ fyn-pep508 = { workspace = true }
 fyn-platform-tags = { workspace = true }
 fyn-preview = { workspace = true }
 fyn-pypi-types = { workspace = true }
+fyn-version = { workspace = true }
 fyn-warnings = { workspace = true }
 
 base64 = { workspace = true }

--- a/crates/fyn-build-backend/src/metadata.rs
+++ b/crates/fyn-build-backend/src/metadata.rs
@@ -1857,4 +1857,29 @@ mod tests {
             @"`fyn-build>=0.5.0, <0.6` is not a known compatible range"
         );
     }
+
+    #[test]
+    fn update_compatibility_for_breaking_release() {
+        // Handle the case where we made a breaking change to the build backend.
+        // Feel free to update the heuristic if it doesn't suit the current compatibility rules
+        // anymore.
+        if COMPATIBLE_VERSIONS.is_empty() {
+            return;
+        }
+
+        let current_version = Version::from_str(fyn_version::version()).unwrap();
+        // Versions are ordered from oldest to latest.
+        let last_compatible =
+            Version::from_str(COMPATIBLE_VERSIONS[COMPATIBLE_VERSIONS.len() - 1]).unwrap();
+        if last_compatible.release()[0] != current_version.release()[0]
+            && last_compatible.release()[0] != current_version.release()[1]
+        {
+            panic!(
+                "Please update the list of compatible versions for the fyn build backend: \
+                If there was no breaking change in fyn-build, add the last release before the \
+                breaking release to `COMPATIBLE_VERSIONS`, otherwise reset `COMPATIBLE_VERSIONS` \
+                to an empty list"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

  - add `fyn-version` to `fyn-build-backend`
  - add a test guard for missed `COMPATIBLE_VERSIONS` updates across build-backend breaking releases

  ## Tests

  - `cargo fmt`
  - `cargo test -p fyn-build-backend update_compatibility_for_breaking_release`
  - `cargo test -p fyn-build-backend`
  - `git diff --check`