### PR TITLE
ci: pin Prettier for format checks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,13 @@
   schedule: ["* 0-3 * * 1"],
   semanticCommits: "disabled",
   separateMajorMinor: false,
-  enabledManagers: ["github-actions", "pre-commit", "cargo", "custom.regex"],
+  enabledManagers: [
+    "github-actions",
+    "pre-commit",
+    "cargo",
+    "npm",
+    "custom.regex",
+  ],
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     rangeStrategy: "update-lockfile",
@@ -84,6 +90,20 @@
       groupName: "pre-commit dependencies",
       matchManagers: ["pre-commit"],
       description: "Weekly update of pre-commit dependencies",
+    },
+    {
+      groupName: "Node dev-dependencies",
+      matchManagers: ["npm"],
+      matchDepTypes: ["devDependencies"],
+      description: "Weekly update of Node development dependencies",
+    },
+    {
+      groupName: "Prettier",
+      // Avoid immediately consuming freshly published formatter packages.
+      matchDatasources: ["npm"],
+      matchPackageNames: ["prettier"],
+      minimumReleaseAge: "7 days",
+      internalChecksFilter: "strict",
     },
     {
       groupName: "Rust dev-dependencies",

--- a/.github/workflows/check-fmt.yml
+++ b/.github/workflows/check-fmt.yml
@@ -22,7 +22,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - run: npx prettier --check .
+      - run: npm ci --ignore-scripts --audit=false --fund=false
+      - run: npm run format:check
 
   python:
     timeout-minutes: 10

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ target/
 # Python tmp files
 __pycache__
 
+# Node dependencies
+/node_modules/
+
 # GitHub issue mirror
 .prism/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         name: prettier
         entry: prettier --write --ignore-unknown
         language: node
-        additional_dependencies: ["prettier@3"]
+        additional_dependencies: ["prettier@3.8.3"]
         types_or: [yaml, json5]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "fyn",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fyn",
+      "devDependencies": {
+        "prettier": "3.8.3"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fyn",
+  "private": true,
+  "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "prettier": "3.8.3"
+  }
+}


### PR DESCRIPTION
## Summary

Hardens the Prettier formatting check by avoiding floating `npx prettier` resolution in CI.

- Adds a minimal private npm manifest and lockfile for Prettier 3.8.3
- Runs CI formatting through `npm ci --ignore-scripts --audit=false --fund=false` and the local `format:check` script
- Pins the pre-commit Prettier dependency to the same exact version
- Enables Renovate npm updates and groups delayed Prettier updates behind a 7-day minimum release age

## Validation

- `npm ci --ignore-scripts --audit=false --fund=false`
- `npm run format:check`
