### PR TITLE
feat: harden status project environment checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,15 @@ workspace root: /home/user/example
 pyproject.toml: yes
 fyn.lock: yes
 pip-in-project: warn
+project environment: /home/user/example/.venv
 environment: /home/user/example/.venv
 python: /home/user/example/.venv/bin/python3 (3.12.0)
 ```
 
 Use `--check` to fail when obvious project checks do not pass, or `--json` for scripting and editor
-integrations. In managed projects, `--check` also reports missing environments and `.python-version`
-pins that do not satisfy `requires-python`, and prints `hint:` lines with the suggested fix.
+integrations. In managed projects, `--check` also reports missing or mismatched project environments
+and `.python-version` pins that do not satisfy `requires-python`, and prints `hint:` lines with the
+suggested fix.
 
 ```console
 $ fyn status --check

--- a/crates/fyn/src/commands/status.rs
+++ b/crates/fyn/src/commands/status.rs
@@ -48,6 +48,12 @@ struct StatusEnvironment {
 }
 
 #[derive(Serialize)]
+struct StatusProjectEnvironment {
+    path: String,
+    found: bool,
+}
+
+#[derive(Serialize)]
 struct StatusCheck {
     passed: bool,
     issues: Vec<String>,
@@ -64,6 +70,8 @@ struct StatusReport {
     pyproject_toml: bool,
     fyn_lock: bool,
     pip_in_project: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    project_environment: Option<StatusProjectEnvironment>,
     environment: Option<StatusEnvironment>,
     #[serde(skip_serializing_if = "Option::is_none")]
     check: Option<StatusCheck>,
@@ -75,6 +83,8 @@ struct StatusIssueInputs {
     pyproject_toml: bool,
     fyn_lock: bool,
     environment_found: bool,
+    project_environment_found: Option<bool>,
+    environment_matches_project: Option<bool>,
 }
 
 fn status_issues(inputs: StatusIssueInputs) -> Vec<String> {
@@ -91,6 +101,10 @@ fn status_issues(inputs: StatusIssueInputs) -> Vec<String> {
     }
     if !inputs.environment_found {
         issues.push("environment not found".to_string());
+    } else if matches!(inputs.project_environment_found, Some(false)) {
+        issues.push("project environment not found".to_string());
+    } else if matches!(inputs.environment_matches_project, Some(false)) {
+        issues.push("active environment does not match project environment".to_string());
     }
     issues
 }
@@ -111,6 +125,13 @@ fn status_hint(issue: &str) -> Option<String> {
         "environment not found" => {
             Some("Run `fyn sync` or `fyn venv` to create the project environment.".to_string())
         }
+        "project environment not found" => {
+            Some("Run `fyn sync` or `fyn venv` to create the project environment.".to_string())
+        }
+        "active environment does not match project environment" => Some(
+            "Run `fyn shell` to activate the project environment, or unset `VIRTUAL_ENV` before running fyn."
+                .to_string(),
+        ),
         _ if issue.starts_with("The pinned Python version `") => {
             Some("Run `fyn python pin` to update the pinned Python version.".to_string())
         }
@@ -248,6 +269,22 @@ pub(crate) async fn status(
         .map(|workspace| workspace.install_path().simplified_display().to_string());
     let pyproject_toml = root.join("pyproject.toml").is_file();
     let fyn_lock = root.join("fyn.lock").is_file();
+    let project_environment_path = workspace
+        .as_ref()
+        .map(|workspace| workspace.venv(Some(false)));
+    let project_environment = project_environment_path
+        .as_ref()
+        .and_then(|path| PythonEnvironment::from_root(path, cache).ok());
+    let environment = environment.or_else(|| project_environment.clone());
+    let project_environment_found = project_environment_path
+        .as_ref()
+        .map(|_| project_environment.is_some());
+    let environment_matches_project = environment.as_ref().zip(project_environment.as_ref()).map(
+        |(environment, project_environment)| {
+            fyn_fs::is_same_file_allow_missing(environment.root(), project_environment.root())
+                .unwrap_or(false)
+        },
+    );
     let virtual_project = if check && managed_project {
         match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
             .await
@@ -267,6 +304,8 @@ pub(crate) async fn status(
             pyproject_toml,
             fyn_lock,
             environment_found: environment.is_some(),
+            project_environment_found,
+            environment_matches_project,
         });
         issues.extend(
             python_pin_issues(
@@ -294,6 +333,13 @@ pub(crate) async fn status(
         pyproject_toml,
         fyn_lock,
         pip_in_project: policy_name(pip_in_project_policy(filesystem)),
+        project_environment: project_environment_path
+            .as_ref()
+            .zip(project_environment_found)
+            .map(|(path, found)| StatusProjectEnvironment {
+                path: path.simplified_display().to_string(),
+                found,
+            }),
         environment: environment.as_ref().map(|environment| StatusEnvironment {
             path: environment.root().simplified_display().to_string(),
             python: environment
@@ -361,6 +407,22 @@ pub(crate) async fn status(
         "pip-in-project: {}",
         report.pip_in_project.cyan()
     )?;
+    if let Some(project_environment) = report.project_environment.as_ref() {
+        if project_environment.found {
+            writeln!(
+                printer.stdout(),
+                "project environment: {}",
+                project_environment.path.cyan()
+            )?;
+        } else {
+            writeln!(
+                printer.stdout(),
+                "project environment: {} ({})",
+                project_environment.path.cyan(),
+                "not found".dimmed()
+            )?;
+        }
+    }
 
     if let Some(environment) = report.environment {
         writeln!(printer.stdout(), "environment: {}", environment.path.cyan())?;

--- a/crates/fyn/tests/it/status.rs
+++ b/crates/fyn/tests/it/status.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 
 use fyn_static::EnvVars;
@@ -28,6 +29,7 @@ fn status_in_managed_project() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.12.[X])
 
@@ -92,6 +94,10 @@ fn status_json_in_managed_project() -> Result<()> {
       "pyproject_toml": true,
       "fyn_lock": true,
       "pip_in_project": "warn",
+      "project_environment": {
+        "path": "[VENV]/",
+        "found": true
+      },
       "environment": {
         "path": "[VENV]/",
         "python": "[VENV]/bin/python3",
@@ -167,6 +173,7 @@ fn status_check_in_managed_project() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.12.[X])
     check: ok
@@ -233,6 +240,7 @@ fn status_check_missing_lock() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: no
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.12.[X])
     check: failed
@@ -318,6 +326,7 @@ fn status_check_compatible_python_pin() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.11.[X])
     check: ok
@@ -361,6 +370,7 @@ fn status_check_incompatible_python_pin() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.11.[X])
     check: failed
@@ -405,11 +415,108 @@ fn status_check_missing_environment() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/ (not found)
     environment: not found
     python: not found
     check: failed
     issue: environment not found
     hint: Run `fyn sync` or `fyn venv` to create the project environment.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn status_check_missing_project_environment_with_active_environment() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .command()
+            .env(EnvVars::UV_PROJECT_ENVIRONMENT, "project-env")
+            .arg("status")
+            .arg("--check"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    current directory: [TEMP_DIR]/
+    project directory: [TEMP_DIR]/
+    managed project: yes
+    workspace root: [TEMP_DIR]/
+    pyproject.toml: yes
+    fyn.lock: yes
+    pip-in-project: warn
+    project environment: [TEMP_DIR]/project-env (not found)
+    environment: [VENV]/
+    python: [VENV]/bin/python3 (3.12.[X])
+    check: failed
+    issue: project environment not found
+    hint: Run `fyn sync` or `fyn venv` to create the project environment.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn status_check_active_environment_mismatch() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+
+    context
+        .venv()
+        .env(EnvVars::UV_PROJECT_ENVIRONMENT, "project-env")
+        .assert()
+        .success();
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .command()
+            .env(EnvVars::UV_PROJECT_ENVIRONMENT, "project-env")
+            .arg("status")
+            .arg("--check"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    current directory: [TEMP_DIR]/
+    project directory: [TEMP_DIR]/
+    managed project: yes
+    workspace root: [TEMP_DIR]/
+    pyproject.toml: yes
+    fyn.lock: yes
+    pip-in-project: warn
+    project environment: [TEMP_DIR]/project-env
+    environment: [VENV]/
+    python: [VENV]/bin/python3 (3.12.[X])
+    check: failed
+    issue: active environment does not match project environment
+    hint: Run `fyn shell` to activate the project environment, or unset `VIRTUAL_ENV` before running fyn.
 
     ----- stderr -----
     "
@@ -451,6 +558,10 @@ fn status_json_check_incompatible_python_pin() -> Result<()> {
       "pyproject_toml": true,
       "fyn_lock": true,
       "pip_in_project": "warn",
+      "project_environment": {
+        "path": "[VENV]/",
+        "found": true
+      },
       "environment": {
         "path": "[VENV]/",
         "python": "[VENV]/bin/python3",

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -188,12 +188,14 @@ workspace root: /path/to/project
 pyproject.toml: yes
 fyn.lock: yes
 pip-in-project: warn
+project environment: /path/to/project/.venv
 environment: /path/to/project/.venv
 python: /path/to/project/.venv/bin/python3 (3.12.0)
 ```
 
 This is useful when you want to confirm whether you're inside a managed project, whether the
-lockfile is present, and which environment and Python interpreter fyn is currently using.
+lockfile is present, which project environment fyn expects, and which environment and Python
+interpreter fyn is currently using.
 
 For automation, use `--check` to fail when obvious project checks do not pass:
 
@@ -206,10 +208,10 @@ hint: Run `fyn sync` or `fyn venv` to create the project environment.
 ```
 
 `--check` fails if you are not inside a managed project. In managed projects, it also fails if
-`pyproject.toml`, `fyn.lock`, or the project environment is missing, or if the discovered
-`.python-version` pin does not satisfy the project's `requires-python`. Text output includes
-`issue:` and `hint:` lines, while `--json` exposes the same data via `check.issues` and
-`check.hints`.
+`pyproject.toml`, `fyn.lock`, or the project environment is missing, if the active environment does
+not match the project environment, or if the discovered `.python-version` pin does not satisfy the
+project's `requires-python`. Text output includes `issue:` and `hint:` lines, while `--json` exposes
+the same data via `check.issues` and `check.hints`.
 
 For editor integrations, scripts, or CI tooling, use JSON output:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,13 +98,14 @@ workspace root: /home/user/example
 pyproject.toml: yes
 fyn.lock: yes
 pip-in-project: warn
+project environment: /home/user/example/.venv
 environment: /home/user/example/.venv
 python: /home/user/example/.venv/bin/python3 (3.12.0)
 ```
 
 Use `fyn status --check` to fail fast in CI or editor integrations. In managed projects, it also
-reports missing environments and `.python-version` pins that do not satisfy `requires-python`, and
-prints matching `hint:` lines with the next command to run.
+reports missing or mismatched project environments and `.python-version` pins that do not satisfy
+`requires-python`, and prints matching `hint:` lines with the next command to run.
 
 Use `fyn upgrade` to refresh all dependencies or only the packages you name:
 


### PR DESCRIPTION
## Summary

  - report the expected project environment in `fyn status` for managed projects
  - make `fyn status --check` fail when the configured project env is missing despite an active env
  - make `fyn status --check` fail when the active env differs from the project env

  ## Testing

  - `cargo test -p fyn --test it status_`
  - `cargo fmt --check`
  - `git diff --check`
  - `cargo check -p fyn`