### PR TITLE
feat: explain audit findings with dependency paths

### DIFF
--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -6536,6 +6536,10 @@ pub struct AuditArgs {
     #[arg(long)]
     pub python_platform: Option<TargetTriple>,
 
+    /// Show dependency paths for audit findings.
+    #[arg(long)]
+    pub explain: bool,
+
     /// A vulnerability ID to ignore during auditing.
     ///
     /// May be provided multiple times.

--- a/crates/fyn-resolver/src/lock/mod.rs
+++ b/crates/fyn-resolver/src/lock/mod.rs
@@ -7156,4 +7156,69 @@ sdist = { url = "https://example.com/typing-extensions-4.10.0.tar.gz", hash = "s
             vec!["base".to_string(), "typing-extensions".to_string()]
         );
     }
+
+    #[test]
+    fn why_display_for_package_filters_target_version() {
+        let lock: Lock = toml::from_str(
+            r#"
+version = 1
+requires-python = ">=3.12"
+
+[manifest]
+members = ["project"]
+
+[[package]]
+name = "project"
+version = "0.1.0"
+source = { editable = "" }
+dependencies = [
+    { name = "alpha", version = "1.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "beta", version = "1.0.0", source = { registry = "https://pypi.org/simple" } },
+]
+
+[[package]]
+name = "alpha"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [{ name = "shared", version = "1.0.0", source = { registry = "https://pypi.org/simple" } }]
+sdist = { url = "https://example.com/alpha-1.0.0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 0 }
+
+[[package]]
+name = "beta"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [{ name = "shared", version = "2.0.0", source = { registry = "https://pypi.org/simple" } }]
+sdist = { url = "https://example.com/beta-1.0.0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 0 }
+
+[[package]]
+name = "shared"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://example.com/shared-1.0.0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 0 }
+
+[[package]]
+name = "shared"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://example.com/shared-2.0.0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 0 }
+"#,
+        )
+        .unwrap();
+
+        let groups = DependencyGroups::default().with_defaults(DefaultGroups::List(vec![]));
+        let target = PackageName::from_str("shared").unwrap();
+        let version = Version::from_str("1.0.0").unwrap();
+
+        let display = WhyDisplay::for_package(&lock, None, &target, &version, usize::MAX, &groups);
+        let paths = display
+            .paths()
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec!["project v0.1.0 -> alpha v1.0.0 -> shared v1.0.0"]
+        );
+    }
 }

--- a/crates/fyn-resolver/src/lock/why.rs
+++ b/crates/fyn-resolver/src/lock/why.rs
@@ -7,6 +7,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use fyn_configuration::DependencyGroupsWithDefaults;
 use fyn_distribution_types::Requirement;
 use fyn_normalize::{ExtraName, GroupName, PackageName};
+use fyn_pep440::Version;
 use fyn_pep508::MarkerTree;
 use fyn_pypi_types::ResolverMarkerEnvironment;
 
@@ -15,6 +16,7 @@ use crate::lock::{Dependency, Lock, Package, PackageId};
 #[derive(Debug)]
 pub struct WhyDisplay {
     target: PackageName,
+    target_version: Option<Version>,
     paths: Vec<String>,
 }
 
@@ -24,6 +26,29 @@ impl WhyDisplay {
         lock: &Lock,
         markers: Option<&ResolverMarkerEnvironment>,
         target: &PackageName,
+        depth: usize,
+        groups: &DependencyGroupsWithDefaults,
+    ) -> Self {
+        Self::from_target(lock, markers, target, None, depth, groups)
+    }
+
+    /// Explain why the target package version is included in the project dependency graph.
+    pub fn for_package(
+        lock: &Lock,
+        markers: Option<&ResolverMarkerEnvironment>,
+        target: &PackageName,
+        target_version: &Version,
+        depth: usize,
+        groups: &DependencyGroupsWithDefaults,
+    ) -> Self {
+        Self::from_target(lock, markers, target, Some(target_version), depth, groups)
+    }
+
+    fn from_target(
+        lock: &Lock,
+        markers: Option<&ResolverMarkerEnvironment>,
+        target: &PackageName,
+        target_version: Option<&Version>,
         depth: usize,
         groups: &DependencyGroupsWithDefaults,
     ) -> Self {
@@ -52,6 +77,7 @@ impl WhyDisplay {
 
         let mut display = Self {
             target: target.clone(),
+            target_version: target_version.cloned(),
             paths: Vec::new(),
         };
         let mut paths = BTreeSet::new();
@@ -141,6 +167,10 @@ impl WhyDisplay {
         self.paths.is_empty()
     }
 
+    pub fn paths(&self) -> &[String] {
+        &self.paths
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn visit<'lock>(
         &self,
@@ -160,7 +190,12 @@ impl WhyDisplay {
             return;
         }
 
-        if package.name() == &self.target {
+        if package.name() == &self.target
+            && self
+                .target_version
+                .as_ref()
+                .is_none_or(|version| package.version() == Some(version))
+        {
             paths.insert(format_path(path));
             seen.remove(&package.id);
             return;

--- a/crates/fyn/src/commands/project/audit.rs
+++ b/crates/fyn/src/commands/project/audit.rs
@@ -1,7 +1,9 @@
-use itertools::Itertools as _;
-use owo_colors::OwoColorize;
+use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::path::Path;
+
+use itertools::Itertools as _;
+use owo_colors::OwoColorize;
 
 use crate::commands::ExitStatus;
 use crate::commands::diagnostics;
@@ -23,11 +25,15 @@ use fyn_audit::service::{VulnerabilityServiceFormat, osv};
 use fyn_audit::types::{Dependency, Finding, VulnerabilityID};
 use fyn_cache::Cache;
 use fyn_client::BaseClientBuilder;
-use fyn_configuration::{Concurrency, DependencyGroups, ExtrasSpecification, TargetTriple};
-use fyn_normalize::{DefaultExtras, DefaultGroups};
+use fyn_configuration::{
+    Concurrency, DependencyGroups, DependencyGroupsWithDefaults, ExtrasSpecification, TargetTriple,
+};
+use fyn_normalize::{DefaultExtras, DefaultGroups, PackageName};
+use fyn_pep440::Version;
 use fyn_preview::{Preview, PreviewFeature};
 use fyn_python::{PythonDownloads, PythonPreference, PythonVersion};
 use fyn_redacted::DisplaySafeUrl;
+use fyn_resolver::{Lock, WhyDisplay};
 use fyn_scripts::Pep723Script;
 use fyn_settings::PythonInstallMirrors;
 use fyn_warnings::warn_user;
@@ -56,6 +62,7 @@ pub(crate) async fn audit(
     preview: Preview,
     service: VulnerabilityServiceFormat,
     service_url: Option<String>,
+    explain: bool,
     ignore: Vec<VulnerabilityID>,
     ignore_until_fixed: Vec<VulnerabilityID>,
 ) -> Result<ExitStatus> {
@@ -204,7 +211,7 @@ pub(crate) async fn audit(
     target.validate_groups(&groups)?;
 
     // Determine the markers to use for resolution.
-    let _markers = (!universal).then(|| {
+    let markers = (!universal).then(|| {
         resolution_markers(
             python_version.as_ref(),
             python_platform.as_ref(),
@@ -273,18 +280,60 @@ pub(crate) async fn audit(
         }
     }
 
+    let explanations = if explain {
+        audit_explanations(&lock, markers.as_ref(), &groups, &all_findings)
+    } else {
+        BTreeMap::new()
+    };
+
     let display = AuditResults {
         printer,
         n_packages: auditable.len(),
         findings: all_findings,
+        explanations,
     };
     display.render()
+}
+
+fn audit_explanations(
+    lock: &Lock,
+    markers: Option<&fyn_pypi_types::ResolverMarkerEnvironment>,
+    groups: &DependencyGroupsWithDefaults,
+    findings: &[Finding],
+) -> BTreeMap<(PackageName, Version), Vec<String>> {
+    let mut explanations = BTreeMap::new();
+
+    for finding in findings {
+        let Finding::Vulnerability(vulnerability) = finding else {
+            continue;
+        };
+
+        let key = (
+            vulnerability.dependency.name().clone(),
+            vulnerability.dependency.version().clone(),
+        );
+        explanations.entry(key).or_insert_with(|| {
+            WhyDisplay::for_package(
+                lock,
+                markers,
+                vulnerability.dependency.name(),
+                vulnerability.dependency.version(),
+                usize::MAX,
+                groups,
+            )
+            .paths()
+            .to_vec()
+        });
+    }
+
+    explanations
 }
 
 struct AuditResults {
     printer: Printer,
     n_packages: usize,
     findings: Vec<Finding>,
+    explanations: BTreeMap<(PackageName, Version), Vec<String>>,
 }
 
 impl AuditResults {
@@ -359,6 +408,23 @@ impl AuditResults {
                         id = vuln.best_id().as_str().bold(),
                         description = vuln.summary.as_deref().unwrap_or("No summary provided"),
                     )?;
+
+                    if let Some(paths) = self.explanations.get(&(
+                        vuln.dependency.name().clone(),
+                        vuln.dependency.version().clone(),
+                    )) {
+                        if paths.is_empty() {
+                            writeln!(
+                                self.printer.stdout_important(),
+                                "\n  Dependency path unavailable for the selected audit view"
+                            )?;
+                        } else {
+                            writeln!(self.printer.stdout_important(), "\n  Included because:")?;
+                            for path in paths {
+                                writeln!(self.printer.stdout_important(), "  {path}")?;
+                            }
+                        }
+                    }
 
                     if vuln.fix_versions.is_empty() {
                         writeln!(

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -3194,6 +3194,7 @@ async fn run_project(
                 globals.preview,
                 args.service_format,
                 args.service_url,
+                args.explain,
                 args.ignore,
                 args.ignore_until_fixed,
             ))

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -2682,6 +2682,7 @@ pub(crate) struct AuditSettings {
     pub(crate) settings: ResolverSettings,
     pub(crate) service_format: VulnerabilityServiceFormat,
     pub(crate) service_url: Option<String>,
+    pub(crate) explain: bool,
     pub(crate) ignore: Vec<VulnerabilityID>,
     pub(crate) ignore_until_fixed: Vec<VulnerabilityID>,
 }
@@ -2709,6 +2710,7 @@ impl AuditSettings {
             script: _,
             python_version,
             python_platform,
+            explain,
             locked,
             frozen,
             build,
@@ -2768,6 +2770,7 @@ impl AuditSettings {
             settings: ResolverSettings::combine(resolver_options(resolver, build), filesystem),
             service_format,
             service_url,
+            explain,
             ignore: {
                 let AuditOptions {
                     ignore: config_ignore,

--- a/crates/fyn/tests/it/audit.rs
+++ b/crates/fyn/tests/it/audit.rs
@@ -3,9 +3,73 @@ use assert_fs::prelude::*;
 use indoc::indoc;
 use serde_json::json;
 use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 use fyn_test::fyn_snapshot;
+
+async fn mock_osv_vulnerability(
+    server: &MockServer,
+    package: &str,
+    id: &str,
+    summary: &str,
+    fixed: Option<&str>,
+) {
+    let package = package.to_string();
+    let id = id.to_string();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/querybatch"))
+        .respond_with({
+            let package = package.clone();
+            let id = id.clone();
+            move |req: &Request| {
+                let body: serde_json::Value =
+                    serde_json::from_slice(&req.body).expect("querybatch request is valid JSON");
+                let results = body["queries"]
+                    .as_array()
+                    .expect("querybatch request contains queries")
+                    .iter()
+                    .map(|query| {
+                        if query["package"]["name"].as_str() == Some(package.as_str()) {
+                            json!({"vulns": [{"id": id}]})
+                        } else {
+                            json!({"vulns": []})
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                ResponseTemplate::new(200).set_body_json(json!({ "results": results }))
+            }
+        })
+        .mount(server)
+        .await;
+
+    let affected = fixed.map(|fixed| {
+        json!([{
+            "ranges": [{
+                "type": "ECOSYSTEM",
+                "events": [
+                    {"introduced": "0"},
+                    {"fixed": fixed}
+                ]
+            }]
+        }])
+    });
+
+    let mut body = json!({
+        "id": id,
+        "modified": "2026-01-01T00:00:00Z",
+        "summary": summary,
+    });
+    if let Some(affected) = affected {
+        body["affected"] = affected;
+    }
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/vulns/{id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(server)
+        .await;
+}
 
 #[tokio::test]
 async fn audit_service_url_override() {
@@ -228,6 +292,200 @@ async fn audit_ignore_by_id() {
 
     ----- stderr -----
     Found no known vulnerabilities and no adverse project statuses in 1 package
+    ");
+}
+
+#[tokio::test]
+async fn audit_explain_direct_vulnerability() {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+    mock_osv_vulnerability(
+        &server,
+        "iniconfig",
+        "PYSEC-2023-0001",
+        "A test vulnerability in iniconfig",
+        Some("2.1.0"),
+    )
+    .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--explain")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    iniconfig 2.0.0 has 1 known vulnerability:
+
+    - PYSEC-2023-0001: A test vulnerability in iniconfig
+
+      Included because:
+      project v0.1.0 -> iniconfig v2.0.0
+
+      Fixed in: 2.1.0
+
+      Advisory information: https://osv.dev/vulnerability/PYSEC-2023-0001
+
+
+    ----- stderr -----
+    Found 1 known vulnerability and no adverse project statuses in 1 package
+    ");
+}
+
+#[tokio::test]
+async fn audit_explain_transitive_vulnerability() {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==4.3.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+    mock_osv_vulnerability(
+        &server,
+        "sniffio",
+        "PYSEC-2023-0002",
+        "A test vulnerability in sniffio",
+        None,
+    )
+    .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--explain")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    sniffio 1.3.1 has 1 known vulnerability:
+
+    - PYSEC-2023-0002: A test vulnerability in sniffio
+
+      Included because:
+      project v0.1.0 -> anyio v4.3.0 -> sniffio v1.3.1
+
+      No fix versions available
+
+      Advisory information: https://osv.dev/vulnerability/PYSEC-2023-0002
+
+
+    ----- stderr -----
+    Found 1 known vulnerability and no adverse project statuses in 3 packages
+    ");
+}
+
+#[tokio::test]
+async fn audit_explain_script_vulnerability() {
+    let context = fyn_test::test_context!("3.12");
+
+    let script = context.temp_dir.child("script.py");
+    script
+        .write_str(indoc! {r#"
+        # /// script
+        # requires-python = ">=3.12"
+        # dependencies = [
+        #   "iniconfig==2.0.0",
+        # ]
+        # ///
+        import iniconfig
+    "#})
+        .unwrap();
+
+    let lockfile = context.temp_dir.child("script.py.lock");
+    lockfile
+        .write_str(indoc! {r#"
+        version = 1
+        revision = 3
+        requires-python = ">=3.12"
+
+        [manifest]
+        requirements = [{ name = "iniconfig", specifier = "==2.0.0" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T12:52:09.585Z" }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beebd3ce04b132a8bf3491/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T12:52:07.538Z" },
+        ]
+    "#})
+        .unwrap();
+
+    let server = MockServer::start().await;
+    mock_osv_vulnerability(
+        &server,
+        "iniconfig",
+        "PYSEC-2023-0001",
+        "A test vulnerability in iniconfig",
+        Some("2.1.0"),
+    )
+    .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--explain")
+        .arg("--script")
+        .arg("script.py")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    iniconfig 2.0.0 has 1 known vulnerability:
+
+    - PYSEC-2023-0001: A test vulnerability in iniconfig
+
+      Included because:
+      iniconfig v2.0.0
+
+      Fixed in: 2.1.0
+
+      Advisory information: https://osv.dev/vulnerability/PYSEC-2023-0001
+
+
+    ----- stderr -----
+    Found 1 known vulnerability and no adverse project statuses in 1 package
     ");
 }
 


### PR DESCRIPTION
## Summary

  - Add `fyn audit --explain` to show dependency paths for vulnerability findings.
  - Reuse `WhyDisplay` so audit explanations match `fyn why` path semantics.
  - Filter explanations by exact package version to handle locks with multiple versions of the same package.

  ## Tests

  - `cargo test -p fyn --test it audit`
  - `cargo test -p fyn --test it why`
  - `cargo test -p fyn --test it help`
  - `cargo test -p fyn-resolver`
  - `cargo check -p fyn`
  - `cargo clippy -p fyn -p fyn-resolver --all-targets --all-features --locked -- -D warnings`
  - `cargo fmt --check`