### PR TITLE
fix: backport uv ANSI logging filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,6 +2728,7 @@ dependencies = [
 name = "fyn-logging"
 version = "0.0.35"
 dependencies = [
+ "anstream 1.0.0",
  "jiff",
  "owo-colors",
  "tracing",

--- a/crates/fyn-logging/Cargo.toml
+++ b/crates/fyn-logging/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+anstream = { workspace = true }
 jiff = { workspace = true }
 owo-colors = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/fyn-logging/src/lib.rs
+++ b/crates/fyn-logging/src/lib.rs
@@ -2,8 +2,9 @@ use std::fmt;
 
 use jiff::Timestamp;
 use owo_colors::OwoColorize;
-use tracing::{Event, Subscriber};
-use tracing_subscriber::fmt::format::Writer;
+use tracing::{Event, Subscriber, field::Field};
+use tracing_subscriber::field::MakeExt;
+use tracing_subscriber::fmt::format::{self, Writer};
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields};
 use tracing_subscriber::registry::LookupSpan;
 
@@ -91,5 +92,69 @@ where
         ctx.field_format().format_fields(writer.by_ref(), event)?;
 
         writeln!(writer)
+    }
+}
+
+/// Return the field formatter for fyn logging.
+///
+/// The event formatter is responsible for fyn's own log colors, such as the level prefix. Field
+/// values can come from arbitrary `Display` or `Debug` implementations, so strip any ANSI escape
+/// sequences there before writing them to the log line.
+pub fn fyn_fields() -> impl for<'writer> FormatFields<'writer> {
+    format::debug_fn(format_field)
+        .display_messages()
+        .delimited(" ")
+}
+
+fn format_field(writer: &mut Writer<'_>, field: &Field, value: &dyn fmt::Debug) -> fmt::Result {
+    // Match tracing-subscriber's default field formatting.
+    let field = field.name();
+    if field.starts_with("log.") {
+        return Ok(());
+    }
+
+    let value = format!("{value:?}");
+    let value = anstream::adapter::strip_str(&value);
+
+    if field == "message" {
+        write!(writer, "{value}")
+    } else {
+        write!(
+            writer,
+            "{}={value}",
+            // Render `type=...` instead of `r#type=...`.
+            field.strip_prefix("r#").unwrap_or(field)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::{Callsite, Event, Level, field::Value, metadata::Kind};
+    use tracing_subscriber::fmt::FormatFields;
+    use tracing_subscriber::fmt::format::Writer;
+
+    use super::fyn_fields;
+
+    #[test]
+    fn strips_ansi_from_message_fields() {
+        let callsite = tracing::callsite! {
+            name: "event",
+            kind: Kind::EVENT,
+            level: Level::TRACE,
+            fields: message
+        };
+        let metadata = callsite.metadata();
+        let message = format_args!("Error trace: {}", "\x1b[36m\x1b[1mhint\x1b[0m");
+        let values = [Some(&message as &dyn Value)];
+        let fields = metadata.fields().value_set_all(&values);
+        let event = Event::new(metadata, &fields);
+        let mut output = String::new();
+
+        fyn_fields()
+            .format_fields(Writer::new(&mut output), event)
+            .expect("field formatting should succeed");
+
+        assert_eq!(output, "Error trace: hint");
     }
 }

--- a/crates/fyn/src/logging.rs
+++ b/crates/fyn/src/logging.rs
@@ -13,7 +13,7 @@ use tracing_tree::HierarchicalLayer;
 use tracing_tree::time::Uptime;
 
 use fyn_cli::ColorChoice;
-use fyn_logging::UvFormat;
+use fyn_logging::{UvFormat, fyn_fields};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Level {
@@ -106,6 +106,7 @@ pub(crate) fn setup_logging(
             .with(
                 tracing_subscriber::fmt::layer()
                     .event_format(UvFormat::default())
+                    .fmt_fields(fyn_fields())
                     .with_writer(writer)
                     .with_ansi(ansi)
                     .with_filter(filter),


### PR DESCRIPTION
Backports uv #19311 into fyn logging.
 
## Summary

  - stripped ANSI escape sequences from tracing field values before writing log lines
  - kept fyn-owned log formatting behavior intact
  - wires the sanitized field formatter into normal CLI logging output

  ## Tests

  - `cargo test -p fyn-logging`
  - `cargo check -p fyn`
  - `cargo fmt --check`