### PR TITLE
fix: backport uv linker conflict registration

### DIFF
--- a/crates/fyn-install-wheel/src/install.rs
+++ b/crates/fyn-install-wheel/src/install.rs
@@ -69,13 +69,13 @@ pub fn install_wheel<Cache: serde::Serialize, Build: serde::Serialize>(
 
     // > 1.c If Root-Is-Purelib == ‘true’, unpack archive into purelib (site-packages).
     // > 1.d Else unpack archive into platlib (site-packages).
-    trace!(?name, "Extracting file");
+    trace!(?name, "Extracting wheel files");
     let site_packages = match lib_kind {
         LibKind::Pure => &layout.scheme.purelib,
         LibKind::Plat => &layout.scheme.platlib,
     };
-    let num_unpacked = link_wheel_files(link_mode, site_packages, &wheel, state, filename)?;
-    trace!(?name, "Extracted {num_unpacked} files");
+    link_wheel_files(link_mode, site_packages, &wheel, state, filename)?;
+    trace!(?name, "Extracted wheel files");
 
     // Read the RECORD file.
     let mut record_file = File::open(

--- a/crates/fyn-install-wheel/src/linker.rs
+++ b/crates/fyn-install-wheel/src/linker.rs
@@ -8,7 +8,6 @@ use fs_err as fs;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use tracing::{debug, instrument};
-use walkdir::WalkDir;
 
 use fyn_distribution_filename::WheelFilename;
 use fyn_fs::Simplified;
@@ -249,8 +248,6 @@ impl InstallState {
 }
 
 /// Extract a wheel by linking all of its files into site packages.
-///
-/// Returns the number of files extracted.
 #[instrument(skip_all)]
 pub fn link_wheel_files(
     link_mode: LinkMode,
@@ -258,10 +255,10 @@ pub fn link_wheel_files(
     wheel: impl AsRef<Path>,
     state: &InstallState,
     filename: &WheelFilename,
-) -> Result<usize, Error> {
+) -> Result<(), Error> {
     let wheel = wheel.as_ref();
     let site_packages = site_packages.as_ref();
-    let count = register_installed_paths(wheel, state, filename)?;
+    register_installed_paths(wheel, state, filename)?;
 
     // The `RECORD` file is modified during installation, so it needs a real
     // copy rather than a link back to the cache.
@@ -281,7 +278,7 @@ pub fn link_wheel_files(
         update_site_packages_mtime(site_packages);
     }
 
-    Ok(count)
+    Ok(())
 }
 
 /// Update the mtime of the site-packages directory to the current time.
@@ -303,23 +300,17 @@ fn update_site_packages_mtime(site_packages: &Path) {
     }
 }
 
-/// Walk the wheel directory and register all paths for conflict detection.
-///
-/// Returns the number of files (not directories) in the wheel.
+/// Register top-level wheel paths for conflict detection.
 fn register_installed_paths(
     wheel: &Path,
     state: &InstallState,
     filename: &WheelFilename,
-) -> Result<usize, Error> {
-    let mut count = 0;
-    for entry in WalkDir::new(wheel) {
+) -> Result<(), Error> {
+    for entry in fs::read_dir(wheel)? {
         let entry = entry?;
         let path = entry.path();
-        let relative = path.strip_prefix(wheel).expect("walkdir starts with root");
-        state.register_installed_path(relative, path, filename);
-        if entry.file_type().is_file() {
-            count += 1;
-        }
+        let relative = PathBuf::from(entry.file_name());
+        state.register_installed_path(&relative, &path, filename);
     }
-    Ok(count)
+    Ok(())
 }


### PR DESCRIPTION
Backports uv #19382 into `fyn-install-wheel`.

## Summary

  - register only top-level wheel entries for module conflict detection
  - avoid recursively walking the entire unpacked wheel before discarding nested paths
  - simplify `link_wheel_files` now that the extracted file count is no longer needed

  ## Tests

  - `cargo test -p fyn-install-wheel`
  - `cargo test -p fyn --test it overlapping_`
  - `cargo test -p fyn --test it install_local_wheel`
  - `cargo fmt --check`