### PR TITLE
Update link to PIP compatibility documentation

### DIFF
--- a/PIP_COMPATIBILITY.md
+++ b/PIP_COMPATIBILITY.md
@@ -1,1 +1,1 @@
-This reference document has moved to the [documentation website](https://github.com/oha/fyn).
+This reference document has moved to the [documentation website](https://duriantaco.github.io/fyn/pip/compatibility/).

--- a/PIP_COMPATIBILITY.md
+++ b/PIP_COMPATIBILITY.md
@@ -1,1 +1,2 @@
-This reference document has moved to the [documentation website](https://duriantaco.github.io/fyn/pip/compatibility/).
+This reference document has moved to the
+[documentation website](https://duriantaco.github.io/fyn/pip/compatibility/).


### PR DESCRIPTION
## Summary

The link in PIP_COMPATIBILITY.md was out of date.  This PR just updates it to point to the relevant page on the current documentation site.

## Test Plan

No testing.
