### PR TITLE
fix: backport critical uv fixes

### DIFF
--- a/crates/fyn-auth/src/index.rs
+++ b/crates/fyn-auth/src/index.rs
@@ -70,8 +70,24 @@ impl Index {
             return false;
         }
 
-        url.path().starts_with(self.root_url.path())
+        is_path_prefix(self.root_url.path(), url.path())
     }
+}
+
+/// Returns `true` if `prefix` is a complete path-segment prefix of `path`.
+///
+/// This rejects partial segment matches, so `/simple` matches `/simple/anyio` but not
+/// `/simpleevil`.
+pub(crate) fn is_path_prefix(prefix: &str, path: &str) -> bool {
+    if prefix == path {
+        return true;
+    }
+
+    let Some(suffix) = path.strip_prefix(prefix) else {
+        return false;
+    };
+
+    prefix.ends_with('/') || suffix.starts_with('/')
 }
 
 // TODO(john): Multiple methods in this struct need to iterate over
@@ -109,5 +125,46 @@ impl Indexes {
 
     fn find_prefix_index(&self, url: &Url) -> Option<&Index> {
         self.0.iter().find(|&index| index.is_prefix_for(url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index(root_url: &str, auth_policy: AuthPolicy) -> Index {
+        let root_url = DisplaySafeUrl::parse(root_url).unwrap();
+        Index {
+            url: root_url.clone(),
+            root_url,
+            auth_policy,
+        }
+    }
+
+    #[test]
+    fn test_index_path_prefix_requires_segment_boundary() {
+        let index = index("https://example.com/simple", AuthPolicy::Always);
+
+        for url in [
+            "https://example.com/simple",
+            "https://example.com/simple/",
+            "https://example.com/simple/anyio",
+        ] {
+            assert!(
+                index.is_prefix_for(&Url::parse(url).unwrap()),
+                "Failed to match URL with prefix: {url}"
+            );
+        }
+
+        for url in [
+            "https://example.com/simpleevil",
+            "https://example.com/simple-evil",
+            "https://example.com/simpl",
+        ] {
+            assert!(
+                !index.is_prefix_for(&Url::parse(url).unwrap()),
+                "Should not match URL with partial path segment: {url}"
+            );
+        }
     }
 }

--- a/crates/fyn-auth/src/providers.rs
+++ b/crates/fyn-auth/src/providers.rs
@@ -12,6 +12,7 @@ use fyn_warnings::warn_user_once;
 
 use crate::Credentials;
 use crate::credentials::Token;
+use crate::index::is_path_prefix;
 use crate::realm::{Realm, RealmRef};
 
 /// The [`Realm`] for the Hugging Face platform.
@@ -56,10 +57,10 @@ impl HuggingFaceProvider {
 }
 
 /// The [`Url`] for the S3 endpoint, if set.
-static S3_ENDPOINT_REALM: LazyLock<Option<Realm>> = LazyLock::new(|| {
+static S3_ENDPOINT_URL: LazyLock<Option<Url>> = LazyLock::new(|| {
     let s3_endpoint_url = std::env::var(EnvVars::UV_S3_ENDPOINT_URL).ok()?;
     let url = Url::parse(&s3_endpoint_url).expect("Failed to parse S3 endpoint URL");
-    Some(Realm::from(&url))
+    Some(url)
 });
 
 /// A provider for authentication credentials for S3 endpoints.
@@ -69,7 +70,7 @@ pub(crate) struct S3EndpointProvider;
 impl S3EndpointProvider {
     /// Returns `true` if the URL matches the configured S3 endpoint.
     pub(crate) fn is_s3_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Some(s3_endpoint_realm) = S3_ENDPOINT_REALM.as_ref().map(RealmRef::from) {
+        if let Some(s3_endpoint_url) = S3_ENDPOINT_URL.as_ref() {
             if !preview.is_enabled(PreviewFeature::S3Endpoint) {
                 warn_user_once!(
                     "The `s3-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -77,9 +78,9 @@ impl S3EndpointProvider {
                 );
             }
 
-            // Treat any URL on the same domain or subdomain as available for S3 signing.
-            let realm = RealmRef::from(url);
-            if realm == s3_endpoint_realm || realm.is_subdomain_of(s3_endpoint_realm) {
+            // Treat any URL under the endpoint path on the same domain or subdomain as available
+            // for S3 signing.
+            if is_endpoint_url(url, s3_endpoint_url) {
                 return true;
             }
         }
@@ -105,10 +106,10 @@ impl S3EndpointProvider {
 }
 
 /// The [`Url`] for the GCS endpoint, if set.
-static GCS_ENDPOINT_REALM: LazyLock<Option<Realm>> = LazyLock::new(|| {
+static GCS_ENDPOINT_URL: LazyLock<Option<Url>> = LazyLock::new(|| {
     let gcs_endpoint_url = std::env::var(EnvVars::UV_GCS_ENDPOINT_URL).ok()?;
     let url = Url::parse(&gcs_endpoint_url).expect("Failed to parse GCS endpoint URL");
-    Some(Realm::from(&url))
+    Some(url)
 });
 
 /// A provider for authentication credentials for GCS endpoints.
@@ -118,7 +119,7 @@ pub(crate) struct GcsEndpointProvider;
 impl GcsEndpointProvider {
     /// Returns `true` if the URL matches the configured GCS endpoint.
     pub(crate) fn is_gcs_endpoint(url: &Url, preview: Preview) -> bool {
-        if let Some(gcs_endpoint_realm) = GCS_ENDPOINT_REALM.as_ref().map(RealmRef::from) {
+        if let Some(gcs_endpoint_url) = GCS_ENDPOINT_URL.as_ref() {
             if !preview.is_enabled(PreviewFeature::GcsEndpoint) {
                 warn_user_once!(
                     "The `gcs-endpoint` option is experimental and may change without warning. Pass `--preview-features {}` to disable this warning.",
@@ -126,9 +127,9 @@ impl GcsEndpointProvider {
                 );
             }
 
-            // Treat any URL on the same domain or subdomain as available for GCS signing.
-            let realm = RealmRef::from(url);
-            if realm == gcs_endpoint_realm || realm.is_subdomain_of(gcs_endpoint_realm) {
+            // Treat any URL under the endpoint path on the same domain or subdomain as available
+            // for GCS signing.
+            if is_endpoint_url(url, gcs_endpoint_url) {
                 return true;
             }
         }
@@ -141,5 +142,85 @@ impl GcsEndpointProvider {
     /// should be cached.
     pub(crate) fn create_signer() -> GcsDefaultSigner {
         reqsign::google::default_signer("storage.googleapis.com")
+    }
+}
+
+/// Returns `true` if `url` is within the configured S3 or GCS-compatible endpoint URL.
+///
+/// The URL must be in the same realm, or a subdomain of the endpoint realm, and must be under the
+/// endpoint path using complete path-segment prefix matching.
+fn is_endpoint_url(url: &Url, endpoint_url: &Url) -> bool {
+    let endpoint_realm = RealmRef::from(endpoint_url);
+    let realm = RealmRef::from(url);
+    if realm != endpoint_realm && !realm.is_subdomain_of(endpoint_realm) {
+        return false;
+    }
+
+    is_path_prefix(endpoint_url.path(), url.path())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_endpoint_url_matches_path_prefix() {
+        let endpoint_url = Url::parse("https://example.com/private").unwrap();
+
+        for url in [
+            "https://example.com/private",
+            "https://example.com/private/",
+            "https://example.com/private/packages/anyio.whl",
+        ] {
+            assert!(
+                is_endpoint_url(&Url::parse(url).unwrap(), &endpoint_url),
+                "Failed to match endpoint URL prefix: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_endpoint_url_rejects_partial_path_segments() {
+        let endpoint_url = Url::parse("https://example.com/private").unwrap();
+
+        for url in [
+            "https://example.com/public",
+            "https://example.com/private-bucket",
+            "https://example.com/privatebucket",
+        ] {
+            assert!(
+                !is_endpoint_url(&Url::parse(url).unwrap(), &endpoint_url),
+                "Should not match URL outside endpoint path: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_endpoint_url_matches_subdomain_with_path_prefix() {
+        let endpoint_url = Url::parse("https://example.com/private").unwrap();
+
+        assert!(is_endpoint_url(
+            &Url::parse("https://bucket.example.com/private/package.whl").unwrap(),
+            &endpoint_url
+        ));
+        assert!(!is_endpoint_url(
+            &Url::parse("https://bucket.example.com/public/package.whl").unwrap(),
+            &endpoint_url
+        ));
+    }
+
+    #[test]
+    fn test_endpoint_url_root_path_matches_all_paths() {
+        let endpoint_url = Url::parse("https://example.com").unwrap();
+
+        for url in [
+            "https://example.com/package.whl",
+            "https://bucket.example.com/package.whl",
+        ] {
+            assert!(
+                is_endpoint_url(&Url::parse(url).unwrap(), &endpoint_url),
+                "Failed to match URL under endpoint root: {url}"
+            );
+        }
     }
 }

--- a/crates/fyn-auth/src/store.rs
+++ b/crates/fyn-auth/src/store.rs
@@ -13,6 +13,7 @@ use fyn_state::{StateBucket, StateStore};
 use fyn_static::EnvVars;
 
 use crate::credentials::{Password, Token, Username};
+use crate::index::is_path_prefix;
 use crate::realm::Realm;
 use crate::service::Service;
 use crate::{Credentials, KeyringProvider};
@@ -366,8 +367,8 @@ impl TextCredentialStore {
                 continue;
             }
 
-            // Service path must be a prefix of request path
-            if !url.path().starts_with(service.url().path()) {
+            // Service path must be a prefix of the request path.
+            if !is_path_prefix(service.url().path(), url.path()) {
                 continue;
             }
 
@@ -551,6 +552,8 @@ password = "pass2"
         let non_matching_urls = [
             "https://example.com/different",
             "https://example.com/ap", // Not a complete path segment match
+            "https://example.com/apiary", // Not a complete path segment match
+            "https://example.com/api-v2", // Not a complete path segment match
             "https://example.com",    // Shorter than the stored prefix
         ];
 

--- a/crates/fyn-install-wheel/src/uninstall.rs
+++ b/crates/fyn-install-wheel/src/uninstall.rs
@@ -208,12 +208,14 @@ pub fn uninstall_egg(
         .parent()
         .expect("egg-info directory is not in a site-packages directory");
 
-    // Read the `namespace_packages.txt` file.
+    // Read the `namespace_packages.txt` file, skipping empty or whitespace-only entries.
     let namespace_packages = {
         let namespace_packages_path = egg_info.join("namespace_packages.txt");
         match fs_err::read_to_string(namespace_packages_path) {
             Ok(namespace_packages) => namespace_packages
                 .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
                 .map(ToString::to_string)
                 .collect::<Vec<_>>(),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -224,13 +226,21 @@ pub fn uninstall_egg(
     };
 
     // Read the `top_level.txt` file, ignoring anything in `namespace_packages.txt`.
+    //
+    // Empty or whitespace-only entries are skipped: legacy setuptools writes `top_level.txt`
+    // with a trailing newline even when the package has no top-level modules, which
+    // `str::lines` yields as an empty string. Joining that onto `dist_location` would
+    // resolve back to `dist_location` itself (site-packages), and a subsequent
+    // `remove_dir_all` would wipe out every installed package.
     let top_level = {
         let top_level_path = egg_info.join("top_level.txt");
         match fs_err::read_to_string(&top_level_path) {
             Ok(top_level) => top_level
                 .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .filter(|line| !namespace_packages.iter().any(|ns| ns.as_str() == *line))
                 .map(ToString::to_string)
-                .filter(|line| !namespace_packages.contains(line))
                 .collect::<Vec<_>>(),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 return Err(Error::MissingTopLevel(top_level_path));
@@ -502,5 +512,95 @@ mod tests {
         assert!(target_file.exists());
         assert!(!init_py.exists());
         assert!(!egg_info.exists());
+    }
+
+    /// Regression test for <https://github.com/astral-sh/uv/issues/19113>.
+    #[test]
+    fn test_uninstall_egg_info_empty_top_level() {
+        let venv = assert_fs::TempDir::new().unwrap();
+        let site_packages = venv.child("lib/python3.12/site-packages");
+        site_packages.create_dir_all().unwrap();
+
+        let sibling_init = site_packages.child("sibling").child("__init__.py");
+        sibling_init.touch().unwrap();
+        let sibling_dist_info = site_packages.child("sibling-1.0.0.dist-info");
+        sibling_dist_info.create_dir_all().unwrap();
+
+        let egg_info = site_packages.child("emptypkg-0.1.0.egg-info");
+        egg_info.create_dir_all().unwrap();
+        egg_info.child("top_level.txt").write_str("\n").unwrap();
+
+        let layout = Layout {
+            sys_executable: venv.path().join("bin/python"),
+            python_version: (3, 13),
+            os_name: "posix".to_string(),
+            scheme: Scheme {
+                purelib: site_packages.to_path_buf(),
+                platlib: site_packages.to_path_buf(),
+                scripts: venv.path().join("bin"),
+                data: venv.path().to_path_buf(),
+                include: venv.path().join("include/python3.12"),
+            },
+        };
+
+        uninstall_egg(egg_info.path(), "emptypkg 0.1.0", &layout).unwrap();
+
+        assert!(!egg_info.exists());
+        assert!(
+            site_packages.exists(),
+            "uninstall must not remove site-packages itself"
+        );
+        assert!(sibling_init.exists(), "sibling package must not be removed");
+        assert!(
+            sibling_dist_info.exists(),
+            "sibling dist-info must not be removed"
+        );
+    }
+
+    /// Same bug shape as #19113, but triggered by blank or whitespace-only lines.
+    #[test]
+    fn test_uninstall_egg_info_blank_lines_in_top_level() {
+        let venv = assert_fs::TempDir::new().unwrap();
+        let site_packages = venv.child("lib/python3.12/site-packages");
+        site_packages.create_dir_all().unwrap();
+
+        let sibling_init = site_packages.child("sibling").child("__init__.py");
+        sibling_init.touch().unwrap();
+
+        let pkg_a_init = site_packages.child("pkg_a").child("__init__.py");
+        pkg_a_init.touch().unwrap();
+        let pkg_b_init = site_packages.child("pkg_b").child("__init__.py");
+        pkg_b_init.touch().unwrap();
+
+        let egg_info = site_packages.child("mixedpkg-0.1.0.egg-info");
+        egg_info.create_dir_all().unwrap();
+        egg_info
+            .child("top_level.txt")
+            .write_str("\npkg_a\n   \r\npkg_b\n\n")
+            .unwrap();
+
+        let layout = Layout {
+            sys_executable: venv.path().join("bin/python"),
+            python_version: (3, 13),
+            os_name: "posix".to_string(),
+            scheme: Scheme {
+                purelib: site_packages.to_path_buf(),
+                platlib: site_packages.to_path_buf(),
+                scripts: venv.path().join("bin"),
+                data: venv.path().to_path_buf(),
+                include: venv.path().join("include/python3.12"),
+            },
+        };
+
+        uninstall_egg(egg_info.path(), "mixedpkg 0.1.0", &layout).unwrap();
+
+        assert!(!egg_info.exists());
+        assert!(!pkg_a_init.exists(), "pkg_a must be removed");
+        assert!(!pkg_b_init.exists(), "pkg_b must be removed");
+        assert!(
+            site_packages.exists(),
+            "uninstall must not remove site-packages itself"
+        );
+        assert!(sibling_init.exists(), "sibling package must not be removed");
     }
 }

--- a/crates/fyn-python/src/discovery.rs
+++ b/crates/fyn-python/src/discovery.rs
@@ -203,6 +203,7 @@ pub enum VersionRequest {
     MajorMinor(u8, u8, PythonVariant),
     MajorMinorPatch(u8, u8, u8, PythonVariant),
     MajorMinorPrerelease(u8, u8, Prerelease, PythonVariant),
+    MajorMinorPatchPrerelease(u8, u8, u8, Prerelease, PythonVariant),
     Range(VersionSpecifiers, PythonVariant),
 }
 
@@ -728,7 +729,8 @@ fn find_all_minor(
         }
         VersionRequest::MajorMinor(_, _, _)
         | VersionRequest::MajorMinorPatch(_, _, _, _)
-        | VersionRequest::MajorMinorPrerelease(_, _, _, _) => Either::Right(iter::empty()),
+        | VersionRequest::MajorMinorPrerelease(_, _, _, _)
+        | VersionRequest::MajorMinorPatchPrerelease(_, _, _, _, _) => Either::Right(iter::empty()),
     }
 }
 
@@ -2640,7 +2642,8 @@ impl VersionRequest {
             Self::Major(..) => self,
             Self::MajorMinor(..) => self,
             Self::MajorMinorPatch(major, minor, _, variant)
-            | Self::MajorMinorPrerelease(major, minor, _, variant) => {
+            | Self::MajorMinorPrerelease(major, minor, _, variant)
+            | Self::MajorMinorPatchPrerelease(major, minor, _, _, variant) => {
                 Self::MajorMinor(major, minor, variant)
             }
         }
@@ -2651,11 +2654,13 @@ impl VersionRequest {
         &self,
         implementation: Option<&ImplementationName>,
     ) -> Vec<ExecutableName> {
-        let prerelease = if let Self::MajorMinorPrerelease(_, _, prerelease, _) = self {
-            // Include the prerelease version, e.g., `python3.8a`
-            Some(prerelease)
-        } else {
-            None
+        let prerelease = match self {
+            Self::MajorMinorPrerelease(_, _, prerelease, _)
+            | Self::MajorMinorPatchPrerelease(_, _, _, prerelease, _) => {
+                // Include the prerelease version, e.g., `python3.8a`
+                Some(prerelease)
+            }
+            _ => None,
         };
 
         // Push a default one
@@ -2743,6 +2748,7 @@ impl VersionRequest {
             Self::MajorMinor(major, _, _) => Some(*major),
             Self::MajorMinorPatch(major, _, _, _) => Some(*major),
             Self::MajorMinorPrerelease(major, _, _, _) => Some(*major),
+            Self::MajorMinorPatchPrerelease(major, _, _, _, _) => Some(*major),
         }
     }
 
@@ -2754,6 +2760,7 @@ impl VersionRequest {
             Self::MajorMinor(_, minor, _) => Some(*minor),
             Self::MajorMinorPatch(_, minor, _, _) => Some(*minor),
             Self::MajorMinorPrerelease(_, minor, _, _) => Some(*minor),
+            Self::MajorMinorPatchPrerelease(_, minor, _, _, _) => Some(*minor),
         }
     }
 
@@ -2765,6 +2772,7 @@ impl VersionRequest {
             Self::MajorMinor(_, _, _) => None,
             Self::MajorMinorPatch(_, _, patch, _) => Some(*patch),
             Self::MajorMinorPrerelease(_, _, _, _) => None,
+            Self::MajorMinorPatchPrerelease(_, _, patch, _, _) => Some(*patch),
         }
     }
 
@@ -2776,6 +2784,7 @@ impl VersionRequest {
             Self::MajorMinor(_, _, _) => None,
             Self::MajorMinorPatch(_, _, _, _) => None,
             Self::MajorMinorPrerelease(_, _, prerelease, _) => Some(prerelease),
+            Self::MajorMinorPatchPrerelease(_, _, _, prerelease, _) => Some(prerelease),
         }
     }
 
@@ -2810,6 +2819,13 @@ impl VersionRequest {
                 if (*major, *minor) < (3, 6) {
                     return Err(format!(
                         "Python <3.6 is not supported but {major}.{minor}{prerelease} was requested."
+                    ));
+                }
+            }
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, _) => {
+                if (*major, *minor) < (3, 6) {
+                    return Err(format!(
+                        "Python <3.6 is not supported but {major}.{minor}.{patch}{prerelease} was requested."
                     ));
                 }
             }
@@ -2904,6 +2920,19 @@ impl VersionRequest {
                 ) == (*major, *minor, *prerelease)
                     && variant.matches_interpreter(interpreter)
             }
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, variant) => {
+                let version = interpreter.python_version();
+                let Some(interpreter_prerelease) = version.pre() else {
+                    return false;
+                };
+                (
+                    interpreter.python_major(),
+                    interpreter.python_minor(),
+                    interpreter.python_patch(),
+                    interpreter_prerelease,
+                ) == (*major, *minor, *patch, *prerelease)
+                    && variant.matches_interpreter(interpreter)
+            }
         }
     }
 
@@ -2938,6 +2967,14 @@ impl VersionRequest {
             Self::MajorMinorPrerelease(major, minor, prerelease, _) => {
                 (version.major(), version.minor(), version.pre())
                     == (*major, *minor, Some(*prerelease))
+            }
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, _) => {
+                (
+                    version.major(),
+                    version.minor(),
+                    version.patch(),
+                    version.pre(),
+                ) == (*major, *minor, Some(*patch), Some(*prerelease))
             }
         }
     }
@@ -2978,6 +3015,9 @@ impl VersionRequest {
             Self::MajorMinorPrerelease(self_major, self_minor, _, _) => {
                 (*self_major, *self_minor) == (major, minor)
             }
+            Self::MajorMinorPatchPrerelease(self_major, self_minor, _, _, _) => {
+                (*self_major, *self_minor) == (major, minor)
+            }
         }
     }
 
@@ -3010,9 +3050,23 @@ impl VersionRequest {
                     .with_pre(prerelease),
             ),
             Self::MajorMinorPrerelease(self_major, self_minor, self_prerelease, _) => {
-                // Pre-releases of Python versions are always for the zero patch version
+                // Pre-releases without a patch in the request match the zero patch version.
                 (*self_major, *self_minor, 0, Some(*self_prerelease))
                     == (major, minor, patch, prerelease)
+            }
+            Self::MajorMinorPatchPrerelease(
+                self_major,
+                self_minor,
+                self_patch,
+                self_prerelease,
+                _,
+            ) => {
+                (
+                    *self_major,
+                    *self_minor,
+                    *self_patch,
+                    Some(*self_prerelease),
+                ) == (major, minor, patch, prerelease)
             }
         }
     }
@@ -3033,6 +3087,7 @@ impl VersionRequest {
             Self::MajorMinor(..) => false,
             Self::MajorMinorPatch(..) => true,
             Self::MajorMinorPrerelease(..) => false,
+            Self::MajorMinorPatchPrerelease(..) => true,
             Self::Range(_, _) => false,
         }
     }
@@ -3053,6 +3108,9 @@ impl VersionRequest {
             Self::MajorMinorPrerelease(major, minor, prerelease, variant) => {
                 Self::MajorMinorPrerelease(major, minor, prerelease, variant)
             }
+            Self::MajorMinorPatchPrerelease(major, minor, _, prerelease, variant) => {
+                Self::MajorMinorPrerelease(major, minor, prerelease, variant)
+            }
             Self::Range(_, _) => self,
         }
     }
@@ -3066,6 +3124,7 @@ impl VersionRequest {
             Self::MajorMinor(..) => false,
             Self::MajorMinorPatch(..) => false,
             Self::MajorMinorPrerelease(..) => true,
+            Self::MajorMinorPatchPrerelease(..) => true,
             Self::Range(specifiers, _) => specifiers.iter().any(VersionSpecifier::any_prerelease),
         }
     }
@@ -3078,6 +3137,7 @@ impl VersionRequest {
             | Self::MajorMinor(_, _, variant)
             | Self::MajorMinorPatch(_, _, _, variant)
             | Self::MajorMinorPrerelease(_, _, _, variant)
+            | Self::MajorMinorPatchPrerelease(_, _, _, _, variant)
             | Self::Range(_, variant) => variant.is_debug(),
         }
     }
@@ -3090,6 +3150,7 @@ impl VersionRequest {
             | Self::MajorMinor(_, _, variant)
             | Self::MajorMinorPatch(_, _, _, variant)
             | Self::MajorMinorPrerelease(_, _, _, variant)
+            | Self::MajorMinorPatchPrerelease(_, _, _, _, variant)
             | Self::Range(_, variant) => variant.is_freethreaded(),
         }
     }
@@ -3113,6 +3174,15 @@ impl VersionRequest {
             Self::MajorMinorPrerelease(major, minor, prerelease, _) => {
                 Self::MajorMinorPrerelease(major, minor, prerelease, PythonVariant::Default)
             }
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, _) => {
+                Self::MajorMinorPatchPrerelease(
+                    major,
+                    minor,
+                    patch,
+                    prerelease,
+                    PythonVariant::Default,
+                )
+            }
             Self::Range(specifiers, _) => Self::Range(specifiers, PythonVariant::Default),
         }
     }
@@ -3126,6 +3196,7 @@ impl VersionRequest {
             | Self::MajorMinor(_, _, variant)
             | Self::MajorMinorPatch(_, _, _, variant)
             | Self::MajorMinorPrerelease(_, _, _, variant)
+            | Self::MajorMinorPatchPrerelease(_, _, _, _, variant)
             | Self::Range(_, variant) => Some(*variant),
         }
     }
@@ -3145,9 +3216,13 @@ impl VersionRequest {
                 u64::from(*minor),
                 u64::from(*patch),
             ])),
-            // Pre-releases of Python versions are always for the zero patch version
+            // Pre-releases without a patch use the zero patch version.
             Self::MajorMinorPrerelease(major, minor, prerelease, _) => Some(
                 Version::new([u64::from(*major), u64::from(*minor), 0]).with_pre(Some(*prerelease)),
+            ),
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, _) => Some(
+                Version::new([u64::from(*major), u64::from(*minor), u64::from(*patch)])
+                    .with_pre(Some(*prerelease)),
             ),
         }
     }
@@ -3177,6 +3252,12 @@ impl VersionRequest {
             Self::MajorMinorPrerelease(major, minor, prerelease, _) => {
                 Some(VersionSpecifiers::from(VersionSpecifier::equals_version(
                     Version::new([u64::from(*major), u64::from(*minor), 0])
+                        .with_pre(Some(*prerelease)),
+                )))
+            }
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, _) => {
+                Some(VersionSpecifiers::from(VersionSpecifier::equals_version(
+                    Version::new([u64::from(*major), u64::from(*minor), u64::from(*patch)])
                         .with_pre(Some(*prerelease)),
                 )))
             }
@@ -3269,16 +3350,16 @@ impl FromStr for VersionRequest {
                 }
                 Ok(Self::MajorMinor(*major, *minor, variant))
             }
-            // e.g. `3.12.1` or `3.13.0rc1`
+            // e.g. `3.12.1`, `3.13.0rc1`, or `3.14.5rc1`
             [major, minor, patch] => {
                 if let Some(prerelease) = prerelease {
-                    // Prereleases are only allowed for the first patch version, e.g, 3.12.2rc1
-                    // isn't a proper Python release
-                    if *patch != 0 {
-                        return Err(Error::InvalidVersionRequest(s.to_string()));
+                    if *patch == 0 {
+                        return Ok(Self::MajorMinorPrerelease(
+                            *major, *minor, prerelease, variant,
+                        ));
                     }
-                    return Ok(Self::MajorMinorPrerelease(
-                        *major, *minor, prerelease, variant,
+                    return Ok(Self::MajorMinorPatchPrerelease(
+                        *major, *minor, *patch, prerelease, variant,
                     ));
                 }
                 Ok(Self::MajorMinorPatch(*major, *minor, *patch, variant))
@@ -3356,6 +3437,13 @@ impl fmt::Display for VersionRequest {
             }
             Self::MajorMinorPrerelease(major, minor, prerelease, variant) => {
                 write!(f, "{major}.{minor}{prerelease}{}", variant.display_suffix())
+            }
+            Self::MajorMinorPatchPrerelease(major, minor, patch, prerelease, variant) => {
+                write!(
+                    f,
+                    "{major}.{minor}.{patch}{prerelease}{}",
+                    variant.display_suffix()
+                )
             }
             Self::Range(specifiers, _) => write!(f, "{specifiers}"),
         }
@@ -3917,6 +4005,12 @@ mod tests {
         );
 
         assert_eq!(
+            PythonRequest::Version(VersionRequest::from_str("3.14.5rc1").unwrap())
+                .to_canonical_string(),
+            "3.14.5rc1"
+        );
+
+        assert_eq!(
             PythonRequest::ExecutableName("foo".to_string()).to_canonical_string(),
             "foo"
         );
@@ -4060,6 +4154,20 @@ mod tests {
                 PythonVariant::Default
             )
         );
+        assert_eq!(
+            VersionRequest::from_str("3.14.5rc1").unwrap(),
+            VersionRequest::MajorMinorPatchPrerelease(
+                3,
+                14,
+                5,
+                Prerelease {
+                    kind: PrereleaseKind::Rc,
+                    number: 1
+                },
+                PythonVariant::Default
+            ),
+            "Pre-release version requests with a non-zero patch are allowed"
+        );
         assert!(
             matches!(
                 VersionRequest::from_str("3rc1"),
@@ -4067,12 +4175,18 @@ mod tests {
             ),
             "Pre-release version requests require a minor version"
         );
-        assert!(
-            matches!(
-                VersionRequest::from_str("3.13.2rc1"),
-                Err(Error::InvalidVersionRequest(_))
-            ),
-            "Pre-release version requests require a patch version of zero"
+        assert_eq!(
+            VersionRequest::from_str("3.13.2rc1").unwrap(),
+            VersionRequest::MajorMinorPatchPrerelease(
+                3,
+                13,
+                2,
+                Prerelease {
+                    kind: PrereleaseKind::Rc,
+                    number: 1
+                },
+                PythonVariant::Default
+            )
         );
         assert!(
             matches!(

--- a/crates/fyn-python/src/downloads.rs
+++ b/crates/fyn-python/src/downloads.rs
@@ -1820,6 +1820,8 @@ async fn read_url(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use crate::PythonVariant;
     use crate::implementation::LenientImplementationName;
     use crate::installation::PythonInstallationKey;
@@ -2355,5 +2357,22 @@ mod tests {
         );
         let err = Error::NetworkError(url, wrapped);
         assert!(err.should_try_next_url());
+    }
+
+    /// Every [`PythonVersion`] in the embedded download metadata must be convertible
+    /// to a [`VersionRequest`] to avoid runtime panics.
+    #[test]
+    fn embedded_download_versions_convert_to_version_requests() {
+        let downloads = ManagedPythonDownloadList::new_only_embedded()
+            .expect("embedded download metadata should load");
+
+        let unique_versions: HashSet<PythonVersion> = downloads
+            .iter_all()
+            .map(ManagedPythonDownload::python_version)
+            .collect();
+
+        for version in &unique_versions {
+            let _ = VersionRequest::from(version);
+        }
     }
 }


### PR DESCRIPTION
## Summary

    - Backport uv uninstall hardening so empty or whitespace-only `.egg-info/top_level.txt` entries cannot target `site-packages` itself
    - Backport uv auth URL path-boundary matching so `/simple` does not match `/simpleevil`, including S3/GCS endpoint and text credential store matching
    - Backport uv Python prerelease request handling for non-zero patch prereleases like `3.14.5rc1`

## Tests

    - `cargo fmt`
    - `git diff --check`
    - `cargo test -p fyn-install-wheel --lib`
    - `cargo test -p fyn-auth --lib`
    - `cargo test -p fyn-python --lib version_request_from_str`
    - `cargo test -p fyn-python --lib interpreter_request_to_canonical_string`
    - `cargo test -p fyn-python --lib embedded_download_versions_convert_to_version_requests`
    - `cargo check -p fyn`