### PR TITLE
fix: reject unsafe build backend script entry points

### DIFF
--- a/crates/fyn-build-backend/src/metadata.rs
+++ b/crates/fyn-build-backend/src/metadata.rs
@@ -59,6 +59,10 @@ pub enum ValidationError {
         "Entrypoint groups must consist of letters and numbers separated by dots, invalid group: {0}"
     )]
     InvalidGroup(String),
+    #[error(
+        "Script entry point name `{0}` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes"
+    )]
+    InvalidScriptName(String),
     #[error("Use `project.scripts` instead of `project.entry-points.console_scripts`")]
     ReservedScripts,
     #[error("Use `project.gui-scripts` instead of `project.entry-points.gui_scripts`")]
@@ -729,10 +733,18 @@ impl PyProjectToml {
 
         let _ = writeln!(writer, "[{group}]");
         for (name, object_reference) in entries {
-            if !name
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
+            let compliant_name = name.chars().all(|character| {
+                character.is_alphanumeric() || matches!(character, '.' | '-' | '_')
+            });
+            let dot_only_name = name.chars().all(|character| character == '.');
+
+            if matches!(group, "console_scripts" | "gui_scripts")
+                && (name.is_empty() || dot_only_name || !compliant_name)
             {
+                return Err(ValidationError::InvalidScriptName(name.clone()));
+            }
+
+            if !compliant_name {
                 warn!(
                     "Entrypoint names should consist of letters, numbers, dots, underscores and \
                     dashes; non-compliant name: {name}"

--- a/crates/fyn/tests/it/build.rs
+++ b/crates/fyn/tests/it/build.rs
@@ -1812,6 +1812,138 @@ fn build_fast_path() -> Result<()> {
     Ok(())
 }
 
+/// Reject path-shaped script entry point names before writing wheel metadata.
+#[test]
+fn build_unsafe_script_entry_point_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "../script" = "project:main"
+
+        [build-system]
+        requires = ["fyn-build>=0.5.15,<10000"]
+        build-backend = "fyn_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    fyn_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (fyn build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `../script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
+/// Reject dot-only script entry point names that do not resolve below the scripts directory.
+#[test]
+fn build_dot_script_entry_point_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "." = "project:main"
+
+        [build-system]
+        requires = ["fyn-build>=0.5.15,<10000"]
+        build-backend = "fyn_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    fyn_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (fyn build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `.` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
+/// Reject script entry point names that PyPI rejects in uploaded wheels.
+#[test]
+fn build_nested_script_entry_point_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "nested/script" = "project:main"
+
+        [build-system]
+        requires = ["fyn-build>=0.5.15,<10000"]
+        build-backend = "fyn_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    fyn_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (fyn build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `nested/script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
 /// Test the `--list` option.
 #[test]
 fn build_list_files() -> Result<()> {


### PR DESCRIPTION
## Summary

  - Reject unsafe `project.scripts` / `project.gui-scripts` names in `fyn_build`
  - Prevent path-shaped, dot-only, or nested script entry point names from being written into wheel metadata
  - Add integration tests for `../script`, `.`, and `nested/script`

  ## Verification

  - `cargo check -p fyn-build-backend`
  - `cargo test -p fyn --test it script_entry_point_name`