### PR TITLE
fix: harden wheel entry point script paths

### DIFF
--- a/crates/fyn-fs/src/path.rs
+++ b/crates/fyn-fs/src/path.rs
@@ -223,6 +223,21 @@ pub fn normalize_path(path: &Path) -> Cow<'_, Path> {
     Cow::Borrowed(path)
 }
 
+/// Normalize `path`, returning it when it remains strictly under a non-empty `root`.
+///
+/// This comparison is lexical and does not resolve symlinks. The returned path is normalized, and
+/// equality with `root` is rejected.
+pub fn normalize_path_under(path: impl AsRef<Path>, root: impl AsRef<Path>) -> Option<PathBuf> {
+    let path = normalize_path(path.as_ref()).into_owned();
+    let root = normalize_path(root.as_ref());
+
+    if root.as_os_str().is_empty() || path.as_path() == root.as_ref() {
+        None
+    } else {
+        path.starts_with(root.as_ref()).then_some(path)
+    }
+}
+
 /// Normalize a [`PathBuf`], removing things like `.` and `..`.
 pub fn normalize_path_buf(path: PathBuf) -> PathBuf {
     if path
@@ -685,6 +700,32 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(normalize_path(Path::new(input)), Path::new(expected));
         }
+    }
+
+    #[test]
+    fn test_normalize_path_under() {
+        assert_eq!(
+            normalize_path_under("scripts/script", "scripts"),
+            Some(PathBuf::from("scripts/script"))
+        );
+        assert_eq!(
+            normalize_path_under("/scripts/script", "/scripts"),
+            Some(PathBuf::from("/scripts/script"))
+        );
+        assert_eq!(
+            normalize_path_under("scripts/nested/../script", "scripts"),
+            Some(PathBuf::from("scripts/script"))
+        );
+        assert_eq!(
+            normalize_path_under("/scripts/nested/../script", "/scripts"),
+            Some(PathBuf::from("/scripts/script"))
+        );
+        assert_eq!(normalize_path_under("scripts/.", "scripts"), None);
+        assert_eq!(normalize_path_under("/scripts/.", "/scripts"), None);
+        assert_eq!(normalize_path_under("scripts/../script", "scripts"), None);
+        assert_eq!(normalize_path_under("/scripts/../script", "/scripts"), None);
+        assert_eq!(normalize_path_under("scripts/script", "."), None);
+        assert_eq!(normalize_path_under("scripts/script", ""), None);
     }
 
     #[cfg(windows)]

--- a/crates/fyn-install-wheel/src/lib.rs
+++ b/crates/fyn-install-wheel/src/lib.rs
@@ -75,8 +75,8 @@ pub enum Error {
     InvalidEggLink(PathBuf),
     #[error(transparent)]
     LauncherError(#[from] fyn_trampoline_builder::Error),
-    #[error("Scripts must not use the reserved name {0}")]
-    ReservedScriptName(String),
+    #[error("Scripts must not use the reserved name `{reserved}`, got: `{declared}`")]
+    ReservedScriptName { reserved: String, declared: String },
     #[error(transparent)]
     Copy(#[from] fyn_fs::link::LinkError),
 }

--- a/crates/fyn-install-wheel/src/script.rs
+++ b/crates/fyn-install-wheel/src/script.rs
@@ -1,4 +1,4 @@
-use configparser::ini::Ini;
+use configparser::ini::{Ini, IniDefault};
 use regex::Regex;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
@@ -69,7 +69,16 @@ pub(crate) fn scripts_from_ini(
     python_minor: u8,
     ini: String,
 ) -> Result<(Vec<Script>, Vec<Script>), Error> {
-    let entry_points_mapping = Ini::new_cs()
+    // Per the Entry Points specification, `entry_points.txt` is a case-sensitive
+    // INI file that only uses `=` as the field delimiter.
+    // See: <https://packaging.python.org/en/latest/specifications/entry-points/#file-format>
+    let mut ini_options = IniDefault::default();
+    ini_options.case_sensitive = true;
+    ini_options.delimiters = vec!['='];
+
+    let mut parser = Ini::new_from_defaults(ini_options);
+
+    let entry_points_mapping = parser
         .read(ini)
         .map_err(|err| Error::InvalidWheel(format!("entry_points.txt is invalid: {err}")))?;
 
@@ -217,5 +226,15 @@ memray3.11 = a:b7
             }),
             console_scripts.get(5)
         );
+    }
+
+    #[test]
+    fn test_rejects_non_equals_entry_point_delimiters() {
+        let sample_ini = "
+[console_scripts]
+script: package.module:main
+";
+
+        assert!(scripts_from_ini(None, 99, sample_ini.to_string()).is_err());
     }
 }

--- a/crates/fyn-install-wheel/src/wheel.rs
+++ b/crates/fyn-install-wheel/src/wheel.rs
@@ -14,7 +14,10 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, instrument, trace, warn};
 use walkdir::WalkDir;
 
-use fyn_fs::{PortablePath, Simplified, normalize_path, persist_with_retry_sync, relative_to};
+use fyn_fs::{
+    PortablePath, Simplified, normalize_path, normalize_path_under, persist_with_retry_sync,
+    relative_to,
+};
 use fyn_normalize::PackageName;
 use fyn_pypi_types::DirectUrl;
 use fyn_shell::escape_posix_for_single_quotes;
@@ -160,21 +163,86 @@ fn get_script_executable(python_executable: &Path, is_gui: bool) -> PathBuf {
     }
 }
 
-/// Determine the absolute path to an entrypoint script.
-fn entrypoint_path(entrypoint: &Script, layout: &Layout) -> PathBuf {
-    if cfg!(windows) {
-        // On windows we actually build an .exe wrapper
-        let script_name = entrypoint
-            .name
-            // FIXME: What are the in-reality rules here for names?
-            .strip_suffix(".py")
-            .unwrap_or(&entrypoint.name)
-            .to_string()
-            + ".exe";
+const RESERVED_SCRIPT_NAMES_ERROR: &[&str; 3] = &["python", "pythonw", "python3"];
+const RESERVED_SCRIPT_NAMES_WARN: &[&str; 2] = &["activate", "activate_this.py"];
 
-        layout.scheme.scripts.join(script_name)
-    } else {
-        layout.scheme.scripts.join(&entrypoint.name)
+/// A form of [`Script`] guaranteed by [`ValidatedScript::try_from_script`] to be constrained to
+/// the scripts directory.
+struct ValidatedScript<'script> {
+    path: PathBuf,
+    script: &'script Script,
+}
+
+impl<'script> ValidatedScript<'script> {
+    fn try_from_script(script: &'script Script, layout: &Layout) -> Result<Self, Error> {
+        let Some(path) = normalize_path_under(
+            layout.scheme.scripts.join(&script.name),
+            &layout.scheme.scripts,
+        ) else {
+            return Err(Error::InvalidWheel(format!(
+                "Script path must resolve to a file within the scripts directory: `{}`",
+                script.name
+            )));
+        };
+
+        let name = relative_to(&path, &layout.scheme.scripts)?
+            .to_string_lossy()
+            .into_owned();
+
+        if RESERVED_SCRIPT_NAMES_WARN.contains(&name.as_str()) || name.starts_with("activate.") {
+            warn_user_once!(
+                "The script name `{}` is reserved for virtual environment activation scripts.",
+                name
+            );
+        }
+
+        if RESERVED_SCRIPT_NAMES_ERROR.contains(&name.as_str())
+            || name
+                .strip_prefix("python3.")
+                .is_some_and(|suffix| suffix.parse::<u8>().is_ok())
+        {
+            return Err(Error::ReservedScriptName {
+                reserved: name,
+                declared: script.name.clone(),
+            });
+        }
+
+        let path = if cfg!(windows) {
+            // On Windows we actually build an `.exe` wrapper.
+            let name = name
+                // FIXME: What are the in-reality rules here for names?
+                .strip_suffix(".py")
+                .unwrap_or(&name)
+                .to_string()
+                + std::env::consts::EXE_SUFFIX;
+
+            layout.scheme.scripts.join(name)
+        } else {
+            layout.scheme.scripts.join(name)
+        };
+
+        Ok(Self { path, script })
+    }
+
+    fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    fn inner(&self) -> &Script {
+        self.script
+    }
+
+    /// Return the script destination relative to `site_packages` for use in `RECORD`.
+    ///
+    /// Entry points are installed in the scripts directory, which may sit outside
+    /// `site_packages`, so we use a lexical diff rather than stripping a prefix.
+    fn relative_to_site_package(&self, site_packages: &Path) -> Result<PathBuf, Error> {
+        pathdiff::diff_paths(self.as_path(), site_packages).ok_or_else(|| {
+            Error::Io(io::Error::other(format!(
+                "Could not find relative path for: {}",
+                self.as_path().simplified_display()
+            )))
+        })
     }
 }
 
@@ -187,42 +255,16 @@ pub(crate) fn write_script_entrypoints(
     record: &mut Vec<RecordEntry>,
     is_gui: bool,
 ) -> Result<(), Error> {
-    for entrypoint in entrypoints {
-        let warn_names = ["activate", "activate_this.py"];
-        if warn_names.contains(&entrypoint.name.as_str())
-            || entrypoint.name.starts_with("activate.")
-        {
-            warn_user_once!(
-                "The script name `{}` is reserved for virtual environment activation scripts.",
-                entrypoint.name
-            );
-        }
-        let reserved_names = ["python", "pythonw", "python3"];
-        if reserved_names.contains(&entrypoint.name.as_str())
-            || entrypoint
-                .name
-                .strip_prefix("python3.")
-                .is_some_and(|suffix| suffix.parse::<u8>().is_ok())
-        {
-            return Err(Error::ReservedScriptName(entrypoint.name.clone()));
-        }
-
-        let entrypoint_absolute = entrypoint_path(entrypoint, layout);
-
-        let entrypoint_relative = pathdiff::diff_paths(&entrypoint_absolute, site_packages)
-            .ok_or_else(|| {
-                Error::Io(io::Error::other(format!(
-                    "Could not find relative path for: {}",
-                    entrypoint_absolute.simplified_display()
-                )))
-            })?;
+    for script in entrypoints {
+        let script = ValidatedScript::try_from_script(script, layout)?;
+        let entrypoint_relative = script.relative_to_site_package(site_packages)?;
 
         // Generate the launcher script.
         let launcher_executable = get_script_executable(&layout.sys_executable, is_gui);
         let launcher_executable =
             get_relocatable_executable(launcher_executable, layout, relocatable)?;
         let launcher_python_script = get_script_launcher(
-            entrypoint,
+            script.inner(),
             &format_shebang(&launcher_executable, &layout.os_name, relocatable),
         );
 
@@ -248,8 +290,8 @@ pub(crate) fn write_script_entrypoints(
                 use std::fs::Permissions;
                 use std::os::unix::fs::PermissionsExt;
 
-                let path = site_packages.join(entrypoint_relative);
-                let permissions = fs::metadata(&path)?.permissions();
+                let path = script.as_path();
+                let permissions = fs::metadata(path)?.permissions();
                 if permissions.mode() & 0o111 != 0o111 {
                     fs::set_permissions(path, Permissions::from_mode(permissions.mode() | 0o111))?;
                 }

--- a/crates/fyn/tests/it/pip_install.rs
+++ b/crates/fyn/tests/it/pip_install.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -16,8 +17,10 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
     matchers::{basic_auth, method, path},
 };
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
 
-use fyn_fs::Simplified;
+use fyn_fs::{PortablePath, Simplified};
 use fyn_static::EnvVars;
 #[cfg(feature = "test-git")]
 use fyn_test::decode_token;
@@ -25,6 +28,7 @@ use fyn_test::{
     DEFAULT_PYTHON_VERSION, TestContext, build_vendor_links_url, download_to_disk, fyn_snapshot,
     get_bin, packse_index_url, venv_bin_path,
 };
+use walkdir::WalkDir;
 
 #[test]
 fn missing_requirements_txt() {
@@ -93,12 +97,12 @@ fn install_warns_inside_managed_project() -> Result<()> {
 
     ----- stderr -----
     warning: `fyn pip install` modifies the active environment directly and will not update `pyproject.toml` or `fyn.lock`.
-    
+
     State impact:
       environment: direct changes only
       pyproject.toml: unchanged
       fyn.lock: unchanged
-    
+
     Because the current directory is inside a fyn-managed project, use `fyn add`, `fyn remove`, `fyn sync`, or `fyn upgrade` instead.
     warning: Requirements file `requirements.txt` does not contain any dependencies
     Checked in [TIME]
@@ -13292,6 +13296,14 @@ fn reserved_script_name() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: `fyn pip install` modifies the active environment directly and will not update `pyproject.toml` or `fyn.lock`.
+
+    State impact:
+      environment: direct changes only
+      pyproject.toml: unchanged
+      fyn.lock: unchanged
+
+    Because the current directory is inside a fyn-managed project, use `fyn add`, `fyn remove`, `fyn sync`, or `fyn upgrade` instead.
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     warning: The script name `activate.bash` is reserved for virtual environment activation scripts.
@@ -13322,13 +13334,226 @@ fn reserved_script_name() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: `fyn pip install` modifies the active environment directly and will not update `pyproject.toml` or `fyn.lock`.
+
+    State impact:
+      environment: direct changes only
+      pyproject.toml: unchanged
+      fyn.lock: unchanged
+
+    Because the current directory is inside a fyn-managed project, use `fyn add`, `fyn remove`, `fyn sync`, or `fyn upgrade` instead.
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     error: Failed to install: project-0.1.0-py3-none-any.whl (project==0.1.0 (from file://[TEMP_DIR]/))
-      Caused by: Scripts must not use the reserved name python
+      Caused by: Scripts must not use the reserved name `python`, got: `python`
     "
     );
+
+    Ok(())
+}
+
+fn repacked_wheel_with_entrypoint(
+    context: &TestContext,
+    section: &str,
+    entrypoint_name: &str,
+) -> Result<PathBuf> {
+    context.init().arg("--lib").arg("foo").assert().success();
+    context.build().arg("--wheel").arg("foo").assert().success();
+
+    let built_wheel = context.temp_dir.join("foo/dist/foo-0.1.0-py3-none-any.whl");
+    let unpacked = context.temp_dir.join("foo-unpacked");
+    fyn_extract::unzip(File::open(&built_wheel)?, &unpacked)?;
+
+    fs::write(
+        unpacked.join("foo-0.1.0.dist-info/entry_points.txt"),
+        formatdoc! {"
+            [{section}]
+            {entrypoint_name} = foo:main
+            ",
+        },
+    )?;
+
+    let repacked_wheel = context.temp_dir.join("foo-0.1.0-py3-none-any.whl");
+    let mut writer = ZipWriter::new(File::create(&repacked_wheel)?);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    for entry in WalkDir::new(&unpacked) {
+        let entry = entry?;
+        let path = entry.path();
+        let name = path.strip_prefix(&unpacked)?;
+        if name.as_os_str().is_empty() {
+            continue;
+        }
+
+        // Zip entries must use forward slashes, even on Windows.
+        let mut name = PortablePath::from(name).to_string();
+        if path.is_dir() {
+            name.push('/');
+            writer.add_directory(name, options)?;
+        } else {
+            writer.start_file(name, options)?;
+            writer.write_all(&fs::read(path)?)?;
+        }
+    }
+    writer.finish()?;
+
+    Ok(repacked_wheel)
+}
+
+#[test]
+fn reject_wheel_entrypoint_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    // Build a normal wheel, then rewrite its entry-point metadata to exercise the installer
+    // directly, rather than relying on backend-side validation.
+    let escaped_entrypoint = context.temp_dir.child("escaped-entrypoint");
+    let repacked_wheel = repacked_wheel_with_entrypoint(
+        &context,
+        "console_scripts",
+        &escaped_entrypoint.path().portable_display().to_string(),
+    )?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: The wheel is invalid: Script path must resolve to a file within the scripts directory: `[TEMP_DIR]/escaped-entrypoint`
+    "
+    );
+
+    escaped_entrypoint.assert(predicates::path::missing());
+
+    Ok(())
+}
+
+#[test]
+fn reject_normalized_reserved_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "console_scripts", "nested/../python")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `python`, got: `nested/../python`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_normalized_reserved_gui_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "gui_scripts", "nested/../python")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `python`, got: `nested/../python`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn warn_normalized_activation_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "console_scripts", "nested/../activate.bash")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    warning: The script name `activate.bash` is reserved for virtual environment activation scripts.
+    Installed 1 package in [TIME]
+     + foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl)
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn accept_normalized_gui_wheel_entrypoint_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "gui_scripts", "nested/../normalized-gui")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl)
+    "
+    );
+
+    let script_name = if cfg!(windows) {
+        "normalized-gui.exe"
+    } else {
+        "normalized-gui"
+    };
+    let normalized_script = venv_bin_path(&context.venv).join(script_name);
+    assert!(normalized_script.exists());
+
+    Ok(())
+}
+
+#[test]
+fn accept_normalized_wheel_entrypoint_paths() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "console_scripts", "nested/../normalized-script")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl)
+    "
+    );
+
+    let script_name = if cfg!(windows) {
+        "normalized-script.exe"
+    } else {
+        "normalized-script"
+    };
+    let normalized_script = venv_bin_path(&context.venv).join(script_name);
+    assert!(normalized_script.exists());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

  - Backport upstream uv entry point script path hardening from astral-sh/uv#19464 and astral-sh/uv#19471
  - Constrain console/gui entry point script destinations to the env scripts directory after path normalization
  - Reject `entry_points.txt` files that use non-standard INI delimiters

  ## Testing

  - `cargo test -p fyn-fs test_normalize_path_under`
  - `cargo test -p fyn-install-wheel`
  - `cargo test -p fyn --test it wheel_entrypoint`
  - `cargo test -p fyn --test it reserved_script_name`