### PR TITLE
fix: backport uv packaging and policy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,15 @@ workspace root: /home/user/example
 pyproject.toml: yes
 fyn.lock: yes
 pip-in-project: warn
+project environment: /home/user/example/.venv
 environment: /home/user/example/.venv
 python: /home/user/example/.venv/bin/python3 (3.12.0)
 ```
 
 Use `--check` to fail when obvious project checks do not pass, or `--json` for scripting and editor
-integrations. In managed projects, `--check` also reports missing environments and `.python-version`
-pins that do not satisfy `requires-python`, and prints `hint:` lines with the suggested fix.
+integrations. In managed projects, `--check` also reports missing or mismatched project environments
+and `.python-version` pins that do not satisfy `requires-python`, and prints `hint:` lines with the
+suggested fix.
 
 ```console
 $ fyn status --check

--- a/crates/fyn-build-backend/src/wheel.rs
+++ b/crates/fyn-build-backend/src/wheel.rs
@@ -229,37 +229,12 @@ fn write_wheel(
         )?;
     }
 
-    // Add the data files
-    for (name, directory) in settings.data.iter() {
-        debug!(
-            "Adding {name} data files from: {}",
-            directory.user_display()
-        );
-        if directory
-            .components()
-            .next()
-            .is_some_and(|component| !matches!(component, Component::CurDir | Component::Normal(_)))
-        {
-            return Err(Error::InvalidDataRoot {
-                name: name.to_string(),
-                path: directory.to_path_buf(),
-            });
-        }
-        let data_dir = format!(
-            "{}-{}.data/{}/",
-            pyproject_toml.name().as_dist_info_name(),
-            pyproject_toml.version(),
-            name
-        );
-
-        wheel_subdir_from_globs(
-            &source_tree.join(directory),
-            &data_dir,
-            &["**".to_string()],
-            &mut wheel_writer,
-            &format!("tool.fyn.build-backend.data.{name}"),
-        )?;
-    }
+    write_data_files(
+        source_tree,
+        pyproject_toml,
+        settings.data.iter(),
+        &mut wheel_writer,
+    )?;
 
     debug!("Adding metadata files to wheel");
     let dist_info_dir = write_dist_info(
@@ -330,6 +305,13 @@ pub fn build_editable(
         src_root.as_os_str().as_encoded_bytes(),
     )?;
 
+    write_data_files(
+        source_tree,
+        &pyproject_toml,
+        settings.data.iter(),
+        &mut wheel_writer,
+    )?;
+
     debug!("Adding metadata files to: {}", wheel_path.user_display());
     let dist_info_dir = write_dist_info(
         &mut wheel_writer,
@@ -345,6 +327,47 @@ pub fn build_editable(
         .map_err(|err| Error::Persist(wheel_path.clone(), err.error))?;
 
     Ok(filename)
+}
+
+/// Add files configured via `tool.fyn.build-backend.data` to a wheel.
+fn write_data_files<'data>(
+    source_tree: &Path,
+    pyproject_toml: &PyProjectToml,
+    data: impl Iterator<Item = (&'static str, &'data Path)>,
+    wheel_writer: &mut impl DirectoryWriter,
+) -> Result<(), Error> {
+    for (name, directory) in data {
+        debug!(
+            "Adding {name} data files from: {}",
+            directory.user_display()
+        );
+        if directory
+            .components()
+            .next()
+            .is_some_and(|component| !matches!(component, Component::CurDir | Component::Normal(_)))
+        {
+            return Err(Error::InvalidDataRoot {
+                name: name.to_string(),
+                path: directory.to_path_buf(),
+            });
+        }
+        let data_dir = format!(
+            "{}-{}.data/{}/",
+            pyproject_toml.name().as_dist_info_name(),
+            pyproject_toml.version(),
+            name
+        );
+
+        wheel_subdir_from_globs(
+            &source_tree.join(directory),
+            &data_dir,
+            &["**".to_string()],
+            wheel_writer,
+            &format!("tool.fyn.build-backend.data.{name}"),
+        )?;
+    }
+
+    Ok(())
 }
 
 /// Write the dist-info directory to the output directory without building the wheel.

--- a/crates/fyn-distribution-filename/src/build_tag.rs
+++ b/crates/fyn-distribution-filename/src/build_tag.rs
@@ -9,6 +9,8 @@ pub enum BuildTagError {
     Empty,
     #[error("must start with a digit")]
     NoLeadingDigit,
+    #[error("must contain only ASCII letters, digits, underscores, and periods")]
+    InvalidCharacters,
     #[error(transparent)]
     ParseInt(#[from] ParseIntError),
 }
@@ -45,8 +47,18 @@ impl FromStr for BuildTag {
             return Err(BuildTagError::Empty);
         }
 
+        let mut prefix_end = None;
+        for (index, byte) in s.bytes().enumerate() {
+            if !is_build_tag_byte(byte) {
+                return Err(BuildTagError::InvalidCharacters);
+            }
+            if prefix_end.is_none() && !byte.is_ascii_digit() {
+                prefix_end = Some(index);
+            }
+        }
+
         // A build tag must start with a digit.
-        let (prefix, suffix) = match s.find(|c: char| !c.is_ascii_digit()) {
+        let (prefix, suffix) = match prefix_end {
             // Ex) `abc`
             Some(0) => return Err(BuildTagError::NoLeadingDigit),
             // Ex) `123abc`
@@ -68,5 +80,47 @@ impl std::fmt::Display for BuildTag {
             Some(suffix) => write!(f, "{}{}", self.0, suffix),
             None => write!(f, "{}", self.0),
         }
+    }
+}
+
+fn is_build_tag_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.')
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::BuildTag;
+
+    #[test]
+    fn parse_periods() {
+        assert_eq!(
+            BuildTag::from_str("0.editable")
+                .map(|build_tag| build_tag.to_string())
+                .map_err(|err| err.to_string()),
+            Ok("0.editable".to_string())
+        );
+    }
+
+    #[test]
+    fn err_invalid_characters() {
+        let err = BuildTag::from_str("1/../../target").unwrap_err();
+        insta::assert_snapshot!(err, @"must contain only ASCII letters, digits, underscores, and periods");
+
+        let err = BuildTag::from_str(r"1..\..\target").unwrap_err();
+        insta::assert_snapshot!(err, @"must contain only ASCII letters, digits, underscores, and periods");
+
+        let err = BuildTag::from_str("1target:stream").unwrap_err();
+        insta::assert_snapshot!(err, @"must contain only ASCII letters, digits, underscores, and periods");
+
+        let err = BuildTag::from_str("1-target").unwrap_err();
+        insta::assert_snapshot!(err, @"must contain only ASCII letters, digits, underscores, and periods");
+
+        let err = BuildTag::from_str("1 target").unwrap_err();
+        insta::assert_snapshot!(err, @"must contain only ASCII letters, digits, underscores, and periods");
+
+        let err = BuildTag::from_str("1target\u{e9}").unwrap_err();
+        insta::assert_snapshot!(err, @"must contain only ASCII letters, digits, underscores, and periods");
     }
 }

--- a/crates/fyn-distribution-filename/src/wheel.rs
+++ b/crates/fyn-distribution-filename/src/wheel.rs
@@ -15,7 +15,7 @@ use fyn_platform_tags::{
 };
 
 use crate::splitter::MemchrSplitter;
-use crate::wheel_tag::{WheelTag, WheelTagLarge, WheelTagSmall};
+use crate::wheel_tag::{TagSet, WheelTag, WheelTagLarge, WheelTagSmall};
 use crate::{BuildTag, BuildTagError};
 
 #[derive(
@@ -262,18 +262,9 @@ impl WheelFilename {
             WheelTag::Large {
                 large: Box::new(WheelTagLarge {
                     build_tag,
-                    python_tag: MemchrSplitter::split(python_tag, b'.')
-                        .map(LanguageTag::from_str)
-                        .filter_map(Result::ok)
-                        .collect(),
-                    abi_tag: MemchrSplitter::split(abi_tag, b'.')
-                        .map(AbiTag::from_str)
-                        .filter_map(Result::ok)
-                        .collect(),
-                    platform_tag: MemchrSplitter::split(platform_tag, b'.')
-                        .map(PlatformTag::from_str)
-                        .filter_map(Result::ok)
-                        .collect(),
+                    python_tag: parse_large_tag_component::<LanguageTag>(python_tag, filename)?,
+                    abi_tag: parse_large_tag_component::<AbiTag>(abi_tag, filename)?,
+                    platform_tag: parse_large_tag_component::<PlatformTag>(platform_tag, filename)?,
                     repr: repr.into(),
                 }),
             }
@@ -285,6 +276,39 @@ impl WheelFilename {
             tags,
         })
     }
+}
+
+fn parse_large_tag_component<T: FromStr>(
+    component: &str,
+    filename: &str,
+) -> Result<TagSet<T>, WheelFilenameError> {
+    if component.is_empty() {
+        return Err(invalid_tag_component(filename));
+    }
+
+    let mut tags = TagSet::new();
+    for tag in MemchrSplitter::split(component, b'.') {
+        if tag.is_empty() || !tag.bytes().all(is_tag_atom_byte) {
+            return Err(invalid_tag_component(filename));
+        }
+        if let Ok(tag) = T::from_str(tag) {
+            tags.push(tag);
+        }
+    }
+
+    Ok(tags)
+}
+
+fn invalid_tag_component(filename: &str) -> WheelFilenameError {
+    WheelFilenameError::InvalidWheelFileName(
+        filename.to_string(),
+        "Tag components must contain only ASCII letters, digits, underscores, and periods"
+            .to_string(),
+    )
+}
+
+fn is_tag_atom_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 impl<'de> Deserialize<'de> for WheelFilename {
@@ -408,6 +432,33 @@ mod tests {
     fn err_invalid_build_tag() {
         let err = WheelFilename::from_str("foo-1.2.3-tag-py3-none-any.whl").unwrap_err();
         insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-tag-py3-none-any.whl" has an invalid build tag: must start with a digit"#);
+
+        let err = WheelFilename::from_str("foo-1.2.3-1/../../target-py3-none-any.whl").unwrap_err();
+        insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-1/../../target-py3-none-any.whl" has an invalid build tag: must contain only ASCII letters, digits, underscores, and periods"#);
+    }
+
+    #[test]
+    fn err_invalid_tag_component() {
+        let err = WheelFilename::from_str("foo-1.2.3-py3-none-../target.whl").unwrap_err();
+        insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-py3-none-../target.whl" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods"#);
+
+        let err = WheelFilename::from_str(r"foo-1.2.3-py3-none-..\target.whl").unwrap_err();
+        insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-py3-none-..\target.whl" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods"#);
+
+        let err = WheelFilename::from_str("foo-1.2.3-py3-none-target:stream.whl").unwrap_err();
+        insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-py3-none-target:stream.whl" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods"#);
+
+        let err = WheelFilename::from_str("foo-1.2.3-py3-none-freebsd_13_x86/64.whl").unwrap_err();
+        insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-py3-none-freebsd_13_x86/64.whl" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods"#);
+
+        let err = WheelFilename::from_str("foo-1.2.3-py3-none-unknown tag.whl").unwrap_err();
+        insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-py3-none-unknown tag.whl" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods"#);
+
+        let err = WheelFilename::from_str("foo-1.2.3-py3-none-unknown\u{e9}.whl").unwrap_err();
+        insta::assert_snapshot!(err, @"The wheel filename \"foo-1.2.3-py3-none-unknown\u{e9}.whl\" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods");
+
+        let err = WheelFilename::from_str("foo-1.2.3-py3-none-unknown..tag.whl").unwrap_err();
+        insta::assert_snapshot!(err, @r#"The wheel filename "foo-1.2.3-py3-none-unknown..tag.whl" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods"#);
     }
 
     #[test]

--- a/crates/fyn-distribution/src/error.rs
+++ b/crates/fyn-distribution/src/error.rs
@@ -38,6 +38,8 @@ impl fmt::Display for PythonVersion {
 pub enum Error {
     #[error("Building source distributions is disabled")]
     NoBuild,
+    #[error("Building source distributions for `{0}` is disabled")]
+    NoBuildPackage(PackageName),
 
     // Network error
     #[error(transparent)]

--- a/crates/fyn-distribution/src/source/mod.rs
+++ b/crates/fyn-distribution/src/source/mod.rs
@@ -2597,6 +2597,22 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     ) -> Result<Option<ResolutionMetadata>, Error> {
         debug!("Preparing metadata for: {source}");
 
+        let source_name = source.name();
+        if self
+            .build_context
+            .build_options()
+            .no_build_requirement(source_name)
+            // Editable requirements without a known name need metadata to apply
+            // package-specific build settings; named editables must respect `--no-build`.
+            && !(source_name.is_none() && source.is_editable())
+        {
+            return if let Some(name) = source_name {
+                Err(Error::NoBuildPackage(name.clone()))
+            } else {
+                Err(Error::NoBuild)
+            };
+        }
+
         // Ensure that the _installed_ Python version is compatible with the `requires-python`
         // specifier.
         if let Some(requires_python) = source.requires_python() {

--- a/crates/fyn-platform-tags/src/lib.rs
+++ b/crates/fyn-platform-tags/src/lib.rs
@@ -1,7 +1,7 @@
 pub use abi_tag::{AbiTag, CPythonAbiVariants, ParseAbiTagError};
 pub use language_tag::{LanguageTag, ParseLanguageTagError};
 pub use platform::{Arch, Os, Platform, PlatformError};
-pub use platform_tag::{ParsePlatformTagError, PlatformTag};
+pub use platform_tag::{ParsePlatformTagError, ParseReleaseArchError, PlatformTag, ReleaseArch};
 pub use tags::{
     BinaryFormat, IncompatibleTag, TagCompatibility, TagPriority, Tags, TagsError, TagsOptions,
 };

--- a/crates/fyn-platform-tags/src/platform.rs
+++ b/crates/fyn-platform-tags/src/platform.rs
@@ -5,6 +5,8 @@ use std::{fmt, io};
 
 use thiserror::Error;
 
+use crate::ParseReleaseArchError;
+
 #[derive(Error, Debug)]
 pub enum PlatformError {
     #[error(transparent)]
@@ -17,6 +19,12 @@ pub enum PlatformError {
     InvalidIosSimulatorArch(Arch),
     #[error("Invalid iOS device architecture: {0}")]
     InvalidIosDeviceArch(Arch),
+    #[error("Invalid release and architecture suffix: {release_arch}")]
+    InvalidReleaseArch {
+        release_arch: String,
+        #[source]
+        error: ParseReleaseArchError,
+    },
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, serde::Deserialize, serde::Serialize)]

--- a/crates/fyn-platform-tags/src/platform_tag.rs
+++ b/crates/fyn-platform-tags/src/platform_tag.rs
@@ -7,6 +7,43 @@ use crate::tags::AndroidAbi;
 use crate::tags::IosMultiarch;
 use crate::{Arch, BinaryFormat};
 
+/// Opaque release-and-architecture suffix used by [`PlatformTag`] variants that preserve a native
+/// platform-specific suffix.
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[rkyv(derive(Debug))]
+pub struct ReleaseArch(SmallString);
+
+impl FromStr for ReleaseArch {
+    type Err = ParseReleaseArchError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+        {
+            Ok(Self(SmallString::from(s)))
+        } else {
+            Err(ParseReleaseArchError)
+        }
+    }
+}
+
+impl std::fmt::Display for ReleaseArch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// A tag to represent the platform compatibility of a Python distribution.
 ///
 /// This is the third segment in the wheel filename, following the language and ABI tags. For
@@ -60,19 +97,19 @@ pub enum PlatformTag {
     /// Ex) `android_21_x86_64`
     Android { api_level: u16, abi: AndroidAbi },
     /// Ex) `freebsd_12_x86_64`
-    FreeBsd { release_arch: SmallString },
+    FreeBsd { release_arch: ReleaseArch },
     /// Ex) `netbsd_9_x86_64`
-    NetBsd { release_arch: SmallString },
+    NetBsd { release_arch: ReleaseArch },
     /// Ex) `openbsd_6_x86_64`
-    OpenBsd { release_arch: SmallString },
+    OpenBsd { release_arch: ReleaseArch },
     /// Ex) `dragonfly_6_x86_64`
-    Dragonfly { release_arch: SmallString },
+    Dragonfly { release_arch: ReleaseArch },
     /// Ex) `haiku_1_x86_64`
-    Haiku { release_arch: SmallString },
+    Haiku { release_arch: ReleaseArch },
     /// Ex) `illumos_5_11_x86_64`
-    Illumos { release_arch: SmallString },
+    Illumos { release_arch: ReleaseArch },
     /// Ex) `solaris_11_4_x86_64`
-    Solaris { release_arch: SmallString },
+    Solaris { release_arch: ReleaseArch },
     /// Ex) `pyodide_2024_0_wasm32`
     Pyodide { major: u16, minor: u16 },
     /// Ex) `ios_13_0_arm64_iphoneos` / `ios_13_0_arm64_iphonesimulator`
@@ -690,7 +727,9 @@ impl FromStr for PlatformTag {
             }
 
             return Ok(Self::FreeBsd {
-                release_arch: SmallString::from(rest),
+                release_arch: rest
+                    .parse::<ReleaseArch>()
+                    .map_err(|_| ParsePlatformTagError::InvalidCharacters { tag: s.to_string() })?,
             });
         }
 
@@ -704,7 +743,9 @@ impl FromStr for PlatformTag {
             }
 
             return Ok(Self::NetBsd {
-                release_arch: SmallString::from(rest),
+                release_arch: rest
+                    .parse::<ReleaseArch>()
+                    .map_err(|_| ParsePlatformTagError::InvalidCharacters { tag: s.to_string() })?,
             });
         }
 
@@ -718,7 +759,9 @@ impl FromStr for PlatformTag {
             }
 
             return Ok(Self::OpenBsd {
-                release_arch: SmallString::from(rest),
+                release_arch: rest
+                    .parse::<ReleaseArch>()
+                    .map_err(|_| ParsePlatformTagError::InvalidCharacters { tag: s.to_string() })?,
             });
         }
 
@@ -732,7 +775,9 @@ impl FromStr for PlatformTag {
             }
 
             return Ok(Self::Dragonfly {
-                release_arch: SmallString::from(rest),
+                release_arch: rest
+                    .parse::<ReleaseArch>()
+                    .map_err(|_| ParsePlatformTagError::InvalidCharacters { tag: s.to_string() })?,
             });
         }
 
@@ -746,7 +791,9 @@ impl FromStr for PlatformTag {
             }
 
             return Ok(Self::Haiku {
-                release_arch: SmallString::from(rest),
+                release_arch: rest
+                    .parse::<ReleaseArch>()
+                    .map_err(|_| ParsePlatformTagError::InvalidCharacters { tag: s.to_string() })?,
             });
         }
 
@@ -760,7 +807,9 @@ impl FromStr for PlatformTag {
             }
 
             return Ok(Self::Illumos {
-                release_arch: SmallString::from(rest),
+                release_arch: rest
+                    .parse::<ReleaseArch>()
+                    .map_err(|_| ParsePlatformTagError::InvalidCharacters { tag: s.to_string() })?,
             });
         }
 
@@ -776,7 +825,9 @@ impl FromStr for PlatformTag {
             if let Some(release_arch) = rest.strip_suffix("_64bit") {
                 if !release_arch.is_empty() {
                     return Ok(Self::Solaris {
-                        release_arch: SmallString::from(release_arch),
+                        release_arch: release_arch.parse::<ReleaseArch>().map_err(|_| {
+                            ParsePlatformTagError::InvalidCharacters { tag: s.to_string() }
+                        })?,
                     });
                 }
             }
@@ -872,6 +923,10 @@ impl FromStr for PlatformTag {
     }
 }
 
+#[derive(Debug, Clone, Copy, thiserror::Error, PartialEq, Eq)]
+#[error("release and architecture must contain only ASCII letters, digits, and underscores")]
+pub struct ParseReleaseArchError;
+
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum ParsePlatformTagError {
     #[error("Unknown platform tag format: {0}")]
@@ -886,13 +941,17 @@ pub enum ParsePlatformTagError {
     InvalidArch { platform: &'static str, tag: String },
     #[error("Invalid API level in {platform} platform tag: {tag}")]
     InvalidApiLevel { platform: &'static str, tag: String },
+    #[error("Platform tag must contain only ASCII letters, digits, and underscores: {tag}")]
+    InvalidCharacters { tag: String },
 }
 
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
 
-    use crate::platform_tag::{ParsePlatformTagError, PlatformTag};
+    use crate::platform_tag::{
+        ParsePlatformTagError, ParseReleaseArchError, PlatformTag, ReleaseArch,
+    };
     use crate::tags::AndroidAbi;
     use crate::tags::IosMultiarch;
     use crate::{Arch, BinaryFormat};
@@ -1111,45 +1170,91 @@ mod tests {
     }
 
     #[test]
-    fn freebsd_platform() {
-        let tag = PlatformTag::FreeBsd {
-            release_arch: "13_14_x86_64".into(),
-        };
+    fn release_arch() {
         assert_eq!(
-            PlatformTag::from_str("freebsd_13_14_x86_64").as_ref(),
-            Ok(&tag)
+            ReleaseArch::from_str("13_14_x86_64").map(|release_arch| release_arch.to_string()),
+            Ok("13_14_x86_64".to_string())
         );
-        assert_eq!(tag.to_string(), "freebsd_13_14_x86_64");
+        assert_eq!(
+            ReleaseArch::from_str("13_x86/64"),
+            Err(ParseReleaseArchError)
+        );
+    }
+
+    #[test]
+    fn freebsd_platform() {
+        assert_eq!(
+            PlatformTag::from_str("freebsd_13_14_x86_64")
+                .as_ref()
+                .map(ToString::to_string),
+            Ok("freebsd_13_14_x86_64".to_string())
+        );
     }
 
     #[test]
     fn illumos_platform() {
-        let tag = PlatformTag::Illumos {
-            release_arch: "5_11_x86_64".into(),
-        };
         assert_eq!(
-            PlatformTag::from_str("illumos_5_11_x86_64").as_ref(),
-            Ok(&tag)
+            PlatformTag::from_str("illumos_5_11_x86_64")
+                .as_ref()
+                .map(ToString::to_string),
+            Ok("illumos_5_11_x86_64".to_string())
         );
-        assert_eq!(tag.to_string(), "illumos_5_11_x86_64");
     }
 
     #[test]
     fn solaris_platform() {
-        let tag = PlatformTag::Solaris {
-            release_arch: "11_4_x86_64".into(),
-        };
         assert_eq!(
-            PlatformTag::from_str("solaris_11_4_x86_64_64bit").as_ref(),
-            Ok(&tag)
+            PlatformTag::from_str("solaris_11_4_x86_64_64bit")
+                .as_ref()
+                .map(ToString::to_string),
+            Ok("solaris_11_4_x86_64_64bit".to_string())
         );
-        assert_eq!(tag.to_string(), "solaris_11_4_x86_64_64bit");
 
         assert_eq!(
             PlatformTag::from_str("solaris_11_4_x86_64"),
             Err(ParsePlatformTagError::InvalidArch {
                 platform: "solaris",
                 tag: "solaris_11_4_x86_64".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn invalid_characters_platform() {
+        assert_eq!(
+            PlatformTag::from_str("freebsd_13_x86/64"),
+            Err(ParsePlatformTagError::InvalidCharacters {
+                tag: "freebsd_13_x86/64".to_string()
+            })
+        );
+        assert_eq!(
+            PlatformTag::from_str(r"netbsd_9_x86\64"),
+            Err(ParsePlatformTagError::InvalidCharacters {
+                tag: r"netbsd_9_x86\64".to_string()
+            })
+        );
+        assert_eq!(
+            PlatformTag::from_str("solaris_11_4_x86:64_64bit"),
+            Err(ParsePlatformTagError::InvalidCharacters {
+                tag: "solaris_11_4_x86:64_64bit".to_string()
+            })
+        );
+        assert_eq!(
+            PlatformTag::from_str("freebsd_13.14_x86_64"),
+            Err(ParsePlatformTagError::InvalidCharacters {
+                tag: "freebsd_13.14_x86_64".to_string()
+            })
+        );
+        assert_eq!(
+            PlatformTag::from_str("freebsd_13 x86_64"),
+            Err(ParsePlatformTagError::InvalidCharacters {
+                tag: "freebsd_13 x86_64".to_string()
+            })
+        );
+        assert_eq!(
+            PlatformTag::from_str("freebsd_13_x86\u{e9}"),
+            Err(ParsePlatformTagError::InvalidCharacters {
+                tag: "freebsd_13_x86\u{e9}".to_string()
             })
         );
     }

--- a/crates/fyn-platform-tags/src/tags.rs
+++ b/crates/fyn-platform-tags/src/tags.rs
@@ -6,10 +6,8 @@ use std::{cmp, num::NonZeroU32};
 
 use rustc_hash::FxHashMap;
 
-use fyn_small_str::SmallString;
-
 use crate::abi_tag::CPythonAbiVariants;
-use crate::{AbiTag, Arch, LanguageTag, Os, Platform, PlatformError, PlatformTag};
+use crate::{AbiTag, Arch, LanguageTag, Os, Platform, PlatformError, PlatformTag, ReleaseArch};
 
 #[derive(Debug, thiserror::Error)]
 pub enum TagsError {
@@ -669,7 +667,12 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
             let arch_tag = arch.machine();
             let release_arch = format!("{release_tag}_{arch_tag}");
             vec![PlatformTag::FreeBsd {
-                release_arch: SmallString::from(release_arch),
+                release_arch: release_arch.parse::<ReleaseArch>().map_err(|error| {
+                    PlatformError::InvalidReleaseArch {
+                        release_arch,
+                        error,
+                    }
+                })?,
             }]
         }
         (Os::NetBsd { release }, arch) => {
@@ -677,7 +680,12 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
             let arch_tag = arch.machine();
             let release_arch = format!("{release_tag}_{arch_tag}");
             vec![PlatformTag::NetBsd {
-                release_arch: SmallString::from(release_arch),
+                release_arch: release_arch.parse::<ReleaseArch>().map_err(|error| {
+                    PlatformError::InvalidReleaseArch {
+                        release_arch,
+                        error,
+                    }
+                })?,
             }]
         }
         (Os::OpenBsd { release }, arch) => {
@@ -685,21 +693,36 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
             let arch_tag = arch.machine();
             let release_arch = format!("{release_tag}_{arch_tag}");
             vec![PlatformTag::OpenBsd {
-                release_arch: SmallString::from(release_arch),
+                release_arch: release_arch.parse::<ReleaseArch>().map_err(|error| {
+                    PlatformError::InvalidReleaseArch {
+                        release_arch,
+                        error,
+                    }
+                })?,
             }]
         }
         (Os::Dragonfly { release }, arch) => {
             let release = release.replace(['.', '-'], "_");
             let release_arch = format!("{release}_{arch}");
             vec![PlatformTag::Dragonfly {
-                release_arch: SmallString::from(release_arch),
+                release_arch: release_arch.parse::<ReleaseArch>().map_err(|error| {
+                    PlatformError::InvalidReleaseArch {
+                        release_arch,
+                        error,
+                    }
+                })?,
             }]
         }
         (Os::Haiku { release }, arch) => {
             let release = release.replace(['.', '-'], "_");
             let release_arch = format!("{release}_{arch}");
             vec![PlatformTag::Haiku {
-                release_arch: SmallString::from(release_arch),
+                release_arch: release_arch.parse::<ReleaseArch>().map_err(|error| {
+                    PlatformError::InvalidReleaseArch {
+                        release_arch,
+                        error,
+                    }
+                })?,
             }]
         }
         (Os::Illumos { release, arch }, _) => {
@@ -716,14 +739,24 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<PlatformTag>, PlatformErro
                     let arch = format!("{arch}_64bit");
                     let release_arch = format!("{release}_{arch}");
                     return Ok(vec![PlatformTag::Solaris {
-                        release_arch: SmallString::from(release_arch),
+                        release_arch: release_arch.parse::<ReleaseArch>().map_err(|error| {
+                            PlatformError::InvalidReleaseArch {
+                                release_arch,
+                                error,
+                            }
+                        })?,
                     }]);
                 }
             }
 
             let release_arch = format!("{release}_{arch}");
             vec![PlatformTag::Illumos {
-                release_arch: SmallString::from(release_arch),
+                release_arch: release_arch.parse::<ReleaseArch>().map_err(|error| {
+                    PlatformError::InvalidReleaseArch {
+                        release_arch,
+                        error,
+                    }
+                })?,
             }]
         }
         (Os::Android { api_level }, arch) => {
@@ -1441,6 +1474,24 @@ mod tests {
         ]
         "#
         );
+    }
+
+    #[test]
+    fn test_platform_tags_invalid_release_arch() {
+        let error = compatible_tags(&Platform::new(
+            Os::FreeBsd {
+                release: "13/14".to_string(),
+            },
+            Arch::X86_64,
+        ))
+        .unwrap_err();
+
+        assert_debug_snapshot!(error, @r#"
+        InvalidReleaseArch {
+            release_arch: "13/14_amd64",
+            error: ParseReleaseArchError,
+        }
+        "#);
     }
 
     #[test]

--- a/crates/fyn-resolver/src/lock/mod.rs
+++ b/crates/fyn-resolver/src/lock/mod.rs
@@ -23,7 +23,7 @@ use fyn_configuration::{
     BuildOptions, Constraints, DependencyGroupsWithDefaults, ExtrasSpecificationWithDefaults,
     InstallTarget,
 };
-use fyn_distribution::{DistributionDatabase, FlatRequiresDist};
+use fyn_distribution::{DistributionDatabase, FlatRequiresDist, RequiresDist};
 use fyn_distribution_filename::{
     BuildTag, DistExtension, ExtensionError, SourceDistExtension, WheelFilename,
 };
@@ -1578,6 +1578,7 @@ impl Lock {
         indexes: Option<&IndexLocations>,
         tags: &Tags,
         markers: &MarkerEnvironment,
+        build_options: &BuildOptions,
         hasher: &HashStrategy,
         index: &InMemoryIndex,
         database: &DistributionDatabase<'_, Context>,
@@ -1937,84 +1938,135 @@ impl Lock {
             }
 
             if let Some(version) = package.id.version.as_ref() {
-                // For a non-dynamic package, fetch the metadata from the distribution database.
-                let HashedDist { dist, .. } = package.to_dist(
-                    root,
-                    TagPolicy::Preferred(tags),
-                    &BuildOptions::default(),
-                    markers,
-                )?;
-
-                let metadata = {
-                    let id = dist.distribution_id();
-                    if let Some(archive) =
-                        index
-                            .distributions()
-                            .get(&id)
-                            .as_deref()
-                            .and_then(|response| {
-                                if let MetadataResponse::Found(archive, ..) = response {
-                                    Some(archive)
-                                } else {
-                                    None
-                                }
-                            })
-                    {
-                        // If the metadata is already in the index, return it.
-                        archive.metadata.clone()
-                    } else {
-                        // Run the PEP 517 build process to extract metadata from the source distribution.
-                        let archive = database
-                            .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
-                            .await
-                            .map_err(|err| LockErrorKind::Resolution {
-                                id: package.id.clone(),
-                                err,
-                            })?;
-
-                        let metadata = archive.metadata.clone();
-
-                        // Insert the metadata into the index.
-                        index
-                            .distributions()
-                            .done(id, Arc::new(MetadataResponse::Found(archive)));
-
-                        metadata
-                    }
-                };
-
-                // If this is a local package, validate that it hasn't become dynamic (in which
-                // case, we'd expect the version to be omitted).
-                if package.id.source.is_source_tree() {
+                // If the distribution is a source tree, attempt to validate it from statically
+                // available `pyproject.toml` metadata before converting it to an installable
+                // distribution. This avoids requiring build permission for static local packages.
+                let statically_satisfied = if let Some(source_tree) =
+                    package.id.source.as_source_tree()
+                    && let Some(SourceTreeRequiresDist {
+                        version: static_version,
+                        metadata,
+                    }) = Self::source_tree_requires_dist(source_tree, root, package, database)
+                        .await?
+                {
+                    // If this local package has become dynamic, the locked package should no longer
+                    // contain a version.
                     if metadata.dynamic {
                         return Ok(SatisfiesResult::MismatchedDynamic(&package.id.name, false));
                     }
-                }
 
-                // Validate the `version` metadata.
-                if metadata.version != *version {
-                    return Ok(SatisfiesResult::MismatchedVersion(
-                        &package.id.name,
-                        version.clone(),
-                        Some(metadata.version.clone()),
-                    ));
-                }
+                    if let Some(static_version) = static_version {
+                        // Validate the static `version` metadata.
+                        if static_version != *version {
+                            return Ok(SatisfiesResult::MismatchedVersion(
+                                &package.id.name,
+                                version.clone(),
+                                Some(static_version),
+                            ));
+                        }
 
-                // Validate the `provides-extras` metadata.
-                match self.satisfies_provides_extra(metadata.provides_extra, package) {
-                    SatisfiesResult::Satisfied => {}
-                    result => return Ok(result),
-                }
+                        // Validate the static `provides-extras` metadata.
+                        match self.satisfies_provides_extra(metadata.provides_extra, package) {
+                            SatisfiesResult::Satisfied => {}
+                            result => return Ok(result),
+                        }
 
-                // Validate that the requirements are unchanged.
-                match self.satisfies_requires_dist(
-                    metadata.requires_dist,
-                    metadata.dependency_groups,
-                    package,
-                    root,
-                )? {
-                    SatisfiesResult::Satisfied => {}
-                    result => return Ok(result),
+                        // Validate that the static requirements are unchanged.
+                        match self.satisfies_requires_dist(
+                            metadata.requires_dist,
+                            metadata.dependency_groups,
+                            package,
+                            root,
+                        )? {
+                            SatisfiesResult::Satisfied => true,
+                            result => return Ok(result),
+                        }
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
+                if !statically_satisfied {
+                    // For a non-dynamic package without usable static metadata, fetch the metadata
+                    // from the distribution database.
+                    let HashedDist { dist, .. } = package.to_dist(
+                        root,
+                        TagPolicy::Preferred(tags),
+                        build_options,
+                        markers,
+                    )?;
+
+                    let metadata = {
+                        let id = dist.distribution_id();
+                        if let Some(archive) =
+                            index
+                                .distributions()
+                                .get(&id)
+                                .as_deref()
+                                .and_then(|response| {
+                                    if let MetadataResponse::Found(archive, ..) = response {
+                                        Some(archive)
+                                    } else {
+                                        None
+                                    }
+                                })
+                        {
+                            // If the metadata is already in the index, return it.
+                            archive.metadata.clone()
+                        } else {
+                            // Run the PEP 517 build process to extract metadata from the source distribution.
+                            let archive = database
+                                .get_or_build_wheel_metadata(&dist, hasher.get(&dist))
+                                .await
+                                .map_err(|err| LockErrorKind::Resolution {
+                                    id: package.id.clone(),
+                                    err,
+                                })?;
+
+                            let metadata = archive.metadata.clone();
+
+                            // Insert the metadata into the index.
+                            index
+                                .distributions()
+                                .done(id, Arc::new(MetadataResponse::Found(archive)));
+
+                            metadata
+                        }
+                    };
+
+                    // If this is a local package, validate that it hasn't become dynamic (in which
+                    // case, we'd expect the version to be omitted).
+                    if package.id.source.is_source_tree() && metadata.dynamic {
+                        return Ok(SatisfiesResult::MismatchedDynamic(&package.id.name, false));
+                    }
+
+                    // Validate the `version` metadata.
+                    if metadata.version != *version {
+                        return Ok(SatisfiesResult::MismatchedVersion(
+                            &package.id.name,
+                            version.clone(),
+                            Some(metadata.version.clone()),
+                        ));
+                    }
+
+                    // Validate the `provides-extras` metadata.
+                    match self.satisfies_provides_extra(metadata.provides_extra, package) {
+                        SatisfiesResult::Satisfied => {}
+                        result => return Ok(result),
+                    }
+
+                    // Validate that the requirements are unchanged.
+                    match self.satisfies_requires_dist(
+                        metadata.requires_dist,
+                        metadata.dependency_groups,
+                        package,
+                        root,
+                    )? {
+                        SatisfiesResult::Satisfied => {}
+                        result => return Ok(result),
+                    }
                 }
             } else if let Some(source_tree) = package.id.source.as_source_tree() {
                 // For dynamic packages, we don't need the version. We only need to know that the
@@ -2026,30 +2078,10 @@ impl Lock {
                 // even if the version is dynamic, we can still extract the requirements without
                 // performing a build, unlike in the database where we typically construct a "complete"
                 // metadata object.
-                let parent = root.join(source_tree);
-                let path = parent.join("pyproject.toml");
-                let metadata = match fs_err::tokio::read_to_string(&path).await {
-                    Ok(contents) => {
-                        let pyproject_toml =
-                            PyProjectToml::from_toml(&contents, path.user_display()).map_err(
-                                |err| LockErrorKind::InvalidPyprojectToml {
-                                    path: path.clone(),
-                                    err,
-                                },
-                            )?;
-                        database
-                            .requires_dist(&parent, &pyproject_toml)
-                            .await
-                            .map_err(|err| LockErrorKind::Resolution {
-                                id: package.id.clone(),
-                                err,
-                            })?
-                    }
-                    Err(err) if err.kind() == io::ErrorKind::NotFound => None,
-                    Err(err) => {
-                        return Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into());
-                    }
-                };
+                let metadata =
+                    Self::source_tree_requires_dist(source_tree, root, package, database)
+                        .await?
+                        .map(|metadata| metadata.metadata);
 
                 let satisfied = metadata.is_some_and(|metadata| {
                     // Validate that the package is still dynamic.
@@ -2093,7 +2125,7 @@ impl Lock {
                     let HashedDist { dist, .. } = package.to_dist(
                         root,
                         TagPolicy::Preferred(tags),
-                        &BuildOptions::default(),
+                        build_options,
                         markers,
                     )?;
 
@@ -2225,6 +2257,44 @@ impl Lock {
 
         Ok(SatisfiesResult::Satisfied)
     }
+
+    async fn source_tree_requires_dist<Context: BuildContext>(
+        source_tree: &Path,
+        root: &Path,
+        package: &Package,
+        database: &DistributionDatabase<'_, Context>,
+    ) -> Result<Option<SourceTreeRequiresDist>, LockError> {
+        let parent = root.join(source_tree);
+        let path = parent.join("pyproject.toml");
+        match fs_err::tokio::read_to_string(&path).await {
+            Ok(contents) => {
+                let pyproject_toml = PyProjectToml::from_toml(&contents, path.user_display())
+                    .map_err(|err| LockErrorKind::InvalidPyprojectToml {
+                        path: path.clone(),
+                        err,
+                    })?;
+                let version = pyproject_toml
+                    .project
+                    .as_ref()
+                    .and_then(|project| project.version.clone());
+                let metadata = database
+                    .requires_dist(&parent, &pyproject_toml)
+                    .await
+                    .map_err(|err| LockErrorKind::Resolution {
+                        id: package.id.clone(),
+                        err,
+                    })?;
+                Ok(metadata.map(|metadata| SourceTreeRequiresDist { version, metadata }))
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(LockErrorKind::UnreadablePyprojectToml { path, err }.into()),
+        }
+    }
+}
+
+struct SourceTreeRequiresDist {
+    version: Option<Version>,
+    metadata: RequiresDist,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -5534,6 +5604,14 @@ impl LockError {
     /// Returns true if the [`LockError`] is a resolver error.
     pub fn is_resolution(&self) -> bool {
         matches!(&*self.kind, LockErrorKind::Resolution { .. })
+    }
+
+    /// Returns true if the [`LockError`] is caused by disabled builds.
+    pub fn is_no_build(&self) -> bool {
+        matches!(
+            &*self.kind,
+            LockErrorKind::NoBuild { .. } | LockErrorKind::NoBinaryNoBuild { .. }
+        )
     }
 }
 

--- a/crates/fyn/src/commands/pip/compile.rs
+++ b/crates/fyn/src/commands/pip/compile.rs
@@ -72,6 +72,7 @@ pub(crate) async fn pip_compile(
     excludes_from_workspace: Vec<fyn_normalize::PackageName>,
     build_constraints_from_workspace: Vec<Requirement>,
     environments: SupportedEnvironments,
+    required_environments: SupportedEnvironments,
     extras: ExtrasSpecification,
     groups: GroupsSpecification,
     output_file: Option<&Path>,
@@ -385,7 +386,13 @@ pub(crate) async fn pip_compile(
     };
 
     let artifact_environments = if universal {
-        environments.clone()
+        SupportedEnvironments::from_markers(
+            environments
+                .iter()
+                .chain(required_environments.iter())
+                .copied()
+                .collect(),
+        )
     } else {
         SupportedEnvironments::default()
     };

--- a/crates/fyn/src/commands/pip/install.rs
+++ b/crates/fyn/src/commands/pip/install.rs
@@ -558,7 +558,11 @@ pub(crate) async fn pip_install(
             &tags,
             &build_options,
         )?;
-        let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
+        let hasher = if let Some(hash_checking) = hash_checking {
+            HashStrategy::from_resolution(&resolution, hash_checking)?
+        } else {
+            HashStrategy::None
+        };
 
         (resolution, hasher)
     } else {

--- a/crates/fyn/src/commands/pip/sync.rs
+++ b/crates/fyn/src/commands/pip/sync.rs
@@ -448,7 +448,11 @@ pub(crate) async fn pip_sync(
             &tags,
             &build_options,
         )?;
-        let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
+        let hasher = if let Some(hash_checking) = hash_checking {
+            HashStrategy::from_resolution(&resolution, hash_checking)?
+        } else {
+            HashStrategy::None
+        };
 
         (resolution, hasher)
     } else {

--- a/crates/fyn/src/commands/project/lock.rs
+++ b/crates/fyn/src/commands/project/lock.rs
@@ -840,9 +840,13 @@ async fn do_lock(
         .await
         {
             Ok(result) => Some(result),
-            Err(ProjectError::Lock(err)) if err.is_resolution() => {
+            Err(ProjectError::Lock(err)) if err.is_resolution() || err.is_no_build() => {
                 // Resolver errors are not recoverable, as such errors can leave the resolver in a
                 // broken state. Specifically, tasks that fail with an error can be left as pending.
+                //
+                // Disabled builds are user policy errors. Static local projects are validated
+                // before this point, so reaching this case means validation genuinely needs
+                // metadata that cannot be obtained under `--no-build`.
                 return Err(ProjectError::Lock(err));
             }
             Err(err) => {
@@ -1244,6 +1248,7 @@ impl ValidatedLock {
                 indexes,
                 interpreter.tags()?,
                 interpreter.markers(),
+                &options.build_options,
                 hasher,
                 index,
                 database,

--- a/crates/fyn/src/commands/status.rs
+++ b/crates/fyn/src/commands/status.rs
@@ -48,6 +48,12 @@ struct StatusEnvironment {
 }
 
 #[derive(Serialize)]
+struct StatusProjectEnvironment {
+    path: String,
+    found: bool,
+}
+
+#[derive(Serialize)]
 struct StatusCheck {
     passed: bool,
     issues: Vec<String>,
@@ -64,6 +70,8 @@ struct StatusReport {
     pyproject_toml: bool,
     fyn_lock: bool,
     pip_in_project: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    project_environment: Option<StatusProjectEnvironment>,
     environment: Option<StatusEnvironment>,
     #[serde(skip_serializing_if = "Option::is_none")]
     check: Option<StatusCheck>,
@@ -75,6 +83,8 @@ struct StatusIssueInputs {
     pyproject_toml: bool,
     fyn_lock: bool,
     environment_found: bool,
+    project_environment_found: Option<bool>,
+    environment_matches_project: Option<bool>,
 }
 
 fn status_issues(inputs: StatusIssueInputs) -> Vec<String> {
@@ -91,6 +101,10 @@ fn status_issues(inputs: StatusIssueInputs) -> Vec<String> {
     }
     if !inputs.environment_found {
         issues.push("environment not found".to_string());
+    } else if matches!(inputs.project_environment_found, Some(false)) {
+        issues.push("project environment not found".to_string());
+    } else if matches!(inputs.environment_matches_project, Some(false)) {
+        issues.push("active environment does not match project environment".to_string());
     }
     issues
 }
@@ -111,6 +125,13 @@ fn status_hint(issue: &str) -> Option<String> {
         "environment not found" => {
             Some("Run `fyn sync` or `fyn venv` to create the project environment.".to_string())
         }
+        "project environment not found" => {
+            Some("Run `fyn sync` or `fyn venv` to create the project environment.".to_string())
+        }
+        "active environment does not match project environment" => Some(
+            "Run `fyn shell` to activate the project environment, or unset `VIRTUAL_ENV` before running fyn."
+                .to_string(),
+        ),
         _ if issue.starts_with("The pinned Python version `") => {
             Some("Run `fyn python pin` to update the pinned Python version.".to_string())
         }
@@ -248,6 +269,22 @@ pub(crate) async fn status(
         .map(|workspace| workspace.install_path().simplified_display().to_string());
     let pyproject_toml = root.join("pyproject.toml").is_file();
     let fyn_lock = root.join("fyn.lock").is_file();
+    let project_environment_path = workspace
+        .as_ref()
+        .map(|workspace| workspace.venv(Some(false)));
+    let project_environment = project_environment_path
+        .as_ref()
+        .and_then(|path| PythonEnvironment::from_root(path, cache).ok());
+    let environment = environment.or_else(|| project_environment.clone());
+    let project_environment_found = project_environment_path
+        .as_ref()
+        .map(|_| project_environment.is_some());
+    let environment_matches_project = environment.as_ref().zip(project_environment.as_ref()).map(
+        |(environment, project_environment)| {
+            fyn_fs::is_same_file_allow_missing(environment.root(), project_environment.root())
+                .unwrap_or(false)
+        },
+    );
     let virtual_project = if check && managed_project {
         match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
             .await
@@ -267,6 +304,8 @@ pub(crate) async fn status(
             pyproject_toml,
             fyn_lock,
             environment_found: environment.is_some(),
+            project_environment_found,
+            environment_matches_project,
         });
         issues.extend(
             python_pin_issues(
@@ -294,6 +333,13 @@ pub(crate) async fn status(
         pyproject_toml,
         fyn_lock,
         pip_in_project: policy_name(pip_in_project_policy(filesystem)),
+        project_environment: project_environment_path
+            .as_ref()
+            .zip(project_environment_found)
+            .map(|(path, found)| StatusProjectEnvironment {
+                path: path.simplified_display().to_string(),
+                found,
+            }),
         environment: environment.as_ref().map(|environment| StatusEnvironment {
             path: environment.root().simplified_display().to_string(),
             python: environment
@@ -361,6 +407,22 @@ pub(crate) async fn status(
         "pip-in-project: {}",
         report.pip_in_project.cyan()
     )?;
+    if let Some(project_environment) = report.project_environment.as_ref() {
+        if project_environment.found {
+            writeln!(
+                printer.stdout(),
+                "project environment: {}",
+                project_environment.path.cyan()
+            )?;
+        } else {
+            writeln!(
+                printer.stdout(),
+                "project environment: {} ({})",
+                project_environment.path.cyan(),
+                "not found".dimmed()
+            )?;
+        }
+    }
 
     if let Some(environment) = report.environment {
         writeln!(printer.stdout(), "environment: {}", environment.path.cyan())?;

--- a/crates/fyn/src/commands/tool/run.rs
+++ b/crates/fyn/src/commands/tool/run.rs
@@ -41,7 +41,7 @@ use fyn_settings::{PythonInstallMirrors, ResolverInstallerOptions, ToolOptions};
 use fyn_shell::runnable::WindowsRunnable;
 use fyn_static::EnvVars;
 use fyn_tool::{InstalledTools, entrypoint_paths};
-use fyn_warnings::warn_user_once;
+use fyn_warnings::{warn_user, warn_user_once};
 use fyn_workspace::WorkspaceCache;
 
 use crate::child::run_to_completion;
@@ -79,6 +79,99 @@ impl Display for ToolRunCommand {
             Self::ToolRun => write!(f, "fyn tool run"),
         }
     }
+}
+
+/// Read dotenv files into an overlay for the spawned tool process.
+///
+/// These values intentionally do not mutate fyn's process environment and cannot mutate the
+/// current fyn process' settings.
+fn read_env_files(
+    env_file: &[PathBuf],
+    no_env_file: bool,
+) -> anyhow::Result<Vec<(String, String)>> {
+    let mut environment = Vec::new();
+
+    if no_env_file {
+        return Ok(environment);
+    }
+
+    for env_file_path in env_file.iter().rev().map(PathBuf::as_path) {
+        let iter = match dotenvy::from_path_iter(env_file_path) {
+            Err(dotenvy::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                bail!(
+                    "No environment file found at: `{}`",
+                    env_file_path.simplified_display()
+                );
+            }
+            Err(dotenvy::Error::Io(err)) => {
+                bail!(
+                    "Failed to read environment file `{}`: {err}",
+                    env_file_path.simplified_display()
+                );
+            }
+            Err(dotenvy::Error::LineParse(content, position)) => {
+                warn_user!(
+                    "Failed to parse environment file `{}` at position {position}: {content}",
+                    env_file_path.simplified_display(),
+                );
+                continue;
+            }
+            Err(err) => {
+                warn_user!(
+                    "Failed to parse environment file `{}`: {err}",
+                    env_file_path.simplified_display(),
+                );
+                continue;
+            }
+            Ok(iter) => iter,
+        };
+
+        let mut parsed = true;
+        for item in iter {
+            match item {
+                Ok((key, value)) => {
+                    if std::env::var(&key).is_err() {
+                        environment.push((key, value));
+                    }
+                }
+                Err(dotenvy::Error::Io(err)) => {
+                    bail!(
+                        "Failed to read environment file `{}`: {err}",
+                        env_file_path.simplified_display()
+                    );
+                }
+                Err(dotenvy::Error::LineParse(content, position)) => {
+                    warn_user!(
+                        "Failed to parse environment file `{}` at position {position}: {content}",
+                        env_file_path.simplified_display(),
+                    );
+                    parsed = false;
+                    break;
+                }
+                Err(err) => {
+                    warn_user!(
+                        "Failed to parse environment file `{}`: {err}",
+                        env_file_path.simplified_display(),
+                    );
+                    parsed = false;
+                    break;
+                }
+            }
+        }
+
+        if parsed {
+            debug!(
+                "Read environment file at: `{}`",
+                env_file_path.simplified_display()
+            );
+        }
+    }
+
+    // `dotenvy::from_path` preserves the first loaded value, while `Command::envs` preserves the
+    // last value set for the child process.
+    environment.reverse();
+
+    Ok(environment)
 }
 
 /// Check if the given arguments contain a verbose flag (e.g., `--verbose`, `-v`, `-vv`, etc.)
@@ -137,10 +230,7 @@ pub(crate) async fn run(
         );
     }
 
-    // Read from the `.env` file, if necessary.
-    if !no_env_file {
-        crate::commands::load_explicit_env_files(env_file.iter().map(PathBuf::as_path))?;
-    }
+    let env_file_environment = read_env_files(&env_file, no_env_file)?;
 
     let Some(command) = command else {
         // When a command isn't provided, we'll show a brief help including available tools
@@ -369,6 +459,7 @@ pub(crate) async fn run(
     };
 
     process.args(args);
+    process.envs(env_file_environment);
 
     // Construct the `PATH` environment variable.
     let new_path = std::env::join_paths(

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -736,6 +736,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.excludes_from_workspace,
                 args.build_constraints_from_workspace,
                 args.environments,
+                args.required_environments,
                 args.settings.extras,
                 groups,
                 args.settings.output_file.as_deref(),

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -2708,6 +2708,7 @@ pub(crate) struct PipCompileSettings {
     pub(crate) excludes_from_workspace: Vec<PackageName>,
     pub(crate) build_constraints_from_workspace: Vec<Requirement>,
     pub(crate) environments: SupportedEnvironments,
+    pub(crate) required_environments: SupportedEnvironments,
     pub(crate) refresh: Refresh,
     pub(crate) settings: PipSettings,
 }
@@ -2830,6 +2831,15 @@ impl PipCompileSettings {
             SupportedEnvironments::default()
         };
 
+        let required_environments = if let Some(configuration) = &filesystem {
+            configuration
+                .required_environments
+                .clone()
+                .unwrap_or_default()
+        } else {
+            SupportedEnvironments::default()
+        };
+
         Self {
             format,
             src_file,
@@ -2854,6 +2864,7 @@ impl PipCompileSettings {
             excludes_from_workspace,
             build_constraints_from_workspace,
             environments,
+            required_environments,
             refresh: Refresh::from(refresh),
             settings: PipSettings::combine(
                 PipOptions {

--- a/crates/fyn/tests/it/pip_compile.rs
+++ b/crates/fyn/tests/it/pip_compile.rs
@@ -14417,6 +14417,59 @@ fn universal_constrained_environment() -> Result<()> {
     Ok(())
 }
 
+/// Resolve with `--universal`, requiring artifact coverage for user-provided environments.
+#[test]
+fn universal_required_environment() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(&indoc::formatdoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["no-sdist-no-wheels-with-matching-platform-a"]
+
+        [tool.fyn]
+        required-environments = ["platform_machine == 'arm64'"]
+
+        [[tool.fyn.index]]
+        name = "packse"
+        url = "{}"
+        default = true
+        "#,
+        packse_index_url()
+    })?;
+
+    let filters: Vec<_> = context
+        .filters()
+        .into_iter()
+        .chain([(
+            // This hint is only shown when the current platform doesn't match the target.
+            r"\n\n\s+hint: The resolution failed for an environment that is not the current one[^\n]*",
+            "",
+        )])
+        .collect();
+
+    fyn_snapshot!(filters, context.pip_compile()
+        .arg("pyproject.toml")
+        .arg("--universal")
+        .arg("--exclude-newer-package")
+        .arg("no-sdist-no-wheels-with-matching-platform-a=false")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies for split (markers: platform_machine == 'arm64'):
+      ╰─▶ Because only no-sdist-no-wheels-with-matching-platform-a==1.0.0 is available and no-sdist-no-wheels-with-matching-platform-a==1.0.0 has no `platform_machine == 'arm64'`-compatible wheels, we can conclude that all versions of no-sdist-no-wheels-with-matching-platform-a cannot be used.
+          And because project depends on no-sdist-no-wheels-with-matching-platform-a, we can conclude that your requirements are unsatisfiable.
+    ");
+
+    Ok(())
+}
+
 /// Resolve a package that has no versions that satisfy the current Python version.
 #[test]
 fn compile_enumerate_no_versions() -> Result<()> {

--- a/crates/fyn/tests/it/pip_install.rs
+++ b/crates/fyn/tests/it/pip_install.rs
@@ -9,6 +9,7 @@ use flate2::write::GzEncoder;
 use fs_err as fs;
 use fs_err::File;
 use indoc::{formatdoc, indoc};
+use insta::assert_snapshot;
 use predicates::prelude::predicate;
 use url::Url;
 use wiremock::{
@@ -2101,6 +2102,36 @@ fn install_editable_bare_cli() {
      + black==0.1.0 (from file://[WORKSPACE]/test/packages/black_editable)
     "
     );
+}
+
+#[test]
+fn install_editable_unnamed_no_build() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.child("setup.py").write_str(indoc! {r#"
+        from setuptools import setup
+
+        setup(name="example", version="0.1.0")
+    "#})?;
+
+    fyn_snapshot!(context.filters(), context.pip_install()
+        .arg("--no-build")
+        .arg("-e")
+        .arg("editable"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + example==0.1.0 (from file://[TEMP_DIR]/editable)
+    "
+    );
+
+    Ok(())
 }
 
 #[test]
@@ -12399,6 +12430,61 @@ fn pep_751_install_directory() -> Result<()> {
 }
 
 #[test]
+fn pep_751_install_require_hashes_directory() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("foo").child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("foo")
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()?;
+
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "fyn"
+        requires-python = ">=3.12"
+
+        [[packages]]
+        name = "foo"
+        version = "1.0.0"
+        directory = { path = "foo" }
+        "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.pip_install()
+        .arg("--preview")
+        .arg("-r")
+        .arg("pylock.toml")
+        .arg("--require-hashes"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: foo
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 #[cfg(feature = "test-git")]
 fn pep_751_install_git() -> Result<()> {
     let context = fyn_test::test_context!("3.12");
@@ -14984,6 +15070,115 @@ fn build_backend_wrong_wheel_platform() -> Result<()> {
       ├─▶ Failed to build `py313 @ file://[TEMP_DIR]/child`
       ╰─▶ The built wheel `py313-0.1.0-py313-none-any.whl` is not compatible with the current Python 3.12 on [ARCH] [OS]
     ");
+
+    Ok(())
+}
+
+/// Test that `tool.fyn.build-backend.data` files are installed for editable builds.
+///
+/// See <https://github.com/astral-sh/uv/issues/19258>.
+#[test]
+fn install_editable_fyn_build_data() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [build-system]
+        requires = ["fyn-build>=0.7,<10000"]
+        build-backend = "fyn_build"
+
+        [tool.fyn.build-backend.data]
+        purelib = "purelib"
+        platlib = "platlib"
+        scripts = "scripts"
+        headers = "headers"
+        data = "data"
+    "#})?;
+
+    context.temp_dir.child("src/project/__init__.py").touch()?;
+    context
+        .temp_dir
+        .child("purelib/project-data.txt")
+        .write_str("project data")?;
+    context
+        .temp_dir
+        .child("platlib/project-platform-data.txt")
+        .write_str("project platform data")?;
+    context
+        .temp_dir
+        .child("scripts/project-script")
+        .write_str(indoc! {r#"
+            #!python
+            print("Hello from project script")
+        "#})?;
+    context
+        .temp_dir
+        .child("headers/project.h")
+        .write_str("#include <stdio.h>")?;
+    context
+        .temp_dir
+        .child("data/project-config.txt")
+        .write_str("project config")?;
+    fyn_snapshot!(context.filters(), context.pip_install().arg("-e").arg("."), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `fyn pip install` modifies the active environment directly and will not update `pyproject.toml` or `fyn.lock`.
+
+    State impact:
+      environment: direct changes only
+      pyproject.toml: unchanged
+      fyn.lock: unchanged
+
+    Because the current directory is inside a fyn-managed project, use `fyn add`, `fyn remove`, `fyn sync`, or `fyn upgrade` instead.
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + project==0.1.0 (from file://[TEMP_DIR]/)
+    ");
+
+    assert_snapshot!(
+        fs::read_to_string(context.site_packages().join("project-data.txt"))?,
+        @"project data"
+    );
+    assert_snapshot!(
+        fs::read_to_string(context.site_packages().join("project-platform-data.txt"))?,
+        @"project platform data"
+    );
+
+    let project_script = fs::read_to_string(venv_bin_path(&context.venv).join("project-script"))?;
+    let normalized_project_script = if let Some(index) = project_script.find('\n') {
+        format!("#![PYTHON]{}", &project_script[index..])
+    } else {
+        project_script
+    };
+    assert_snapshot!(
+        normalized_project_script,
+        @r#"
+        #![PYTHON]
+        print("Hello from project script")
+        "#
+    );
+
+    let record = fs::read_to_string(
+        context
+            .site_packages()
+            .join("project-0.1.0.dist-info")
+            .join("RECORD"),
+    )?;
+    assert!(record.lines().any(|line| line.contains("/project-script")));
+    assert!(record.lines().any(|line| line.contains("/project.h")));
+    assert!(
+        record
+            .lines()
+            .any(|line| line.contains("/project-config.txt"))
+    );
 
     Ok(())
 }

--- a/crates/fyn/tests/it/pip_sync.rs
+++ b/crates/fyn/tests/it/pip_sync.rs
@@ -1306,6 +1306,54 @@ fn install_local_wheel() -> Result<()> {
     Ok(())
 }
 
+/// Reject decoded path separators in an unnamed wheel URL before using the filename in cache paths.
+#[test]
+fn install_unnamed_wheel_url_rejects_path_traversal() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt
+        .write_str("https://example.com/packages/pkg-1.0-py3-none-..%2F..%2F..%2Ftarget.whl")?;
+
+    fyn_snapshot!(context.filters(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--strict"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: The wheel filename \"pkg-1.0-py3-none-../../../target.whl\" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods
+    "
+    );
+
+    Ok(())
+}
+
+/// Reject decoded stream separators in an unnamed wheel URL before using the filename in cache paths.
+#[test]
+fn install_unnamed_wheel_url_rejects_stream_separator() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt
+        .write_str("https://example.com/packages/pkg-1.0-py3-none-target%3Astream.whl")?;
+
+    fyn_snapshot!(context.filters(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--strict"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: The wheel filename \"pkg-1.0-py3-none-target:stream.whl\" is invalid: Tag components must contain only ASCII letters, digits, underscores, and periods
+    "
+    );
+
+    Ok(())
+}
+
 /// Install a wheel whose actual version doesn't match the version encoded in the filename.
 #[test]
 fn mismatched_version() -> Result<()> {
@@ -5975,6 +6023,60 @@ fn pep_751() -> Result<()> {
      - idna==3.6
      + iniconfig==2.0.0
      - sniffio==1.3.1
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn pep_751_require_hashes_directory() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("foo").child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        "#,
+    )?;
+    context
+        .temp_dir
+        .child("foo")
+        .child("src")
+        .child("foo")
+        .child("__init__.py")
+        .touch()?;
+
+    let pylock_toml = context.temp_dir.child("pylock.toml");
+    pylock_toml.write_str(
+        r#"
+        lock-version = "1.0"
+        created-by = "fyn"
+        requires-python = ">=3.12"
+
+        [[packages]]
+        name = "foo"
+        version = "1.0.0"
+        directory = { path = "foo" }
+        "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.pip_sync()
+        .arg("--preview")
+        .arg("pylock.toml")
+        .arg("--require-hashes"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: In `--require-hashes` mode, all requirements must have a hash, but none were provided for: foo
     "
     );
 

--- a/crates/fyn/tests/it/status.rs
+++ b/crates/fyn/tests/it/status.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 
 use fyn_static::EnvVars;
@@ -28,6 +29,7 @@ fn status_in_managed_project() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.12.[X])
 
@@ -92,6 +94,10 @@ fn status_json_in_managed_project() -> Result<()> {
       "pyproject_toml": true,
       "fyn_lock": true,
       "pip_in_project": "warn",
+      "project_environment": {
+        "path": "[VENV]/",
+        "found": true
+      },
       "environment": {
         "path": "[VENV]/",
         "python": "[VENV]/bin/python3",
@@ -167,6 +173,7 @@ fn status_check_in_managed_project() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.12.[X])
     check: ok
@@ -233,6 +240,7 @@ fn status_check_missing_lock() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: no
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.12.[X])
     check: failed
@@ -318,6 +326,7 @@ fn status_check_compatible_python_pin() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.11.[X])
     check: ok
@@ -361,6 +370,7 @@ fn status_check_incompatible_python_pin() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/
     environment: [VENV]/
     python: [VENV]/bin/python3 (3.11.[X])
     check: failed
@@ -405,11 +415,108 @@ fn status_check_missing_environment() -> Result<()> {
     pyproject.toml: yes
     fyn.lock: yes
     pip-in-project: warn
+    project environment: [VENV]/ (not found)
     environment: not found
     python: not found
     check: failed
     issue: environment not found
     hint: Run `fyn sync` or `fyn venv` to create the project environment.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn status_check_missing_project_environment_with_active_environment() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .command()
+            .env(EnvVars::UV_PROJECT_ENVIRONMENT, "project-env")
+            .arg("status")
+            .arg("--check"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    current directory: [TEMP_DIR]/
+    project directory: [TEMP_DIR]/
+    managed project: yes
+    workspace root: [TEMP_DIR]/
+    pyproject.toml: yes
+    fyn.lock: yes
+    pip-in-project: warn
+    project environment: [TEMP_DIR]/project-env (not found)
+    environment: [VENV]/
+    python: [VENV]/bin/python3 (3.12.[X])
+    check: failed
+    issue: project environment not found
+    hint: Run `fyn sync` or `fyn venv` to create the project environment.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn status_check_active_environment_mismatch() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc::indoc! {r#"
+        [project]
+        name = "example"
+        version = "0.1.0"
+    "#})?;
+    context.temp_dir.child("fyn.lock").touch()?;
+
+    context
+        .venv()
+        .env(EnvVars::UV_PROJECT_ENVIRONMENT, "project-env")
+        .assert()
+        .success();
+
+    fyn_snapshot!(
+        context.filters(),
+        context
+            .command()
+            .env(EnvVars::UV_PROJECT_ENVIRONMENT, "project-env")
+            .arg("status")
+            .arg("--check"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    current directory: [TEMP_DIR]/
+    project directory: [TEMP_DIR]/
+    managed project: yes
+    workspace root: [TEMP_DIR]/
+    pyproject.toml: yes
+    fyn.lock: yes
+    pip-in-project: warn
+    project environment: [TEMP_DIR]/project-env
+    environment: [VENV]/
+    python: [VENV]/bin/python3 (3.12.[X])
+    check: failed
+    issue: active environment does not match project environment
+    hint: Run `fyn shell` to activate the project environment, or unset `VIRTUAL_ENV` before running fyn.
 
     ----- stderr -----
     "
@@ -451,6 +558,10 @@ fn status_json_check_incompatible_python_pin() -> Result<()> {
       "pyproject_toml": true,
       "fyn_lock": true,
       "pip_in_project": "warn",
+      "project_environment": {
+        "path": "[VENV]/",
+        "found": true
+      },
       "environment": {
         "path": "[VENV]/",
         "python": "[VENV]/bin/python3",

--- a/crates/fyn/tests/it/sync.rs
+++ b/crates/fyn/tests/it/sync.rs
@@ -6050,6 +6050,68 @@ fn no_install_project_no_build() -> Result<()> {
     Ok(())
 }
 
+/// Ensure that lock validation respects `--no-build` when the project itself won't be installed.
+#[test]
+fn no_install_project_no_build_locked_dynamic_metadata() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dynamic = ["dependencies"]
+
+        [build-system]
+        requires = []
+        backend-path = ["."]
+        build-backend = "build_backend"
+    "#})?;
+
+    let build_backend = context.temp_dir.child("build_backend.py");
+    build_backend.write_str(indoc! {r#"
+        import pathlib
+
+        def prepare_metadata_for_build_editable(metadata_directory, config_settings=None):
+            pathlib.Path("validation-hook-called").write_text("called")
+            dist_info = pathlib.Path(metadata_directory, "project-0.1.0.dist-info")
+            dist_info.mkdir()
+            dist_info.joinpath("METADATA").write_text(
+                "Metadata-Version: 2.1\n"
+                "Name: project\n"
+                "Version: 0.1.0\n"
+                "Requires-Dist: anyio==3.7.0\n"
+            )
+            return dist_info.name
+    "#})?;
+
+    // Generate a lockfile, then remove the cached metadata so validation would need to invoke the
+    // build backend again if it ignored `--no-build`.
+    context.lock().assert().success();
+
+    let marker = context.temp_dir.child("validation-hook-called");
+    assert!(marker.exists());
+    fs_err::remove_file(marker.path())?;
+    fs_err::remove_dir_all(&context.cache_dir)?;
+
+    fyn_snapshot!(context.filters(), context.sync()
+        .arg("--no-install-project")
+        .arg("--no-build")
+        .arg("--locked"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Distribution `project==0.1.0 @ editable+.` can't be installed because it is marked as `--no-build` but has no binary distribution
+    ");
+
+    assert!(!marker.exists());
+
+    Ok(())
+}
+
 #[test]
 fn sync_extra_build_dependencies_script() -> Result<()> {
     let context = fyn_test::test_context!("3.12").with_filtered_counts();

--- a/crates/fyn/tests/it/tool_run.rs
+++ b/crates/fyn/tests/it/tool_run.rs
@@ -1,6 +1,11 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
+#[cfg(unix)]
+use fs_err::{metadata, set_permissions};
 use fyn_fs::copy_dir_all;
 use fyn_static::EnvVars;
 use fyn_test::{fyn_snapshot, venv_bin_path};
@@ -2671,6 +2676,60 @@ fn run_with_env_file() -> anyhow::Result<()> {
     ----- stderr -----
     Resolved [N] packages in [TIME]
     ");
+
+    let evil_tools = context.temp_dir.child(".evil-tools");
+    let evil_tool = evil_tools.child("foo");
+    let evil_python = if cfg!(windows) {
+        let scripts = evil_tool.child("Scripts");
+        scripts.create_dir_all()?;
+        scripts.child("python.exe")
+    } else {
+        let bin = evil_tool.child("bin");
+        bin.create_dir_all()?;
+        bin.child("python3")
+    };
+    evil_python.write_str(indoc! { r"
+        #!/bin/sh
+        echo queried > queried.txt
+        exit 1
+    " })?;
+
+    #[cfg(unix)]
+    {
+        let mut permissions = metadata(evil_python.path())?.permissions();
+        permissions.set_mode(0o755);
+        set_permissions(evil_python.path(), permissions)?;
+    }
+
+    context.temp_dir.child(".file").write_str(indoc! { "
+        UV_TOOL_DIR=.evil-tools
+        THE_EMPIRE_VARIABLE=palpatine
+        REBEL_1=leia_organa
+        REBEL_2=obi_wan_kenobi
+        REBEL_3=C3PO
+       "
+    })?;
+
+    fyn_snapshot!(context.filters(), context.tool_run()
+        .arg("--from")
+        .arg("./foo")
+        .arg("script")
+        .env(EnvVars::UV_ENV_FILE, ".file")
+        .env(EnvVars::UV_TOOL_DIR, tool_dir.as_os_str())
+        .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    palpatine
+    leia_organa
+    obi_wan_kenobi
+    C3PO
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    ");
+
+    assert!(!context.temp_dir.child("queried.txt").exists());
 
     Ok(())
 }

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -188,12 +188,14 @@ workspace root: /path/to/project
 pyproject.toml: yes
 fyn.lock: yes
 pip-in-project: warn
+project environment: /path/to/project/.venv
 environment: /path/to/project/.venv
 python: /path/to/project/.venv/bin/python3 (3.12.0)
 ```
 
 This is useful when you want to confirm whether you're inside a managed project, whether the
-lockfile is present, and which environment and Python interpreter fyn is currently using.
+lockfile is present, which project environment fyn expects, and which environment and Python
+interpreter fyn is currently using.
 
 For automation, use `--check` to fail when obvious project checks do not pass:
 
@@ -206,10 +208,10 @@ hint: Run `fyn sync` or `fyn venv` to create the project environment.
 ```
 
 `--check` fails if you are not inside a managed project. In managed projects, it also fails if
-`pyproject.toml`, `fyn.lock`, or the project environment is missing, or if the discovered
-`.python-version` pin does not satisfy the project's `requires-python`. Text output includes
-`issue:` and `hint:` lines, while `--json` exposes the same data via `check.issues` and
-`check.hints`.
+`pyproject.toml`, `fyn.lock`, or the project environment is missing, if the active environment does
+not match the project environment, or if the discovered `.python-version` pin does not satisfy the
+project's `requires-python`. Text output includes `issue:` and `hint:` lines, while `--json` exposes
+the same data via `check.issues` and `check.hints`.
 
 For editor integrations, scripts, or CI tooling, use JSON output:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,13 +98,14 @@ workspace root: /home/user/example
 pyproject.toml: yes
 fyn.lock: yes
 pip-in-project: warn
+project environment: /home/user/example/.venv
 environment: /home/user/example/.venv
 python: /home/user/example/.venv/bin/python3 (3.12.0)
 ```
 
 Use `fyn status --check` to fail fast in CI or editor integrations. In managed projects, it also
-reports missing environments and `.python-version` pins that do not satisfy `requires-python`, and
-prints matching `hint:` lines with the next command to run.
+reports missing or mismatched project environments and `.python-version` pins that do not satisfy
+`requires-python`, and prints matching `hint:` lines with the next command to run.
 
 Use `fyn upgrade` to refresh all dependencies or only the packages you name:
 


### PR DESCRIPTION
## Summary

  - harden wheel filename parsing across build tags, tag segments, and platform release/arch tags
  - avoid applying `tool run` `.env` files to fyn’s parent process
  - respect `--no-build` during lock validation
  - include `required-environments` when resolving `fyn pip compile --universal`
  - make pylock install/sync hash behavior follow `--require-hashes`
  - include `tool.fyn.build-backend.data` files in editable builds

  ## Tests

  - `cargo fmt --check`
  - `git diff --check`
  - `cargo test -p fyn-distribution-filename -p fyn-platform-tags -p fyn-build-backend`
  - `cargo test -p fyn-distribution -p fyn-resolver`
  - `cargo test -p fyn --test it run_with_env_file`
  - `cargo test -p fyn --test it no_install_project_no_build`
  - `cargo test -p fyn --test it install_editable_unnamed_no_build`
  - `cargo test -p fyn --test it universal_required_environment`
  - `cargo test -p fyn --test it require_hashes_directory`
  - `cargo test -p fyn --test it install_editable_fyn_build_data`
  - `cargo test -p fyn --test it install_unnamed_wheel_url_rejects`
  - `cargo test -p fyn --test it record_uses_forward_slashes`
  - `cargo test -p fyn --test it universal_constrained_environment`