### PR TITLE
fix: update astral-tokio-tar for GHSA-3cv2-h65g-fgmm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ anstream = { version = "1.0.0" }
 anyhow = { version = "1.0.89" }
 arcstr = { version = "1.2.0" }
 arrayvec = { version = "0.7.6" }
-astral-tokio-tar = { version = "0.6.0" }
+astral-tokio-tar = { version = "0.6.2" }
 async-channel = { version = "2.3.1" }
 async-compression = { version = "0.4.12", features = [
   "bzip2",


### PR DESCRIPTION
## Summary

  - Update `astral-tokio-tar` from `0.6.0` to `0.6.2`
  - Pull in upstream uv’s fix for `GHSA-3cv2-h65g-fgmm`
  - Keep the change scoped to `Cargo.toml` and `Cargo.lock`

  ## Tests
  - `cargo check -p fyn-extract -p fyn-publish`