### PR TITLE
docs: update owner references and fyn notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 ## Finding ways to help
 
 We label issues that would be good for a first time contributor as
-[`good first issue`](https://github.com/oha/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+[`good first issue`](https://github.com/duriantaco/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 These usually do not require significant experience with Rust or the fyn code base.
 
 We label issues that we think are a good opportunity for subsequent contributions as
-[`help wanted`](https://github.com/oha/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+[`help wanted`](https://github.com/duriantaco/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
 These require varying levels of experience with Rust and fyn. Often, we want to accomplish these
 tasks but do not have the resources to do so ourselves.
 
@@ -20,7 +20,7 @@ for community contribution. We're happy to receive contributions for other issue
 important to make sure we have consensus on the solution to the problem first.
 
 Outside of issues with the labels above, issues labeled as
-[`bug`](https://github.com/oha/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22bug%22) are the best
+[`bug`](https://github.com/duriantaco/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22bug%22) are the best
 candidates for contribution. In contrast, issues labeled with `needs-decision` or `needs-design` are
 _not_ good candidates for contribution. Please do not open pull requests for issues with these
 labels.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,10 @@ for community contribution. We're happy to receive contributions for other issue
 important to make sure we have consensus on the solution to the problem first.
 
 Outside of issues with the labels above, issues labeled as
-[`bug`](https://github.com/duriantaco/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22bug%22) are the best
-candidates for contribution. In contrast, issues labeled with `needs-decision` or `needs-design` are
-_not_ good candidates for contribution. Please do not open pull requests for issues with these
-labels.
+[`bug`](https://github.com/duriantaco/fyn/issues?q=is%3Aopen+is%3Aissue+label%3A%22bug%22) are the
+best candidates for contribution. In contrast, issues labeled with `needs-decision` or
+`needs-design` are _not_ good candidates for contribution. Please do not open pull requests for
+issues with these labels.
 
 Please do not open pull requests for new features without prior discussion. While we appreciate
 exploration of new features, we will almost always close these pull requests immediately. Adding a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 edition = "2024"
 rust-version = "1.92.0"
 homepage = "https://pypi.org/project/fyn/"
-repository = "https://github.com/oha/fyn"
+repository = "https://github.com/duriantaco/fyn"
 authors = ["fyn"]
 license = "MIT OR Apache-2.0"
 

--- a/crates/fyn-dev/src/generate_json_schema.rs
+++ b/crates/fyn-dev/src/generate_json_schema.rs
@@ -86,7 +86,7 @@ const REPLACEMENTS: &[(&str, &str)] = &[
     // Use the fully-resolved URL rather than the relative Markdown path.
     (
         "(../concepts/projects/dependencies.md)",
-        "(https://github.com/oha/fyn)",
+        "(https://duriantaco.github.io/fyn/concepts/projects/dependencies/)",
     ),
 ];
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -69,7 +69,7 @@ install-updater = false
 install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]
 # Prefer simple hosting for downloads, falling back to GitHub releases
 hosting = ["simple", "github"]
-simple-download-url = "https://github.com/oha/fyn/releases/download/{tag}"
+simple-download-url = "https://github.com/duriantaco/fyn/releases/download/{tag}"
 
 [dist.github-custom-runners]
 global = "depot-ubuntu-latest-4"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,8 +69,6 @@ $ pip install fyn
     [contributing setup guide](https://github.com/duriantaco/fyn/blob/main/CONTRIBUTING.md#setup)
     for details on building fyn from source.
 
-
-
 ### GitHub Releases
 
 fyn release artifacts can be downloaded directly from
@@ -78,7 +76,6 @@ fyn release artifacts can be downloaded directly from
 
 Each release page includes binaries for supported platforms, and may also include standalone
 installer scripts.
-
 
 !!! note
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -69,43 +69,7 @@ $ pip install fyn
     [contributing setup guide](https://github.com/duriantaco/fyn/blob/main/CONTRIBUTING.md#setup)
     for details on building fyn from source.
 
-### Homebrew
 
-fyn is available in the core Homebrew packages.
-
-```console
-$ brew install fyn
-```
-
-### MacPorts
-
-fyn is available via [MacPorts](https://ports.macports.org/port/fyn/).
-
-```console
-$ sudo port install fyn
-```
-
-### WinGet
-
-fyn is available via [WinGet](https://winstall.app/apps/oha.fyn).
-
-```console
-$ winget install --id=oha.fyn  -e
-```
-
-### Scoop
-
-fyn is available via [Scoop](https://scoop.sh/#/apps?q=fyn).
-
-```console
-$ scoop install main/fyn
-```
-
-### Docker
-
-fyn provides a Docker image at [`ghcr.io/oha/fyn`](https://github.com/oha/fyn/pkgs/container/fyn).
-
-See our guide on [using fyn in Docker](../guides/integration/docker.md) for more details.
 
 ### GitHub Releases
 
@@ -115,13 +79,6 @@ fyn release artifacts can be downloaded directly from
 Each release page includes binaries for supported platforms, and may also include standalone
 installer scripts.
 
-### Cargo
-
-fyn is available via [crates.io](https://crates.io).
-
-```console
-$ cargo install --locked fyn
-```
 
 !!! note
 

--- a/docs/guides/integration/aws-lambda.md
+++ b/docs/guides/integration/aws-lambda.md
@@ -93,7 +93,7 @@ the second stage, we'll copy this directory over to the final image, omitting th
 other unnecessary files.
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/oha/fyn:0.10.14 AS fyn
+FROM ghcr.io/duriantaco/fyn:0.10.14 AS fyn
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder
@@ -157,10 +157,10 @@ layers, resulting in millisecond builds:
  => [internal] load build definition from Dockerfile                                                                 0.0s
  => => transferring dockerfile: 1.31kB                                                                               0.0s
  => [internal] load metadata for public.ecr.aws/lambda/python:3.13                                                   0.3s
- => [internal] load metadata for ghcr.io/oha/fyn:latest                                                         0.3s
+ => [internal] load metadata for ghcr.io/duriantaco/fyn:latest                                                         0.3s
  => [internal] load .dockerignore                                                                                    0.0s
  => => transferring context: 106B                                                                                    0.0s
- => [fyn 1/1] FROM ghcr.io/oha/fyn:latest@sha256:ea61e006cfec0e8d81fae901ad703e09d2c6cf1aa58abcb6507d124b50286f  0.0s
+ => [fyn 1/1] FROM ghcr.io/duriantaco/fyn:latest@sha256:ea61e006cfec0e8d81fae901ad703e09d2c6cf1aa58abcb6507d124b50286f  0.0s
  => [builder 1/2] FROM public.ecr.aws/lambda/python:3.13@sha256:f5b51b377b80bd303fe8055084e2763336ea8920d12955b23ef  0.0s
  => [internal] load build context                                                                                    0.0s
  => => transferring context: 185B                                                                                    0.0s
@@ -335,7 +335,7 @@ And confirm that opening http://127.0.0.1:8000/ in a web browser displays, "Hell
 Finally, we'll update the Dockerfile to include the local library in the deployment package:
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/oha/fyn:0.10.14 AS fyn
+FROM ghcr.io/duriantaco/fyn:0.10.14 AS fyn
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder

--- a/docs/guides/integration/coiled.md
+++ b/docs/guides/integration/coiled.md
@@ -83,7 +83,7 @@ using Coiled.
 To instruct Coiled to run the script on a virtual machine on AWS, add two comments to the top:
 
 ```python title="process.py" hl_lines="1-2"
-# COILED container ghcr.io/oha/fyn:debian-slim
+# COILED container ghcr.io/duriantaco/fyn:debian-slim
 # COILED region us-east-2
 
 # /// script

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -23,75 +23,75 @@ pre-installed.
 As an example, to run fyn in a container using a Debian-based image:
 
 ```console
-$ docker run --rm -it ghcr.io/oha/fyn:debian fyn --help
+$ docker run --rm -it ghcr.io/duriantaco/fyn:debian fyn --help
 ```
 
 ### Available images
 
 The following distroless images are available:
 
-- `ghcr.io/oha/fyn:latest`
-- `ghcr.io/oha/fyn:{major}.{minor}.{patch}`, e.g., `ghcr.io/oha/fyn:0.10.14`
-- `ghcr.io/oha/fyn:{major}.{minor}`, e.g., `ghcr.io/oha/fyn:0.8` (the latest patch version)
+- `ghcr.io/duriantaco/fyn:latest`
+- `ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}`, e.g., `ghcr.io/duriantaco/fyn:0.10.14`
+- `ghcr.io/duriantaco/fyn:{major}.{minor}`, e.g., `ghcr.io/duriantaco/fyn:0.8` (the latest patch version)
 
 And the following derived images are available:
 
 <!-- prettier-ignore -->
 - Based on `alpine:3.23`:
-    - `ghcr.io/oha/fyn:alpine`
-    - `ghcr.io/oha/fyn:alpine3.23`
+    - `ghcr.io/duriantaco/fyn:alpine`
+    - `ghcr.io/duriantaco/fyn:alpine3.23`
 - Based on `alpine:3.22`:
-    - `ghcr.io/oha/fyn:alpine3.22`
+    - `ghcr.io/duriantaco/fyn:alpine3.22`
 - Based on `debian:trixie-slim`:
-    - `ghcr.io/oha/fyn:debian-slim`
-    - `ghcr.io/oha/fyn:trixie-slim`
+    - `ghcr.io/duriantaco/fyn:debian-slim`
+    - `ghcr.io/duriantaco/fyn:trixie-slim`
 - Based on `buildpack-deps:trixie`:
-    - `ghcr.io/oha/fyn:debian`
-    - `ghcr.io/oha/fyn:trixie`
+    - `ghcr.io/duriantaco/fyn:debian`
+    - `ghcr.io/duriantaco/fyn:trixie`
 - Based on `dhi.io/alpine-base:3.23`:
-    - `ghcr.io/oha/fyn:alpine-dhi`
-    - `ghcr.io/oha/fyn:alpine3.23-dhi`
+    - `ghcr.io/duriantaco/fyn:alpine-dhi`
+    - `ghcr.io/duriantaco/fyn:alpine3.23-dhi`
 - Based on `dhi.io/debian-base:trixie-debian13`:
-    - `ghcr.io/oha/fyn:debian-dhi`
-    - `ghcr.io/oha/fyn:trixie-dhi`
+    - `ghcr.io/duriantaco/fyn:debian-dhi`
+    - `ghcr.io/duriantaco/fyn:trixie-dhi`
 - Based on `dhi/python:3.x`:
-    - `ghcr.io/oha/fyn:python3.14-dhi`
-    - `ghcr.io/oha/fyn:python3.13-dhi`
-    - `ghcr.io/oha/fyn:python3.12-dhi`
-    - `ghcr.io/oha/fyn:python3.11-dhi`
-    - `ghcr.io/oha/fyn:python3.10-dhi`
+    - `ghcr.io/duriantaco/fyn:python3.14-dhi`
+    - `ghcr.io/duriantaco/fyn:python3.13-dhi`
+    - `ghcr.io/duriantaco/fyn:python3.12-dhi`
+    - `ghcr.io/duriantaco/fyn:python3.11-dhi`
+    - `ghcr.io/duriantaco/fyn:python3.10-dhi`
 - Based on `python3.x-alpine`:
-    - `ghcr.io/oha/fyn:python3.14-alpine`
-    - `ghcr.io/oha/fyn:python3.14-alpine3.23`
-    - `ghcr.io/oha/fyn:python3.13-alpine`
-    - `ghcr.io/oha/fyn:python3.13-alpine3.23`
-    - `ghcr.io/oha/fyn:python3.12-alpine`
-    - `ghcr.io/oha/fyn:python3.12-alpine3.23`
-    - `ghcr.io/oha/fyn:python3.11-alpine`
-    - `ghcr.io/oha/fyn:python3.11-alpine3.23`
-    - `ghcr.io/oha/fyn:python3.10-alpine`
-    - `ghcr.io/oha/fyn:python3.10-alpine3.23`
-    - `ghcr.io/oha/fyn:python3.9-alpine`
-    - `ghcr.io/oha/fyn:python3.9-alpine3.22`
+    - `ghcr.io/duriantaco/fyn:python3.14-alpine`
+    - `ghcr.io/duriantaco/fyn:python3.14-alpine3.23`
+    - `ghcr.io/duriantaco/fyn:python3.13-alpine`
+    - `ghcr.io/duriantaco/fyn:python3.13-alpine3.23`
+    - `ghcr.io/duriantaco/fyn:python3.12-alpine`
+    - `ghcr.io/duriantaco/fyn:python3.12-alpine3.23`
+    - `ghcr.io/duriantaco/fyn:python3.11-alpine`
+    - `ghcr.io/duriantaco/fyn:python3.11-alpine3.23`
+    - `ghcr.io/duriantaco/fyn:python3.10-alpine`
+    - `ghcr.io/duriantaco/fyn:python3.10-alpine3.23`
+    - `ghcr.io/duriantaco/fyn:python3.9-alpine`
+    - `ghcr.io/duriantaco/fyn:python3.9-alpine3.22`
 - Based on `python3.x-trixie`:
-    - `ghcr.io/oha/fyn:python3.14-trixie`
-    - `ghcr.io/oha/fyn:python3.13-trixie`
-    - `ghcr.io/oha/fyn:python3.12-trixie`
-    - `ghcr.io/oha/fyn:python3.11-trixie`
-    - `ghcr.io/oha/fyn:python3.10-trixie`
-    - `ghcr.io/oha/fyn:python3.9-trixie`
+    - `ghcr.io/duriantaco/fyn:python3.14-trixie`
+    - `ghcr.io/duriantaco/fyn:python3.13-trixie`
+    - `ghcr.io/duriantaco/fyn:python3.12-trixie`
+    - `ghcr.io/duriantaco/fyn:python3.11-trixie`
+    - `ghcr.io/duriantaco/fyn:python3.10-trixie`
+    - `ghcr.io/duriantaco/fyn:python3.9-trixie`
 - Based on `python3.x-slim-trixie`:
-    - `ghcr.io/oha/fyn:python3.14-trixie-slim`
-    - `ghcr.io/oha/fyn:python3.13-trixie-slim`
-    - `ghcr.io/oha/fyn:python3.12-trixie-slim`
-    - `ghcr.io/oha/fyn:python3.11-trixie-slim`
-    - `ghcr.io/oha/fyn:python3.10-trixie-slim`
-    - `ghcr.io/oha/fyn:python3.9-trixie-slim`
+    - `ghcr.io/duriantaco/fyn:python3.14-trixie-slim`
+    - `ghcr.io/duriantaco/fyn:python3.13-trixie-slim`
+    - `ghcr.io/duriantaco/fyn:python3.12-trixie-slim`
+    - `ghcr.io/duriantaco/fyn:python3.11-trixie-slim`
+    - `ghcr.io/duriantaco/fyn:python3.10-trixie-slim`
+    - `ghcr.io/duriantaco/fyn:python3.9-trixie-slim`
 <!-- prettier-ignore-end -->
 
 As with the distroless image, each derived image is published with fyn version tags as
-`ghcr.io/oha/fyn:{major}.{minor}.{patch}-{base}` and `ghcr.io/oha/fyn:{major}.{minor}-{base}`, e.g.,
-`ghcr.io/oha/fyn:0.10.14-alpine`.
+`ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}-{base}` and `ghcr.io/duriantaco/fyn:{major}.{minor}-{base}`, e.g.,
+`ghcr.io/duriantaco/fyn:0.10.14-alpine`.
 
 In addition, starting with `0.8` each derived image also sets `UV_TOOL_BIN_DIR` to `/usr/local/bin`
 to allow `fyn tool install` to work as expected with the default user.
@@ -105,7 +105,7 @@ official distroless Docker image:
 
 ```dockerfile title="Dockerfile"
 FROM python:3.12-slim-trixie
-COPY --from=ghcr.io/oha/fyn:latest /fyn /fynx /bin/
+COPY --from=ghcr.io/duriantaco/fyn:latest /fyn /fynx /bin/
 ```
 
 Or, with an installer script you downloaded from a GitHub release:
@@ -131,7 +131,7 @@ Note this requires `curl` to be available.
 In either case, it is best practice to pin to a specific fyn version, e.g., with:
 
 ```dockerfile
-COPY --from=ghcr.io/oha/fyn:0.10.14 /fyn /fynx /bin/
+COPY --from=ghcr.io/duriantaco/fyn:0.10.14 /fyn /fynx /bin/
 ```
 
 !!! tip
@@ -143,7 +143,7 @@ COPY --from=ghcr.io/oha/fyn:0.10.14 /fyn /fynx /bin/
 
     ```Dockerfile
     # e.g., using a hash from a previous release
-    COPY --from=ghcr.io/oha/fyn@sha256:2381d6aa60c326b71fd40023f921a0a3b8f91b14d5db6b90402e65a635053709 /fyn /fynx /bin/
+    COPY --from=ghcr.io/duriantaco/fyn@sha256:2381d6aa60c326b71fd40023f921a0a3b8f91b14d5db6b90402e65a635053709 /fyn /fynx /bin/
     ```
 
 Or, if you prefer the installer flow, use the same `COPY install.sh /fyn-installer.sh` pattern with
@@ -392,7 +392,7 @@ a big time saver.
 ```dockerfile title="Dockerfile"
 # Install fyn
 FROM python:3.12-slim
-COPY --from=ghcr.io/oha/fyn:latest /fyn /fynx /bin/
+COPY --from=ghcr.io/duriantaco/fyn:latest /fyn /fynx /bin/
 
 # Change the working directory to the `app` directory
 WORKDIR /app
@@ -430,7 +430,7 @@ needed:
 ```dockerfile title="Dockerfile"
 # Install fyn
 FROM python:3.12-slim
-COPY --from=ghcr.io/oha/fyn:latest /fyn /fynx /bin/
+COPY --from=ghcr.io/duriantaco/fyn:latest /fyn /fynx /bin/
 
 WORKDIR /app
 
@@ -467,7 +467,7 @@ For example:
 ```dockerfile title="Dockerfile"
 # Install fyn
 FROM python:3.12-slim AS builder
-COPY --from=ghcr.io/oha/fyn:latest /fyn /fynx /bin/
+COPY --from=ghcr.io/duriantaco/fyn:latest /fyn /fynx /bin/
 
 # Use the system Python across both stages
 ENV UV_PYTHON_DOWNLOADS=0
@@ -502,7 +502,7 @@ CMD ["/app/.venv/bin/hello"]
 If fyn isn't needed in the final image, the binary can be mounted in each invocation:
 
 ```dockerfile title="Dockerfile"
-RUN --mount=from=ghcr.io/oha/fyn,source=/fyn,target=/bin/fyn \
+RUN --mount=from=ghcr.io/duriantaco/fyn,source=/fyn,target=/bin/fyn \
     fyn sync
 ```
 
@@ -570,8 +570,8 @@ For example, you can verify the attestations with the
 [GitHub CLI tool `gh`](https://cli.github.com/):
 
 ```console
-$ gh attestation verify --owner <repo-owner> oci://ghcr.io/oha/fyn:latest
-Loaded digest sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx for oci://ghcr.io/oha/fyn:latest
+$ gh attestation verify --owner <repo-owner> oci://ghcr.io/duriantaco/fyn:latest
+Loaded digest sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx for oci://ghcr.io/duriantaco/fyn:latest
 Loaded 1 attestation from GitHub API
 
 The following policy criteria will be enforced:
@@ -596,12 +596,12 @@ attestation blob against the (multi-platform) manifest for `fyn`:
 
 ```console
 $ REPO=<repo-owner>/fyn
-$ gh attestation download --repo $REPO oci://ghcr.io/oha/fyn:latest
+$ gh attestation download --repo $REPO oci://ghcr.io/duriantaco/fyn:latest
 Wrote attestations to file sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.jsonl.
 Any previous content has been overwritten
 
 The trusted metadata is now available at sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.jsonl
-$ docker buildx imagetools inspect ghcr.io/oha/fyn:latest --format "{{json .Manifest}}" > manifest.json
+$ docker buildx imagetools inspect ghcr.io/duriantaco/fyn:latest --format "{{json .Manifest}}" > manifest.json
 $ cosign verify-blob-attestation \
     --new-bundle-format \
     --bundle "$(jq -r .digest manifest.json).jsonl"  \
@@ -614,5 +614,5 @@ Verified OK
 !!! tip
 
     These examples use `latest`, but best practice is to verify the attestation for a specific
-    version tag, e.g., `ghcr.io/oha/fyn:0.10.14`, or (even better) the specific image digest,
-    such as `ghcr.io/oha/fyn:0.5.27@sha256:5adf09a5a526f380237408032a9308000d14d5947eafa687ad6c6a2476787b4f`.
+    version tag, e.g., `ghcr.io/duriantaco/fyn:0.10.14`, or (even better) the specific image digest,
+    such as `ghcr.io/duriantaco/fyn:0.5.27@sha256:5adf09a5a526f380237408032a9308000d14d5947eafa687ad6c6a2476787b4f`.

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -32,7 +32,8 @@ The following distroless images are available:
 
 - `ghcr.io/duriantaco/fyn:latest`
 - `ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}`, e.g., `ghcr.io/duriantaco/fyn:0.10.14`
-- `ghcr.io/duriantaco/fyn:{major}.{minor}`, e.g., `ghcr.io/duriantaco/fyn:0.8` (the latest patch version)
+- `ghcr.io/duriantaco/fyn:{major}.{minor}`, e.g., `ghcr.io/duriantaco/fyn:0.8` (the latest patch
+  version)
 
 And the following derived images are available:
 
@@ -90,8 +91,8 @@ And the following derived images are available:
 <!-- prettier-ignore-end -->
 
 As with the distroless image, each derived image is published with fyn version tags as
-`ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}-{base}` and `ghcr.io/duriantaco/fyn:{major}.{minor}-{base}`, e.g.,
-`ghcr.io/duriantaco/fyn:0.10.14-alpine`.
+`ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}-{base}` and
+`ghcr.io/duriantaco/fyn:{major}.{minor}-{base}`, e.g., `ghcr.io/duriantaco/fyn:0.10.14-alpine`.
 
 In addition, starting with `0.8` each derived image also sets `UV_TOOL_BIN_DIR` to `/usr/local/bin`
 to allow `fyn tool install` to work as expected with the default user.

--- a/docs/guides/integration/fastapi.md
+++ b/docs/guides/integration/fastapi.md
@@ -103,7 +103,7 @@ To deploy the FastAPI application with Docker, you can use the following `Docker
 FROM python:3.12-slim
 
 # Install fyn.
-COPY --from=ghcr.io/oha/fyn:latest /fyn /fynx /bin/
+COPY --from=ghcr.io/duriantaco/fyn:latest /fyn /fynx /bin/
 
 # Copy the application into the container.
 COPY . /app

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -350,8 +350,8 @@ steps:
 ## Publishing to PyPI
 
 fyn can be used to build and publish your package to PyPI from GitHub Actions. We provide a
-standalone example alongside this guide in
-[oha/trusted-publishing-examples](https://github.com/oha/trusted-publishing-examples). The workflow
+standalone example alongside Astral's uv guide in
+[astral-sh/trusted-publishing-examples](https://github.com/astral-sh/trusted-publishing-examples). The workflow
 uses [trusted publishing](https://docs.pypi.org/trusted-publishers/), so no credentials need to be
 configured.
 

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -351,9 +351,9 @@ steps:
 
 fyn can be used to build and publish your package to PyPI from GitHub Actions. We provide a
 standalone example alongside Astral's uv guide in
-[astral-sh/trusted-publishing-examples](https://github.com/astral-sh/trusted-publishing-examples). The workflow
-uses [trusted publishing](https://docs.pypi.org/trusted-publishers/), so no credentials need to be
-configured.
+[astral-sh/trusted-publishing-examples](https://github.com/astral-sh/trusted-publishing-examples).
+The workflow uses [trusted publishing](https://docs.pypi.org/trusted-publishers/), so no credentials
+need to be configured.
 
 In the example workflow, we use a script to test that the source distribution and the wheel are both
 functional and we didn't miss any files. This step is recommended, but optional.

--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -21,7 +21,7 @@ variables:
   UV_LINK_MODE: copy
 
 fyn:
-  image: ghcr.io/oha/fyn:$UV_VERSION-python$PYTHON_VERSION-$BASE_LAYER
+  image: ghcr.io/duriantaco/fyn:$UV_VERSION-python$PYTHON_VERSION-$BASE_LAYER
   script:
     # your `fyn` commands
 ```
@@ -32,7 +32,7 @@ fyn:
     ```yaml
     fyn:
       image:
-        name: ghcr.io/oha/fyn:$UV_VERSION
+        name: ghcr.io/duriantaco/fyn:$UV_VERSION
         entrypoint: [""]
       # ...
     ```

--- a/docs/guides/integration/pre-commit.md
+++ b/docs/guides/integration/pre-commit.md
@@ -7,7 +7,8 @@ description:
 
 # Under development
 
-Astral's uv-pre-commit hook has not been forked yet.  The documentation below is for future use once an official fyn-pre-commit exists.
+Astral's uv-pre-commit hook has not been forked yet. The documentation below is for future use once
+an official fyn-pre-commit exists.
 
 # Using fyn in pre-commit
 

--- a/docs/guides/integration/pre-commit.md
+++ b/docs/guides/integration/pre-commit.md
@@ -5,10 +5,14 @@ description:
   compile requirements files.
 ---
 
+# Under development
+
+Astral's uv-pre-commit hook has not been forked yet.  The documentation below is for future use once an official fyn-pre-commit exists.
+
 # Using fyn in pre-commit
 
 An official pre-commit hook is provided at
-[`oha/fyn-pre-commit`](https://github.com/oha/fyn-pre-commit).
+[`duriantaco/fyn-pre-commit`](https://github.com/duriantaco/fyn-pre-commit).
 
 To use fyn with pre-commit, add one of the following examples to the `repos` list in the
 `.pre-commit-config.yaml`.
@@ -17,7 +21,7 @@ To make sure your `fyn.lock` file is up to date even if your `pyproject.toml` fi
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
-  - repo: https://github.com/oha/fyn-pre-commit
+  - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
     rev: 0.10.14
     hooks:
@@ -28,7 +32,7 @@ To keep a `requirements.txt` file in sync with your `fyn.lock` file:
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
-  - repo: https://github.com/oha/fyn-pre-commit
+  - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
     rev: 0.10.14
     hooks:
@@ -39,7 +43,7 @@ To compile requirements files:
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
-  - repo: https://github.com/oha/fyn-pre-commit
+  - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
     rev: 0.10.14
     hooks:
@@ -52,7 +56,7 @@ To compile alternative requirements files, modify `args` and `files`:
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
-  - repo: https://github.com/oha/fyn-pre-commit
+  - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
     rev: 0.10.14
     hooks:
@@ -66,7 +70,7 @@ To run the hook over multiple files at the same time, add additional entries:
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
-  - repo: https://github.com/oha/fyn-pre-commit
+  - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
     rev: 0.10.14
     hooks:

--- a/docs/guides/migration/index.md
+++ b/docs/guides/migration/index.md
@@ -7,7 +7,7 @@ Learn how to migrate from other tools to fyn:
 !!! note
 
     Other guides, such as migrating from another project management tool, or from pip to `fyn pip`
-    are not yet available. See [#5200](https://github.com/oha/fyn/issues/5200) to track
+    are not yet available. See [#5200](https://github.com/astral-sh/fyn/issues/5200) to track
     progress.
 
 Or, explore the [integration guides](../integration/index.md) to learn how to use fyn with other

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -153,7 +153,7 @@ fyn pip install wheel && fyn pip install --no-build-isolation biopython==1.77
 ```
 
 For a list of packages that are known to fail under PEP 517 build isolation, see
-[#2252](https://github.com/oha/fyn/issues/2252).
+[#2252](https://github.com/astral-sh/fyn/issues/2252).
 
 ## Transitive URL dependencies
 
@@ -303,7 +303,7 @@ Additionally, pip will fall back to the `user` install scheme if it detects that
 have write permissions to the target directory, as is the case on some systems when installing into
 the system Python. fyn does not implement any such fallback.
 
-For more, see [#2077](https://github.com/oha/fyn/issues/2077).
+For more, see [#2077](https://github.com/astral-sh/uv/issues/2077).
 
 ## `--only-binary` enforcement
 
@@ -397,8 +397,8 @@ does support a large subset.
 Missing options and subcommands are prioritized based on user demand and the complexity of the
 implementation, and tend to be tracked in individual issues. For example:
 
-- [`--trusted-host`](https://github.com/oha/fyn/issues/1339)
-- [`--user`](https://github.com/oha/fyn/issues/2077)
+- [`--trusted-host`](https://github.com/astral-sh/fyn/issues/1339)
+- [`--user`](https://github.com/astral-sh/uv/issues/2077)
 
 If you encounter a missing option or subcommand, please search the issue tracker to see if it has
 already been reported, and if not, consider opening a new issue. Feel free to upvote any existing

--- a/docs/reference/troubleshooting/build-failures.md
+++ b/docs/reference/troubleshooting/build-failures.md
@@ -116,7 +116,7 @@ The following examples demonstrate common build failures and how to resolve them
 
 If the build error mentions a missing command, for example, `gcc`:
 
-<!-- docker run --platform linux/x86_64 -it ghcr.io/oha/fyn:python3.10-trixie-slim /bin/bash -c "fyn pip install --system pysha3==1.0.2" -->
+<!-- docker run --platform linux/x86_64 -it ghcr.io/duriantaco/fyn:python3.10-trixie-slim /bin/bash -c "fyn pip install --system pysha3==1.0.2" -->
 
 ```hl_lines="17"
 × Failed to build `pysha3==1.0.2`
@@ -164,7 +164,7 @@ install it with your system package manager.
 
 For example, installing `pygraphviz` requires Graphviz to be installed:
 
-<!-- docker run --platform linux/x86_64 -it ghcr.io/oha/fyn:python3.12-trixie /bin/bash -c "fyn pip install --system 'pygraphviz'" -->
+<!-- docker run --platform linux/x86_64 -it ghcr.io/duriantaco/fyn:python3.12-trixie /bin/bash -c "fyn pip install --system 'pygraphviz'" -->
 
 ```hl_lines="18-19"
 × Failed to build `pygraphviz==1.14`
@@ -215,7 +215,7 @@ If the build error mentions a failing import, consider
 For example, some packages assume that `pip` is available without declaring it as a build
 dependency:
 
-<!-- docker run --platform linux/x86_64 -it ghcr.io/oha/fyn:python3.12-trixie-slim /bin/bash -c "fyn pip install --system chumpy" -->
+<!-- docker run --platform linux/x86_64 -it ghcr.io/duriantaco/fyn:python3.12-trixie-slim /bin/bash -c "fyn pip install --system chumpy" -->
 
 ```hl_lines="7"
   × Failed to build `chumpy==0.70`
@@ -271,7 +271,7 @@ dill<0.3.9,>=0.2.2
 apache-beam<=2.49.0
 ```
 
-<!-- docker run --platform linux/x86_64 -it ghcr.io/oha/fyn:python3.10-trixie-slim /bin/bash -c "printf 'dill<0.3.9,>=0.2.2\napache-beam<=2.49.0' | fyn pip compile -" -->
+<!-- docker run --platform linux/x86_64 -it ghcr.io/duriantaco/fyn:python3.10-trixie-slim /bin/bash -c "printf 'dill<0.3.9,>=0.2.2\napache-beam<=2.49.0' | fyn pip compile -" -->
 
 ```hl_lines="1"
 × Failed to build `apache-beam==2.0.0`

--- a/docs/reference/troubleshooting/reproducible-examples.md
+++ b/docs/reference/troubleshooting/reproducible-examples.md
@@ -51,7 +51,7 @@ When writing a Docker MRE with fyn, it's best to start with one of
 to pin to a specific version of fyn.
 
 ```Dockerfile
-FROM ghcr.io/oha/fyn:0.5.24-debian-slim
+FROM ghcr.io/duriantaco/fyn:0.5.24-debian-slim
 ```
 
 While Docker images are isolated from the system, the build will use your system's architecture by
@@ -60,13 +60,13 @@ gets the expected behavior. fyn publishes images for `linux/amd64` (e.g., Intel 
 `linux/arm64` (e.g., Apple M Series or ARM)
 
 ```Dockerfile
-FROM --platform=linux/amd64 ghcr.io/oha/fyn:0.5.24-debian-slim
+FROM --platform=linux/amd64 ghcr.io/duriantaco/fyn:0.5.24-debian-slim
 ```
 
 Docker images are best for reproducing issues that can be constructed with commands, e.g.:
 
 ```Dockerfile
-FROM --platform=linux/amd64 ghcr.io/oha/fyn:0.5.24-debian-slim
+FROM --platform=linux/amd64 ghcr.io/duriantaco/fyn:0.5.24-debian-slim
 
 RUN fyn init /mre
 WORKDIR /mre
@@ -78,7 +78,7 @@ RUN fyn run -v python -c "import pydantic"
 However, you can also write files into the image inline:
 
 ```Dockerfile
-FROM --platform=linux/amd64 ghcr.io/oha/fyn:0.5.24-debian-slim
+FROM --platform=linux/amd64 ghcr.io/duriantaco/fyn:0.5.24-debian-slim
 
 COPY <<EOF /mre/pyproject.toml
 [project]

--- a/fyn.schema.json
+++ b/fyn.schema.json
@@ -868,7 +868,7 @@
       }
     },
     "DisplaySafeUrl": {
-      "description": "A [`Url`] wrapper that redacts credentials when displaying the URL.\n\n`DisplaySafeUrl` wraps the standard [`url::Url`] type, providing functionality to mask\nsecrets by default when the URL is displayed or logged. This helps prevent accidental\nexposure of sensitive information in logs and debug output.\n\n# Examples\n\n```\nuse fyn_redacted::DisplaySafeUrl;\nuse std::str::FromStr;\n\n// Create a `DisplaySafeUrl` from a `&str`\nlet mut url = DisplaySafeUrl::parse(\"https://user:password@example.com\").unwrap();\n\n// Display will mask secrets\nassert_eq!(url.to_string(), \"https://user:****@example.com/\");\n\n// You can still access the username and password\nassert_eq!(url.username(), \"user\");\nassert_eq!(url.password(), Some(\"password\"));\n\n// And you can still update the username and password\nlet _ = url.set_username(\"new_user\");\nlet _ = url.set_password(Some(\"new_password\"));\nassert_eq!(url.username(), \"new_user\");\nassert_eq!(url.password(), Some(\"new_password\"));\n\n// It is also possible to remove the credentials entirely\nurl.remove_credentials();\nassert_eq!(url.username(), \"\");\nassert_eq!(url.password(), None);\n```",
+      "description": "A [`Url`] wrapper that redacts credentials and sensitive query parameters when displaying the URL.\n\n`DisplaySafeUrl` wraps the standard [`url::Url`] type, providing functionality to mask\nsecrets by default when the URL is displayed or logged. This helps prevent accidental\nexposure of sensitive information in logs and debug output.\n\n# Examples\n\n```\nuse fyn_redacted::DisplaySafeUrl;\nuse std::str::FromStr;\n\n// Create a `DisplaySafeUrl` from a `&str`\nlet mut url = DisplaySafeUrl::parse(\"https://user:password@example.com\").unwrap();\n\n// Display will mask secrets\nassert_eq!(url.to_string(), \"https://user:****@example.com/\");\n\n// You can still access the username and password\nassert_eq!(url.username(), \"user\");\nassert_eq!(url.password(), Some(\"password\"));\n\n// And you can still update the username and password\nlet _ = url.set_username(\"new_user\");\nlet _ = url.set_password(Some(\"new_password\"));\nassert_eq!(url.username(), \"new_user\");\nassert_eq!(url.password(), Some(\"new_password\"));\n\n// It is also possible to remove the credentials entirely\nurl.remove_credentials();\nassert_eq!(url.username(), \"\");\nassert_eq!(url.password(), None);\n```",
       "type": "string",
       "format": "uri"
     },
@@ -1013,6 +1013,13 @@
             }
           ]
         },
+        "exclude-packages": {
+          "description": "Exclude matching packages from this index.\n\nAccepts glob patterns matched against normalized package names. If no `include-packages`\npatterns match a package, and an `exclude-packages` pattern matches, this index will be\nskipped for that package unless it has an explicit `[tool.fyn.sources]` index pin.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PackageNamePattern"
+          }
+        },
         "explicit": {
           "description": "Mark the index as explicit.\n\nExplicit indexes will _only_ be used when explicitly requested via a `[tool.fyn.sources]`\ndefinition, as in:\n\n```toml\n[[tool.fyn.index]]\nname = \"pytorch\"\nurl = \"https://download.pytorch.org/whl/cu121\"\nexplicit = true\n\n[tool.fyn.sources]\ntorch = { index = \"pytorch\" }\n```",
           "type": "boolean",
@@ -1033,6 +1040,13 @@
           "default": null,
           "items": {
             "$ref": "#/definitions/StatusCode"
+          }
+        },
+        "include-packages": {
+          "description": "Route matching packages exclusively to this index.\n\nAccepts glob patterns matched against normalized package names. If any pattern matches a\npackage, only indexes whose `include-packages` also match will be searched for that package,\nunless it has an explicit `[tool.fyn.sources]` index pin.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PackageNamePattern"
           }
         },
         "name": {
@@ -1204,6 +1218,9 @@
     },
     "PackageName": {
       "description": "The normalized name of a package.\n\nConverts the name to lowercase and collapses runs of `-`, `_`, and `.` down to a single `-`.\nFor example, `---`, `.`, and `__` are all converted to a single `-`.\n\nSee: <https://packaging.python.org/en/latest/specifications/name-normalization/>",
+      "type": "string"
+    },
+    "PackageNamePattern": {
       "type": "string"
     },
     "PackageNameSpecifier": {

--- a/fyn.schema.json
+++ b/fyn.schema.json
@@ -520,7 +520,7 @@
       ]
     },
     "sources": {
-      "description": "The sources to use when resolving dependencies.\n\n`tool.fyn.sources` enriches the dependency metadata with additional sources, incorporated\nduring development. A dependency source can be a Git repository, a URL, a local path, or an\nalternative registry.\n\nSee [Dependencies](https://github.com/oha/fyn) for more.",
+      "description": "The sources to use when resolving dependencies.\n\n`tool.fyn.sources` enriches the dependency metadata with additional sources, incorporated\nduring development. A dependency source can be a Git repository, a URL, a local path, or an\nalternative registry.\n\nSee [Dependencies](https://duriantaco.github.io/fyn/concepts/projects/dependencies/) for more.",
       "anyOf": [
         {
           "$ref": "#/definitions/ToolfynSources"

--- a/scripts/check_registry.py
+++ b/scripts/check_registry.py
@@ -15,7 +15,7 @@ expected_registry = [
 Name                           Property
 ----                           --------
 fyn                            DisplayName : fyn contributors
-                               SupportUrl  : https://github.com/oha/fyn
+                               SupportUrl  : https://github.com/duriantaco/fyn
 """,
     # The actual Python installations
     r"""
@@ -25,7 +25,7 @@ fyn                            DisplayName : fyn contributors
 Name                           Property
 ----                           --------
 fyn                            DisplayName : fyn contributors
-                               SupportUrl  : https://github.com/oha/fyn
+                               SupportUrl  : https://github.com/duriantaco/fyn
 
 
     Hive: HKEY_CURRENT_USER\Software\Python\fyn
@@ -34,7 +34,7 @@ fyn                            DisplayName : fyn contributors
 Name                           Property
 ----                           --------
 CPython3.11.11                 DisplayName     : CPython 3.11.11 (64-bit)
-                               SupportUrl      : https://github.com/oha/fyn
+                               SupportUrl      : https://github.com/duriantaco/fyn
                                Version         : 3.11.11
                                SysVersion      : 3.11.11
                                SysArchitecture : 64bit
@@ -58,7 +58,7 @@ InstallPath                    (default)              : C:\Users\runneradmin\App
 Name                           Property
 ----                           --------
 CPython3.12.8                  DisplayName     : CPython 3.12.8 (64-bit)
-                               SupportUrl      : https://github.com/oha/fyn
+                               SupportUrl      : https://github.com/duriantaco/fyn
                                Version         : 3.12.8
                                SysVersion      : 3.12.8
                                SysArchitecture : 64bit
@@ -82,7 +82,7 @@ InstallPath                    (default)              : C:\Users\runneradmin\App
 Name                           Property
 ----                           --------
 CPython3.13.1                  DisplayName     : CPython 3.13.1 (64-bit)
-                               SupportUrl      : https://github.com/oha/fyn
+                               SupportUrl      : https://github.com/duriantaco/fyn
                                Version         : 3.13.1
                                SysVersion      : 3.13.1
                                SysArchitecture : 64bit

--- a/scripts/generate-crate-readmes.py
+++ b/scripts/generate-crate-readmes.py
@@ -15,7 +15,7 @@ fyn_TEMPLATE = """{GENERATED_HEADER}
 
 fyn is a Python package and project manager.
 
-See the [repository](https://github.com/oha/fyn)
+See the [repository](https://github.com/duriantaco/fyn)
 for more information.
 
 This crate is the entry point to the fyn command-line interface. The Rust API exposed here is not
@@ -47,7 +47,7 @@ See fyn's crate versioning policy for details on versioning.
 """
 
 
-REPO_URL = "https://github.com/oha/fyn"
+REPO_URL = "https://github.com/duriantaco/fyn"
 PRETTIER_VERSION = "3.8.3"
 
 


### PR DESCRIPTION
## Summary

It appears that the maintainer changed username from oha to duriantaco, breaking many links in this repo.  This PR started off as a simple find-and-replace, manually vetting each occurrence.

I discovered docs that have statements that are true for uv but not for fyn, so I removed them.  Example: docs/getting-started/installation.md shows how to install from various sources that fyn is not on.

Some docs and comments refer to issues that are only on the astral repository, so those links were updated.

