### PR TITLE
feat: add fyn why dependency explanations

### DIFF
--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -48,6 +48,7 @@ you ask for.
   `fyn run --list-tasks`.
 - **`fyn shell`**
 - **`fyn upgrade`**
+- **`fyn why`** — explain the dependency paths that include a package.
 - **`fyn status`**
 - **Managed-project pip guardrails** — configure `pip-in-project = "warn" | "error" | "allow"` to
   control direct `fyn pip` mutations inside managed projects.
@@ -65,6 +66,7 @@ you ask for.
 | Task runner                     | No `[tool.uv.tasks]`                  | `[tool.fyn.tasks]`                        |
 | `shell` command                 | No `uv shell`                         | `fyn shell`                               |
 | `upgrade` command               | No `uv upgrade`                       | `fyn upgrade`                             |
+| `why` command                   | No `uv why`                           | `fyn why`                                 |
 | `status` command                | No `uv status`                        | `fyn status`                              |
 | Managed-project `pip` policy    | No `pip-in-project` setting           | `pip-in-project` = warn \| error \| allow |
 | Cache size limit                | No `UV_CACHE_MAX_SIZE`                | `UV_CACHE_MAX_SIZE`                       |

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ reduced package-index request metadata, added features, and long-standing bug fi
 - Built-in [task runner](#task-runner) — define and run project tasks in `pyproject.toml`.
 - [Activates virtual environments](#shell-activation) with `fyn shell`.
 - [Upgrades dependencies](#upgrade-dependencies) in one command with `fyn upgrade`.
+- Explains dependency paths with `fyn why <package>`.
 - [Runs scripts](#scripts), with support for inline dependency metadata.
 - [Installs and manages](#python-versions) Python versions.
 - [Runs and installs](#tools) tools published as Python packages.
@@ -167,6 +168,20 @@ success: Dependencies upgraded successfully.
 Supports `--dry-run` and `--no-sync`.
 
 `fyn upgrade` is the convenience form of running `fyn lock --upgrade` and then `fyn sync`.
+
+### Explain dependencies
+
+Show the project dependency paths that include a package:
+
+```console
+$ fyn why numpy
+numpy is included because:
+project v0.1.0 -> pandas v2.2.1 -> numpy v1.26.4
+project v0.1.0 -> scikit-learn v1.4.1.post1 -> scipy v1.12.0 -> numpy v1.26.4
+```
+
+Use `--universal` to ignore the current platform and Python version, or the dependency group flags
+such as `--group`, `--only-group`, and `--no-dev` to explain the selected project view.
 
 ### Project status
 
@@ -415,6 +430,7 @@ comparison, or the table below for some of the larger user-visible differences:
 | Task runner                   | No `[tool.uv.tasks]`                  | `[tool.fyn.tasks]`                            |
 | `shell` command               | No `uv shell`                         | `fyn shell`                                   |
 | `upgrade` command             | No `uv upgrade`                       | `fyn upgrade`                                 |
+| `why` command                 | No `uv why`                           | `fyn why`                                     |
 | `status` command              | No `uv status`                        | `fyn status`                                  |
 | `torch doctor` command        | No `uv torch doctor`                  | `fyn torch doctor`                            |
 | Managed-project `pip` policy  | No `pip-in-project` setting           | `pip-in-project`: `warn`, `error`, or `allow` |

--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -1276,6 +1276,8 @@ pub enum ProjectCommand {
     Export(ExportArgs),
     /// Display the project's dependency tree.
     Tree(TreeArgs),
+    /// Explain why a package is included in the project.
+    Why(WhyArgs),
     /// Format Python code in the project.
     ///
     /// Formats Python code using the Ruff formatter. By default, all Python files in the project
@@ -5763,7 +5765,7 @@ pub struct TreeArgs {
     /// Shows resolved package versions for all Python versions and platforms, rather than filtering
     /// to those that are relevant for the current environment.
     ///
-    /// Multiple versions may be shown for a each package.
+    /// Multiple versions may be shown for each package.
     #[arg(long)]
     pub universal: bool,
 
@@ -5881,6 +5883,151 @@ pub struct TreeArgs {
     ///
     /// By default, the tree is filtered to match the platform as reported by the Python
     /// interpreter. Use `--universal` to display the tree for all platforms, or use
+    /// `--python-version` or `--python-platform` to override a subset of markers.
+    ///
+    /// See `fyn help python` for details on Python discovery and supported request formats.
+    #[arg(
+        long,
+        short,
+        env = EnvVars::UV_PYTHON,
+        verbatim_doc_comment,
+        help_heading = "Python options",
+        value_parser = parse_maybe_string,
+        value_hint = ValueHint::Other,
+    )]
+    pub python: Option<Maybe<String>>,
+}
+
+#[derive(Args)]
+pub struct WhyArgs {
+    /// The package to explain.
+    #[arg(value_hint = ValueHint::Other)]
+    pub package: PackageName,
+
+    /// Show platform-independent dependency paths.
+    ///
+    /// Shows resolved package versions for all Python versions and platforms, rather than filtering
+    /// to those that are relevant for the current environment.
+    ///
+    /// Multiple versions may be shown for each package.
+    #[arg(long)]
+    pub universal: bool,
+
+    /// Maximum dependency path depth.
+    #[arg(long, short, default_value_t = 255)]
+    pub depth: u8,
+
+    /// Include the development dependency group [env: UV_DEV=]
+    ///
+    /// Development dependencies are defined via `dependency-groups.dev` or
+    /// `tool.fyn.dev-dependencies` in a `pyproject.toml`.
+    ///
+    /// This option is an alias for `--group dev`.
+    #[arg(long, overrides_with("no_dev"), hide = true, value_parser = clap::builder::BoolishValueParser::new())]
+    pub dev: bool,
+
+    /// Only include the development dependency group.
+    ///
+    /// The project and its dependencies will be omitted.
+    ///
+    /// This option is an alias for `--only-group dev`. Implies `--no-default-groups`.
+    #[arg(long, conflicts_with_all = ["group", "all_groups", "no_dev"])]
+    pub only_dev: bool,
+
+    /// Disable the development dependency group [env: UV_NO_DEV=]
+    ///
+    /// This option is an alias of `--no-group dev`.
+    /// See `--no-default-groups` to disable all default groups instead.
+    #[arg(long, overrides_with("dev"), value_parser = clap::builder::BoolishValueParser::new())]
+    pub no_dev: bool,
+
+    /// Include dependencies from the specified dependency group.
+    ///
+    /// May be provided multiple times.
+    #[arg(long, conflicts_with_all = ["only_group", "only_dev"])]
+    pub group: Vec<GroupName>,
+
+    /// Disable the specified dependency group.
+    ///
+    /// This option always takes precedence over default groups,
+    /// `--all-groups`, and `--group`.
+    ///
+    /// May be provided multiple times.
+    #[arg(long, env = EnvVars::UV_NO_GROUP, value_delimiter = ' ')]
+    pub no_group: Vec<GroupName>,
+
+    /// Ignore the default dependency groups.
+    ///
+    /// fyn includes the groups defined in `tool.fyn.default-groups` by default.
+    /// This disables that option, however, specific groups can still be included with `--group`.
+    #[arg(long, env = EnvVars::UV_NO_DEFAULT_GROUPS, value_parser = clap::builder::BoolishValueParser::new())]
+    pub no_default_groups: bool,
+
+    /// Only include dependencies from the specified dependency group.
+    ///
+    /// The project and its dependencies will be omitted.
+    ///
+    /// May be provided multiple times. Implies `--no-default-groups`.
+    #[arg(long, conflicts_with_all = ["group", "dev", "all_groups"])]
+    pub only_group: Vec<GroupName>,
+
+    /// Include dependencies from all dependency groups.
+    ///
+    /// `--no-group` can be used to exclude specific groups.
+    #[arg(long, conflicts_with_all = ["only_group", "only_dev"])]
+    pub all_groups: bool,
+
+    /// Assert that the `fyn.lock` will remain unchanged [env: UV_LOCKED=]
+    ///
+    /// Requires that the lockfile is up-to-date. If the lockfile is missing or needs to be updated,
+    /// fyn will exit with an error.
+    #[arg(long, conflicts_with_all = ["frozen", "upgrade"])]
+    pub locked: bool,
+
+    /// Display the requirements without locking the project [env: UV_FROZEN=]
+    ///
+    /// If the lockfile is missing, fyn will exit with an error.
+    #[arg(long, conflicts_with_all = ["locked", "upgrade", "no_sources"])]
+    pub frozen: bool,
+
+    #[command(flatten)]
+    pub build: BuildOptionsArgs,
+
+    #[command(flatten)]
+    pub resolver: ResolverArgs,
+
+    /// Explain dependencies for the specified PEP 723 Python script, rather than the current
+    /// project.
+    ///
+    /// If provided, fyn will resolve the dependencies based on its inline metadata table, in
+    /// adherence with PEP 723.
+    #[arg(long, value_hint = ValueHint::FilePath)]
+    pub script: Option<PathBuf>,
+
+    /// The Python version to use when filtering dependency paths.
+    ///
+    /// For example, pass `--python-version 3.10` to display the paths that would be included
+    /// when installing on Python 3.10.
+    ///
+    /// Defaults to the version of the discovered Python interpreter.
+    #[arg(long, conflicts_with = "universal")]
+    pub python_version: Option<PythonVersion>,
+
+    /// The platform to use when filtering dependency paths.
+    ///
+    /// For example, pass `--platform windows` to display the paths that would be included when
+    /// installing on Windows.
+    ///
+    /// Represented as a "target triple", a string that describes the target platform in terms of
+    /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
+    /// `aarch64-apple-darwin`.
+    #[arg(long, conflicts_with = "universal")]
+    pub python_platform: Option<TargetTriple>,
+
+    /// The Python interpreter to use for locking and filtering.
+    ///
+    /// By default, dependency paths are filtered to match the platform as reported by the Python
+    /// interpreter. Use `--universal` to display paths for all platforms, or use
     /// `--python-version` or `--python-platform` to override a subset of markers.
     ///
     /// See `fyn help python` for details on Python discovery and supported request formats.

--- a/crates/fyn-resolver/src/lib.rs
+++ b/crates/fyn-resolver/src/lib.rs
@@ -12,7 +12,7 @@ pub use fork_strategy::ForkStrategy;
 pub use lock::{
     Installable, Lock, LockError, LockVersion, Package, PackageMap, PylockToml,
     PylockTomlErrorKind, RequirementsTxtExport, ResolverManifest, SatisfiesResult, TreeDisplay,
-    VERSION, cyclonedx_json,
+    VERSION, WhyDisplay, cyclonedx_json,
 };
 pub use manifest::Manifest;
 pub use options::{Flexibility, Options, OptionsBuilder};

--- a/crates/fyn-resolver/src/lock/mod.rs
+++ b/crates/fyn-resolver/src/lock/mod.rs
@@ -62,6 +62,7 @@ pub use crate::lock::export::{PylockToml, PylockTomlErrorKind, cyclonedx_json};
 pub use crate::lock::installable::Installable;
 pub use crate::lock::map::PackageMap;
 pub use crate::lock::tree::TreeDisplay;
+pub use crate::lock::why::WhyDisplay;
 use crate::resolution::{AnnotatedDist, ResolutionGraphNode};
 use crate::universal_marker::{ConflictMarker, UniversalMarker};
 use crate::{
@@ -73,6 +74,7 @@ mod export;
 mod installable;
 mod map;
 mod tree;
+mod why;
 
 /// The current version of the lockfile format.
 pub const VERSION: u32 = 1;

--- a/crates/fyn-resolver/src/lock/why.rs
+++ b/crates/fyn-resolver/src/lock/why.rs
@@ -1,0 +1,420 @@
+use std::collections::BTreeSet;
+use std::fmt::Write;
+
+use itertools::Itertools;
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+
+use fyn_configuration::DependencyGroupsWithDefaults;
+use fyn_distribution_types::Requirement;
+use fyn_normalize::{ExtraName, GroupName, PackageName};
+use fyn_pep508::MarkerTree;
+use fyn_pypi_types::ResolverMarkerEnvironment;
+
+use crate::lock::{Dependency, Lock, Package, PackageId};
+
+#[derive(Debug)]
+pub struct WhyDisplay {
+    target: PackageName,
+    paths: Vec<String>,
+}
+
+impl WhyDisplay {
+    /// Explain why the target package is included in the project dependency graph.
+    pub fn new(
+        lock: &Lock,
+        markers: Option<&ResolverMarkerEnvironment>,
+        target: &PackageName,
+        depth: usize,
+        groups: &DependencyGroupsWithDefaults,
+    ) -> Self {
+        let members: BTreeSet<&PackageId> = if lock.members().is_empty() {
+            lock.root().into_iter().map(|package| &package.id).collect()
+        } else {
+            lock.packages
+                .iter()
+                .filter_map(|package| {
+                    if lock.members().contains(&package.id.name) {
+                        Some(&package.id)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        };
+
+        let by_name: FxHashMap<_, Vec<_>> = lock.packages().iter().fold(
+            FxHashMap::with_capacity_and_hasher(lock.len(), FxBuildHasher),
+            |mut map, package| {
+                map.entry(package.name()).or_default().push(package);
+                map
+            },
+        );
+
+        let mut display = Self {
+            target: target.clone(),
+            paths: Vec::new(),
+        };
+        let mut paths = BTreeSet::new();
+
+        for id in members.iter().copied() {
+            let package = lock.find_by_id(id);
+            let mut path = vec![Step {
+                package: &package.id,
+                edge: None,
+            }];
+            let mut seen = FxHashSet::default();
+            display.visit(
+                lock,
+                package,
+                &[],
+                true,
+                markers,
+                depth,
+                groups,
+                &members,
+                &mut seen,
+                &mut path,
+                &mut paths,
+            );
+        }
+
+        for requirement in lock.requirements() {
+            for package in matching_packages(&by_name, requirement, markers) {
+                let active_extras = requirement.extras.iter().collect::<Vec<_>>();
+                let edge = (!active_extras.is_empty()).then(|| Edge::Prod(active_extras.clone()));
+                let mut path = vec![Step {
+                    package: &package.id,
+                    edge,
+                }];
+                let mut seen = FxHashSet::default();
+                display.visit(
+                    lock,
+                    package,
+                    &active_extras,
+                    false,
+                    markers,
+                    depth,
+                    groups,
+                    &members,
+                    &mut seen,
+                    &mut path,
+                    &mut paths,
+                );
+            }
+        }
+
+        for (group, requirements) in lock.dependency_groups() {
+            if !groups.contains(group) {
+                continue;
+            }
+
+            for requirement in requirements {
+                for package in matching_packages(&by_name, requirement, markers) {
+                    let active_extras = requirement.extras.iter().collect::<Vec<_>>();
+                    let mut path = vec![Step {
+                        package: &package.id,
+                        edge: Some(Edge::Dev(group, active_extras.clone())),
+                    }];
+                    let mut seen = FxHashSet::default();
+                    display.visit(
+                        lock,
+                        package,
+                        &active_extras,
+                        false,
+                        markers,
+                        depth,
+                        groups,
+                        &members,
+                        &mut seen,
+                        &mut path,
+                        &mut paths,
+                    );
+                }
+            }
+        }
+
+        display.paths = paths.into_iter().collect();
+        display
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn visit<'lock>(
+        &self,
+        lock: &'lock Lock,
+        package: &'lock Package,
+        active_extras: &[&'lock ExtraName],
+        include_workspace_extras: bool,
+        markers: Option<&ResolverMarkerEnvironment>,
+        depth: usize,
+        groups: &DependencyGroupsWithDefaults,
+        members: &BTreeSet<&'lock PackageId>,
+        seen: &mut FxHashSet<&'lock PackageId>,
+        path: &mut Vec<Step<'lock>>,
+        paths: &mut BTreeSet<String>,
+    ) {
+        if !seen.insert(&package.id) {
+            return;
+        }
+
+        if package.name() == &self.target {
+            paths.insert(format_path(path));
+            seen.remove(&package.id);
+            return;
+        }
+
+        if path.len().saturating_sub(1) >= depth {
+            seen.remove(&package.id);
+            return;
+        }
+
+        let is_member = members.contains(&package.id);
+
+        if !is_member || groups.prod() {
+            for dependency in package.dependencies() {
+                self.visit_dependency(
+                    lock,
+                    dependency,
+                    EdgeKind::Prod,
+                    markers,
+                    depth,
+                    groups,
+                    members,
+                    seen,
+                    path,
+                    paths,
+                );
+            }
+        }
+
+        if is_member {
+            for (group, dependencies) in package.resolved_dependency_groups() {
+                if !groups.contains(group) {
+                    continue;
+                }
+
+                for dependency in dependencies {
+                    self.visit_dependency(
+                        lock,
+                        dependency,
+                        EdgeKind::Dev(group),
+                        markers,
+                        depth,
+                        groups,
+                        members,
+                        seen,
+                        path,
+                        paths,
+                    );
+                }
+            }
+        }
+
+        let extras = if include_workspace_extras && groups.prod() {
+            EitherExtras::Both(
+                active_extras.iter().copied(),
+                package.optional_dependencies().keys(),
+            )
+        } else {
+            EitherExtras::Active(active_extras.iter().copied())
+        };
+
+        for extra in extras {
+            let Some(dependencies) = package.optional_dependencies().get(extra) else {
+                continue;
+            };
+            for dependency in dependencies {
+                self.visit_dependency(
+                    lock,
+                    dependency,
+                    EdgeKind::Optional(extra),
+                    markers,
+                    depth,
+                    groups,
+                    members,
+                    seen,
+                    path,
+                    paths,
+                );
+            }
+        }
+
+        seen.remove(&package.id);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn visit_dependency<'lock>(
+        &self,
+        lock: &'lock Lock,
+        dependency: &'lock Dependency,
+        edge_kind: EdgeKind<'lock>,
+        markers: Option<&ResolverMarkerEnvironment>,
+        depth: usize,
+        groups: &DependencyGroupsWithDefaults,
+        members: &BTreeSet<&'lock PackageId>,
+        seen: &mut FxHashSet<&'lock PackageId>,
+        path: &mut Vec<Step<'lock>>,
+        paths: &mut BTreeSet<String>,
+    ) {
+        if markers
+            .is_some_and(|markers| !dependency.complexified_marker.evaluate_no_extras(markers))
+        {
+            return;
+        }
+
+        let active_extras = dependency.extra().iter().collect::<Vec<_>>();
+        let edge = match edge_kind {
+            EdgeKind::Prod => Edge::Prod(active_extras.clone()),
+            EdgeKind::Optional(extra) => Edge::Optional(extra, active_extras.clone()),
+            EdgeKind::Dev(group) => Edge::Dev(group, active_extras.clone()),
+        };
+        let package = lock.find_by_id(&dependency.package_id);
+
+        path.push(Step {
+            package: &package.id,
+            edge: Some(edge),
+        });
+        self.visit(
+            lock,
+            package,
+            &active_extras,
+            false,
+            markers,
+            depth,
+            groups,
+            members,
+            seen,
+            path,
+            paths,
+        );
+        path.pop();
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Step<'lock> {
+    package: &'lock PackageId,
+    edge: Option<Edge<'lock>>,
+}
+
+#[derive(Debug, Clone)]
+enum Edge<'lock> {
+    Prod(Vec<&'lock ExtraName>),
+    Optional(&'lock ExtraName, Vec<&'lock ExtraName>),
+    Dev(&'lock GroupName, Vec<&'lock ExtraName>),
+}
+
+impl Edge<'_> {
+    fn extras(&self) -> &[&ExtraName] {
+        match self {
+            Self::Prod(extras) | Self::Optional(_, extras) | Self::Dev(_, extras) => extras,
+        }
+    }
+}
+
+enum EdgeKind<'lock> {
+    Prod,
+    Optional(&'lock ExtraName),
+    Dev(&'lock GroupName),
+}
+
+enum EitherExtras<I, J> {
+    Active(I),
+    Both(I, J),
+}
+
+impl<'a, I, J> Iterator for EitherExtras<I, J>
+where
+    I: Iterator<Item = &'a ExtraName>,
+    J: Iterator<Item = &'a ExtraName>,
+{
+    type Item = &'a ExtraName;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Active(iter) => iter.next(),
+            Self::Both(left, right) => left.next().or_else(|| right.next()),
+        }
+    }
+}
+
+fn matching_packages<'lock>(
+    by_name: &'lock FxHashMap<&'lock PackageName, Vec<&'lock Package>>,
+    requirement: &Requirement,
+    markers: Option<&ResolverMarkerEnvironment>,
+) -> impl Iterator<Item = &'lock Package> {
+    by_name
+        .get(&requirement.name)
+        .into_iter()
+        .flatten()
+        .copied()
+        .filter(move |package| requirement_matches(package, requirement, markers))
+}
+
+fn requirement_matches(
+    package: &Package,
+    requirement: &Requirement,
+    markers: Option<&ResolverMarkerEnvironment>,
+) -> bool {
+    let marker = if package.fork_markers.is_empty() {
+        requirement.marker
+    } else {
+        let mut combined = MarkerTree::FALSE;
+        for fork_marker in &package.fork_markers {
+            combined.or(fork_marker.pep508());
+        }
+        combined.and(requirement.marker);
+        combined
+    };
+    !marker.is_false() && markers.is_none_or(|markers| marker.evaluate(markers, &[]))
+}
+
+fn format_path(path: &[Step<'_>]) -> String {
+    path.iter().map(format_step).join(" -> ")
+}
+
+fn format_step(step: &Step<'_>) -> String {
+    let mut line = step.package.name.to_string();
+
+    if let Some(edge) = &step.edge {
+        let extras = edge.extras();
+        if !extras.is_empty() {
+            line.push('[');
+            line.push_str(&extras.iter().join(", "));
+            line.push(']');
+        }
+    }
+
+    if let Some(version) = step.package.version.as_ref() {
+        line.push(' ');
+        line.push('v');
+        let _ = write!(line, "{version}");
+    }
+
+    if let Some(edge) = &step.edge {
+        match edge {
+            Edge::Prod(_) => {}
+            Edge::Optional(extra, _) => {
+                let _ = write!(line, " (extra: {extra})");
+            }
+            Edge::Dev(group, _) => {
+                let _ = write!(line, " (group: {group})");
+            }
+        }
+    }
+
+    line
+}
+
+impl std::fmt::Display for WhyDisplay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{} is included because:", self.target)?;
+        for path in &self.paths {
+            writeln!(f, "{path}")?;
+        }
+        Ok(())
+    }
+}

--- a/crates/fyn-resolver/src/lock/why.rs
+++ b/crates/fyn-resolver/src/lock/why.rs
@@ -315,6 +315,7 @@ impl Edge<'_> {
     }
 }
 
+#[derive(Clone, Copy)]
 enum EdgeKind<'lock> {
     Prod,
     Optional(&'lock ExtraName),

--- a/crates/fyn-test/src/lib.rs
+++ b/crates/fyn-test/src/lib.rs
@@ -1662,6 +1662,14 @@ impl TestContext {
         command
     }
 
+    /// Create a `fyn why` command with options shared across scenarios.
+    pub fn why(&self) -> Command {
+        let mut command = self.new_command();
+        command.arg("why");
+        self.add_shared_options(&mut command, false);
+        command
+    }
+
     /// Create a `fyn cache clean` command.
     pub fn clean(&self) -> Command {
         let mut command = self.new_command();

--- a/crates/fyn/src/commands/mod.rs
+++ b/crates/fyn/src/commands/mod.rs
@@ -52,6 +52,7 @@ pub(crate) use project::sync::sync;
 pub(crate) use project::tree::tree;
 pub(crate) use project::upgrade::upgrade;
 pub(crate) use project::version::{project_version, self_version};
+pub(crate) use project::why::why;
 pub(crate) use publish::publish;
 pub(crate) use python::dir::dir as python_dir;
 pub(crate) use python::find::find as python_find;

--- a/crates/fyn/src/commands/project/mod.rs
+++ b/crates/fyn/src/commands/project/mod.rs
@@ -77,6 +77,7 @@ pub(crate) mod sync;
 pub(crate) mod tree;
 pub(crate) mod upgrade;
 pub(crate) mod version;
+pub(crate) mod why;
 
 /// The source of a missing lockfile error.
 #[derive(Debug, Clone, Copy)]

--- a/crates/fyn/src/commands/project/why.rs
+++ b/crates/fyn/src/commands/project/why.rs
@@ -30,7 +30,6 @@ use crate::settings::LockCheck;
 use crate::settings::ResolverSettings;
 
 /// Run a command.
-#[expect(clippy::fn_params_excessive_bools)]
 pub(crate) async fn why(
     project_dir: &Path,
     package: PackageName,

--- a/crates/fyn/src/commands/project/why.rs
+++ b/crates/fyn/src/commands/project/why.rs
@@ -1,0 +1,214 @@
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use anstream::print;
+use anyhow::{Result, bail};
+use fyn_cache::Cache;
+use fyn_client::BaseClientBuilder;
+use fyn_configuration::{
+    Concurrency, DependencyGroups, DependencyGroupsWithDefaults, TargetTriple,
+};
+use fyn_normalize::{DefaultGroups, PackageName};
+use fyn_preview::Preview;
+use fyn_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion};
+use fyn_resolver::{Lock, WhyDisplay};
+use fyn_scripts::Pep723Script;
+use fyn_settings::PythonInstallMirrors;
+use fyn_workspace::{DiscoveryOptions, Workspace, WorkspaceCache};
+
+use crate::commands::pip::loggers::DefaultResolveLogger;
+use crate::commands::pip::resolution_markers;
+use crate::commands::project::lock::{LockMode, LockOperation};
+use crate::commands::project::lock_target::LockTarget;
+use crate::commands::project::{
+    ProjectError, ProjectInterpreter, ScriptInterpreter, UniversalState, default_dependency_groups,
+};
+use crate::commands::{ExitStatus, diagnostics};
+use crate::printer::Printer;
+use crate::settings::FrozenSource;
+use crate::settings::LockCheck;
+use crate::settings::ResolverSettings;
+
+/// Run a command.
+#[expect(clippy::fn_params_excessive_bools)]
+pub(crate) async fn why(
+    project_dir: &Path,
+    package: PackageName,
+    groups: DependencyGroups,
+    lock_check: LockCheck,
+    frozen: Option<FrozenSource>,
+    universal: bool,
+    depth: u8,
+    python_version: Option<PythonVersion>,
+    python_platform: Option<TargetTriple>,
+    python: Option<String>,
+    install_mirrors: PythonInstallMirrors,
+    settings: ResolverSettings,
+    client_builder: &BaseClientBuilder<'_>,
+    script: Option<Pep723Script>,
+    python_preference: PythonPreference,
+    python_downloads: PythonDownloads,
+    concurrency: Concurrency,
+    no_config: bool,
+    cache: &Cache,
+    printer: Printer,
+    preview: Preview,
+) -> Result<ExitStatus> {
+    // Find the project requirements.
+    let workspace_cache = WorkspaceCache::default();
+    let workspace;
+    let target = if let Some(script) = script.as_ref() {
+        LockTarget::Script(script)
+    } else {
+        workspace =
+            Workspace::discover(project_dir, &DiscoveryOptions::default(), &workspace_cache)
+                .await?;
+        LockTarget::Workspace(&workspace)
+    };
+
+    // Determine the groups to include.
+    let default_groups = match target {
+        LockTarget::Workspace(workspace) => default_dependency_groups(workspace.pyproject_toml())?,
+        LockTarget::Script(_) => DefaultGroups::default(),
+    };
+    let groups = groups.with_defaults(default_groups);
+
+    if matches!(target, LockTarget::Script(_)) {
+        if let Some(group) = groups.explicit_names().next() {
+            return Err(ProjectError::MissingGroupScript(group.clone()).into());
+        }
+    }
+
+    // Find an interpreter for the project, unless `--frozen` and `--universal` are both set.
+    let interpreter = if frozen.is_some() && universal {
+        None
+    } else {
+        Some(match target {
+            LockTarget::Script(script) => ScriptInterpreter::discover(
+                script.into(),
+                python.as_deref().map(PythonRequest::parse),
+                client_builder,
+                python_preference,
+                python_downloads,
+                &install_mirrors,
+                false,
+                no_config,
+                Some(false),
+                cache,
+                printer,
+                preview,
+            )
+            .await?
+            .into_interpreter(),
+            LockTarget::Workspace(workspace) => ProjectInterpreter::discover(
+                workspace,
+                project_dir,
+                &groups,
+                python.as_deref().map(PythonRequest::parse),
+                client_builder,
+                python_preference,
+                python_downloads,
+                &install_mirrors,
+                false,
+                no_config,
+                Some(false),
+                cache,
+                printer,
+                preview,
+            )
+            .await?
+            .into_interpreter(),
+        })
+    };
+
+    // Determine the lock mode.
+    let mode = if let Some(frozen_source) = frozen {
+        LockMode::Frozen(frozen_source.into())
+    } else if let LockCheck::Enabled(lock_check) = lock_check {
+        LockMode::Locked(interpreter.as_ref().unwrap(), lock_check)
+    } else if matches!(target, LockTarget::Script(_)) && !target.lock_path().is_file() {
+        // If we're locking a script, avoid creating a lockfile if it doesn't already exist.
+        LockMode::DryRun(interpreter.as_ref().unwrap())
+    } else {
+        LockMode::Write(interpreter.as_ref().unwrap())
+    };
+
+    // Initialize any shared state.
+    let state = UniversalState::default();
+
+    // Update the lockfile, if necessary.
+    let lock = match Box::pin(
+        LockOperation::new(
+            mode,
+            &settings,
+            client_builder,
+            &state,
+            Box::new(DefaultResolveLogger),
+            &concurrency,
+            cache,
+            &workspace_cache,
+            printer,
+            preview,
+        )
+        .execute(target),
+    )
+    .await
+    {
+        Ok(result) => result.into_lock(),
+        Err(ProjectError::Operation(err)) => {
+            return diagnostics::OperationDiagnostic::native_tls(client_builder.is_native_tls())
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    // Determine the markers to use for resolution.
+    let markers = (!universal).then(|| {
+        resolution_markers(
+            python_version.as_ref(),
+            python_platform.as_ref(),
+            interpreter.as_ref().unwrap(),
+        )
+    });
+
+    validate_groups(&lock, &groups)?;
+
+    let why = WhyDisplay::new(&lock, markers.as_ref(), &package, depth.into(), &groups);
+    if why.is_empty() {
+        bail!("No dependency path found for `{package}`");
+    }
+
+    print!("{why}");
+
+    Ok(ExitStatus::Success)
+}
+
+fn validate_groups(lock: &Lock, groups: &DependencyGroupsWithDefaults) -> Result<(), ProjectError> {
+    // If no groups were specified, short-circuit.
+    if groups.explicit_names().next().is_none() {
+        return Ok(());
+    }
+
+    let mut known_groups = lock.dependency_groups().keys().collect::<BTreeSet<_>>();
+    let members = if lock.members().is_empty() {
+        lock.root().into_iter().collect::<Vec<_>>()
+    } else {
+        lock.packages()
+            .iter()
+            .filter(|package| lock.members().contains(package.name()))
+            .collect::<Vec<_>>()
+    };
+
+    for package in members {
+        known_groups.extend(package.dependency_groups().keys());
+    }
+
+    for group in groups.explicit_names() {
+        if !known_groups.contains(group) {
+            return Err(ProjectError::MissingGroupProjects(group.clone()));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -372,6 +372,10 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 script: Some(script),
                 ..
             })
+            | ProjectCommand::Why(fyn_cli::WhyArgs {
+                script: Some(script),
+                ..
+            })
             | ProjectCommand::Export(fyn_cli::ExportArgs {
                 script: Some(script),
                 ..
@@ -3030,6 +3034,46 @@ async fn run_project(
                 args.install_mirrors,
                 args.resolver,
                 &client_builder.subcommand(vec!["tree".to_owned()]),
+                script,
+                globals.python_preference,
+                globals.python_downloads,
+                globals.concurrency,
+                no_config,
+                &cache,
+                printer,
+                globals.preview,
+            ))
+            .await
+        }
+        ProjectCommand::Why(args) => {
+            // Resolve the settings from the command-line arguments and workspace configuration.
+            let args = settings::WhySettings::resolve(args, filesystem, environment);
+            show_settings!(args);
+
+            // Initialize the cache.
+            let cache = cache.init().await?;
+
+            // Unwrap the script.
+            let script = script.map(|script| match script {
+                Pep723Item::Script(script) => script,
+                Pep723Item::Stdin(..) => unreachable!("`fyn why` does not support stdin"),
+                Pep723Item::Remote(..) => unreachable!("`fyn why` does not support remote files"),
+            });
+
+            Box::pin(commands::why(
+                project_dir,
+                args.package,
+                args.groups,
+                args.lock_check,
+                args.frozen,
+                args.universal,
+                args.depth,
+                args.python_version,
+                args.python_platform,
+                args.python,
+                args.install_mirrors,
+                args.resolver,
+                &client_builder.subcommand(vec!["why".to_owned()]),
                 script,
                 globals.python_preference,
                 globals.python_downloads,

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -2382,7 +2382,6 @@ impl TreeSettings {
 }
 
 /// The resolved settings to use for a `why` invocation.
-#[expect(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct WhySettings {
     pub(crate) package: PackageName,

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -21,7 +21,7 @@ use fyn_cli::{
     PythonInstallArgs, PythonListArgs, PythonListFormat, PythonPinArgs, PythonUninstallArgs,
     PythonUpgradeArgs, RemoveArgs, RunArgs, SyncArgs, SyncFormat, ToolDirArgs, ToolInstallArgs,
     ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs, VenvArgs, VersionArgs, VersionBumpSpec,
-    VersionFormat,
+    VersionFormat, WhyArgs,
 };
 use fyn_cli::{
     AuthorFrom, BuildArgs, ExportArgs, FormatArgs, PublishArgs, PythonDirArgs,
@@ -2369,6 +2369,103 @@ impl TreeSettings {
             invert: tree.invert,
             outdated: tree.outdated,
             show_sizes: tree.show_sizes,
+            script,
+            python_version,
+            python_platform,
+            python: python.and_then(Maybe::into_option),
+            resolver: ResolverSettings::combine(resolver_options(resolver, build), filesystem),
+            install_mirrors: environment
+                .install_mirrors
+                .combine(filesystem_install_mirrors),
+        }
+    }
+}
+
+/// The resolved settings to use for a `why` invocation.
+#[expect(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
+pub(crate) struct WhySettings {
+    pub(crate) package: PackageName,
+    pub(crate) groups: DependencyGroups,
+    pub(crate) lock_check: LockCheck,
+    pub(crate) frozen: Option<FrozenSource>,
+    pub(crate) universal: bool,
+    pub(crate) depth: u8,
+    #[allow(dead_code)]
+    pub(crate) script: Option<PathBuf>,
+    pub(crate) python_version: Option<PythonVersion>,
+    pub(crate) python_platform: Option<TargetTriple>,
+    pub(crate) python: Option<String>,
+    pub(crate) install_mirrors: PythonInstallMirrors,
+    pub(crate) resolver: ResolverSettings,
+}
+
+impl WhySettings {
+    /// Resolve the [`WhySettings`] from the CLI and workspace configuration.
+    pub(crate) fn resolve(
+        args: WhyArgs,
+        filesystem: Option<FilesystemOptions>,
+        environment: EnvironmentOptions,
+    ) -> Self {
+        let WhyArgs {
+            package,
+            universal,
+            depth,
+            dev,
+            only_dev,
+            no_dev,
+            group,
+            no_group,
+            no_default_groups,
+            only_group,
+            all_groups,
+            locked,
+            frozen,
+            build,
+            resolver,
+            script,
+            python_version,
+            python_platform,
+            python,
+        } = args;
+
+        let filesystem_install_mirrors = filesystem
+            .clone()
+            .map(|fs| fs.install_mirrors.clone())
+            .unwrap_or_default();
+
+        // Resolve flags from CLI and environment variables.
+        let locked = resolve_flag(locked, "locked", environment.locked);
+        let frozen = resolve_flag(frozen, "frozen", environment.frozen);
+
+        // Check for conflicts between locked and frozen.
+        check_conflicts(locked, frozen);
+
+        let (dev, no_dev) = resolve_flag_pair(
+            dev,
+            no_dev,
+            "dev",
+            "no-dev",
+            Some(environment.dev),
+            Some(environment.no_dev),
+        );
+
+        Self {
+            package,
+            groups: DependencyGroups::from_args(
+                dev.into(),
+                no_dev.into(),
+                only_dev,
+                group,
+                no_group,
+                no_default_groups,
+                only_group,
+                all_groups,
+            ),
+            lock_check: resolve_lock_check(locked),
+            frozen: resolve_frozen(frozen),
+            universal,
+            depth,
             script,
             python_version,
             python_platform,

--- a/crates/fyn/tests/it/help.rs
+++ b/crates/fyn/tests/it/help.rs
@@ -11,7 +11,7 @@ fn help() {
     success: true
     exit_code: 0
     ----- stdout -----
-    An extremely fast Python package manager.
+    An extremely fast Python package and project manager.
 
     Usage: fyn [OPTIONS] <COMMAND>
 
@@ -27,6 +27,7 @@ fn help() {
       upgrade                    Upgrade project dependencies
       export                     Export the project's lockfile to an alternate format
       tree                       Display the project's dependency tree
+      why                        Explain why a package is included in the project
       format                     Format Python code in the project
       audit                      Audit the project's dependencies
       tool                       Run and install commands provided by Python packages
@@ -97,7 +98,7 @@ fn help_flag() {
     success: true
     exit_code: 0
     ----- stdout -----
-    An extremely fast Python package manager.
+    An extremely fast Python package and project manager.
 
     Usage: fyn [OPTIONS] <COMMAND>
 
@@ -113,6 +114,7 @@ fn help_flag() {
       upgrade  Upgrade project dependencies
       export   Export the project's lockfile to an alternate format
       tree     Display the project's dependency tree
+      why      Explain why a package is included in the project
       format   Format Python code in the project
       audit    Audit the project's dependencies
       tool     Run and install commands provided by Python packages
@@ -181,7 +183,7 @@ fn help_short_flag() {
     success: true
     exit_code: 0
     ----- stdout -----
-    An extremely fast Python package manager.
+    An extremely fast Python package and project manager.
 
     Usage: fyn [OPTIONS] <COMMAND>
 
@@ -197,6 +199,7 @@ fn help_short_flag() {
       upgrade  Upgrade project dependencies
       export   Export the project's lockfile to an alternate format
       tree     Display the project's dependency tree
+      why      Explain why a package is included in the project
       format   Format Python code in the project
       audit    Audit the project's dependencies
       tool     Run and install commands provided by Python packages
@@ -974,6 +977,7 @@ fn help_unknown_subcommand() {
         upgrade
         export
         tree
+        why
         format
         audit
         tool
@@ -1008,6 +1012,7 @@ fn help_unknown_subcommand() {
         upgrade
         export
         tree
+        why
         format
         audit
         tool
@@ -1043,6 +1048,7 @@ fn help_unknown_subsubcommand() {
         pin
         dir
         uninstall
+        install-shim
         update-shell
     ");
 }
@@ -1055,7 +1061,7 @@ fn help_with_global_option() {
     success: true
     exit_code: 0
     ----- stdout -----
-    An extremely fast Python package manager.
+    An extremely fast Python package and project manager.
 
     Usage: fyn [OPTIONS] <COMMAND>
 
@@ -1071,6 +1077,7 @@ fn help_with_global_option() {
       upgrade                    Upgrade project dependencies
       export                     Export the project's lockfile to an alternate format
       tree                       Display the project's dependency tree
+      why                        Explain why a package is included in the project
       format                     Format Python code in the project
       audit                      Audit the project's dependencies
       tool                       Run and install commands provided by Python packages
@@ -1182,7 +1189,7 @@ fn help_with_no_pager() {
     success: true
     exit_code: 0
     ----- stdout -----
-    An extremely fast Python package manager.
+    An extremely fast Python package and project manager.
 
     Usage: fyn [OPTIONS] <COMMAND>
 
@@ -1198,6 +1205,7 @@ fn help_with_no_pager() {
       upgrade                    Upgrade project dependencies
       export                     Export the project's lockfile to an alternate format
       tree                       Display the project's dependency tree
+      why                        Explain why a package is included in the project
       format                     Format Python code in the project
       audit                      Audit the project's dependencies
       tool                       Run and install commands provided by Python packages

--- a/crates/fyn/tests/it/main.rs
+++ b/crates/fyn/tests/it/main.rs
@@ -174,3 +174,6 @@ mod workspace;
 mod workspace_dir;
 mod workspace_list;
 mod workspace_metadata;
+
+#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+mod why;

--- a/crates/fyn/tests/it/why.rs
+++ b/crates/fyn/tests/it/why.rs
@@ -1,0 +1,375 @@
+use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
+use assert_fs::prelude::*;
+use indoc::indoc;
+
+use fyn_test::fyn_snapshot;
+
+#[test]
+fn transitive_dependency_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "pandas",
+            "scikit-learn==1.4.1.post1",
+        ]
+    "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.why().arg("numpy").arg("--universal"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    numpy is included because:
+    project v0.1.0 -> pandas v2.2.1 -> numpy v1.26.4
+    project v0.1.0 -> scikit-learn v1.4.1.post1 -> numpy v1.26.4
+    project v0.1.0 -> scikit-learn v1.4.1.post1 -> scipy v1.12.0 -> numpy v1.26.4
+
+    ----- stderr -----
+    Resolved 11 packages in [TIME]
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("pandas").arg("--frozen").arg("--universal"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    pandas is included because:
+    project v0.1.0 -> pandas v2.2.1
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn dependency_group_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["typing-extensions"]
+
+        [dependency-groups]
+        foo = ["anyio"]
+        bar = ["iniconfig"]
+        dev = ["sniffio"]
+        "#,
+    )?;
+
+    context.lock().assert().success();
+
+    fyn_snapshot!(context.filters(), context.why().arg("sniffio").arg("--frozen"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    sniffio is included because:
+    project v0.1.0 -> sniffio v1.3.1 (group: dev)
+
+    ----- stderr -----
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("sniffio").arg("--frozen").arg("--no-dev"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No dependency path found for `sniffio`
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("sniffio").arg("--frozen").arg("--group").arg("foo"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    sniffio is included because:
+    project v0.1.0 -> anyio v4.3.0 (group: foo) -> sniffio v1.3.1
+    project v0.1.0 -> sniffio v1.3.1 (group: dev)
+
+    ----- stderr -----
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("sniffio").arg("--frozen").arg("--only-group").arg("foo"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    sniffio is included because:
+    project v0.1.0 -> anyio v4.3.0 (group: foo) -> sniffio v1.3.1
+
+    ----- stderr -----
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("sniffio").arg("--frozen").arg("--group").arg("missing"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Group `missing` is not defined in any project's `dependency-groups` table
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn optional_and_extra_dependency_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["flask[dotenv]"]
+
+        [project.optional-dependencies]
+        async = ["anyio"]
+    "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.why().arg("python-dotenv").arg("--universal"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    python-dotenv is included because:
+    project v0.1.0 -> flask[dotenv] v3.0.2 -> python-dotenv v1.0.1 (extra: dotenv)
+
+    ----- stderr -----
+    Resolved 13 packages in [TIME]
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("sniffio").arg("--frozen").arg("--universal"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    sniffio is included because:
+    project v0.1.0 -> anyio v4.3.0 (extra: async) -> sniffio v1.3.1
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn platform_filtered_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["jupyter-client"]
+    "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.why().arg("pywin32").arg("--python-platform").arg("windows"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    pywin32 is included because:
+    project v0.1.0 -> jupyter-client v8.6.1 -> jupyter-core v5.7.2 -> pywin32 v306
+
+    ----- stderr -----
+    Resolved 12 packages in [TIME]
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("pywin32").arg("--frozen").arg("--python-platform").arg("linux"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No dependency path found for `pywin32`
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn script_paths_are_dry_run() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script.write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #   "requests<3",
+        # ]
+        # ///
+
+        import requests
+        "#})?;
+
+    fyn_snapshot!(context.filters(), context.why().arg("urllib3").arg("--script").arg(script.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    urllib3 is included because:
+    requests v2.31.0 -> urllib3 v2.2.1
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("requests").arg("--script").arg(script.path()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    requests is included because:
+    requests v2.31.0
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    ");
+
+    fyn_snapshot!(context.filters(), context.why().arg("requests").arg("--script").arg(script.path()).arg("--group").arg("dev"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: PEP 723 scripts do not support dependency groups, but group `dev` was specified
+    ");
+
+    assert!(!context.temp_dir.child("script.py.lock").exists());
+
+    Ok(())
+}
+
+#[test]
+fn depth_limits_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "pandas",
+            "scikit-learn==1.4.1.post1",
+        ]
+    "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.why().arg("numpy").arg("--universal").arg("--depth").arg("2"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    numpy is included because:
+    project v0.1.0 -> pandas v2.2.1 -> numpy v1.26.4
+    project v0.1.0 -> scikit-learn v1.4.1.post1 -> numpy v1.26.4
+
+    ----- stderr -----
+    Resolved 11 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn workspace_member_paths_do_not_cycle() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [tool.fyn.workspace]
+        members = ["packages/*"]
+    "#,
+    )?;
+
+    let package_a_dir = context.temp_dir.child("packages").child("package-a");
+    package_a_dir.create_dir_all()?;
+    package_a_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-a"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-b"]
+
+        [tool.fyn.sources]
+        package-b = { workspace = true }
+    "#,
+    )?;
+
+    let package_b_dir = context.temp_dir.child("packages").child("package-b");
+    package_b_dir.create_dir_all()?;
+    package_b_dir.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "package-b"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["package-a"]
+
+        [tool.fyn.sources]
+        package-a = { workspace = true }
+    "#,
+    )?;
+
+    fyn_snapshot!(context.filters(), context.why().arg("package-a"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    package-a is included because:
+    package-a v0.1.0
+    package-b v0.1.0 -> package-a v0.1.0
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    ");
+
+    Ok(())
+}
+
+#[test]
+fn missing_selected_dependency_path() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["typing-extensions"]
+    "#,
+    )?;
+
+    context.lock().assert().success();
+
+    fyn_snapshot!(context.filters(), context.why().arg("sniffio").arg("--frozen"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No dependency path found for `sniffio`
+    ");
+
+    Ok(())
+}

--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -44,6 +44,7 @@ Creating and working on Python projects, i.e., with a `pyproject.toml`.
 - `fyn status`: Inspect the current project and environment state, and surface actionable health
   checks.
 - `fyn tree`: View the dependency tree for the project.
+- `fyn why`: Explain why a package is included in the project dependency graph.
 - `fyn build`: Build the project into distribution archives.
 - `fyn publish`: Publish the project to a package index.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,14 @@ $ fyn upgrade
 $ fyn upgrade requests flask
 ```
 
+Use `fyn why` to explain the dependency paths that include a package:
+
+```console
+$ fyn why numpy
+numpy is included because:
+project v0.1.0 -> pandas v2.2.1 -> numpy v1.26.4
+```
+
 Use `fyn shell` to open a new shell with the project environment activated:
 
 ```console


### PR DESCRIPTION
## Summary

  - Add `fyn why <package>` to explain dependency paths from the project, workspace, or script root.
  - Add resolver graph formatting for dependency explanations, including depth limiting and platform/group filtering.
  - Documented new workflow in the README, docs index, features page, and manifesto.

  ## Tests

  - `cargo test -p fyn --test it why`
  - `cargo test -p fyn --test it help`
  - `cargo check -p fyn`
  - `cargo fmt --check`