### PR TITLE
feat: add audit direct-only mode

### DIFF
--- a/crates/fyn-build-backend/src/metadata.rs
+++ b/crates/fyn-build-backend/src/metadata.rs
@@ -59,6 +59,10 @@ pub enum ValidationError {
         "Entrypoint groups must consist of letters and numbers separated by dots, invalid group: {0}"
     )]
     InvalidGroup(String),
+    #[error(
+        "Script entry point name `{0}` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes"
+    )]
+    InvalidScriptName(String),
     #[error("Use `project.scripts` instead of `project.entry-points.console_scripts`")]
     ReservedScripts,
     #[error("Use `project.gui-scripts` instead of `project.entry-points.gui_scripts`")]
@@ -729,10 +733,18 @@ impl PyProjectToml {
 
         let _ = writeln!(writer, "[{group}]");
         for (name, object_reference) in entries {
-            if !name
-                .chars()
-                .all(|c| c.is_alphanumeric() || c == '.' || c == '-' || c == '_')
+            let compliant_name = name.chars().all(|character| {
+                character.is_alphanumeric() || matches!(character, '.' | '-' | '_')
+            });
+            let dot_only_name = name.chars().all(|character| character == '.');
+
+            if matches!(group, "console_scripts" | "gui_scripts")
+                && (name.is_empty() || dot_only_name || !compliant_name)
             {
+                return Err(ValidationError::InvalidScriptName(name.clone()));
+            }
+
+            if !compliant_name {
                 warn!(
                     "Entrypoint names should consist of letters, numbers, dots, underscores and \
                     dashes; non-compliant name: {name}"

--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -6588,6 +6588,13 @@ pub struct AuditArgs {
     #[arg(long)]
     pub explain: bool,
 
+    /// Only audit the project's direct dependencies.
+    ///
+    /// Transitive dependencies are excluded, so only vulnerabilities in packages that the project
+    /// (or the selected groups and extras) depends on directly are reported.
+    #[arg(long)]
+    pub direct_only: bool,
+
     /// A vulnerability ID to ignore during auditing.
     ///
     /// May be provided multiple times.

--- a/crates/fyn-resolver/src/lock/mod.rs
+++ b/crates/fyn-resolver/src/lock/mod.rs
@@ -818,6 +818,7 @@ impl Lock {
         &'lock self,
         extras: &'lock ExtrasSpecificationWithDefaults,
         groups: &'lock DependencyGroupsWithDefaults,
+        direct_only: bool,
     ) -> Vec<(&'lock PackageName, &'lock Version)> {
         fn enqueue_dep<'lock>(
             lock: &'lock Lock,
@@ -939,8 +940,13 @@ impl Lock {
                 None => &package.dependencies,
             };
 
-            for dep in dependencies {
-                enqueue_dep(self, &mut seen, &mut queue, dep);
+            // When `direct_only` is set, expand only workspace members so that their first-hop
+            // (direct) dependencies are recorded, but stop before walking into the transitive
+            // dependencies of non-member packages.
+            if is_member || !direct_only {
+                for dep in dependencies {
+                    enqueue_dep(self, &mut seen, &mut queue, dep);
+                }
             }
         }
 
@@ -7118,7 +7124,7 @@ sdist = { url = "https://example.com/typing-extensions-4.10.0.tar.gz", hash = "s
         let groups = DependencyGroups::default().with_defaults(DefaultGroups::List(vec![]));
 
         assert_eq!(
-            audited_package_names(lock.packages_for_audit(&extras, &groups)),
+            audited_package_names(lock.packages_for_audit(&extras, &groups, false)),
             vec!["iniconfig".to_string(), "typing-extensions".to_string()]
         );
     }
@@ -7141,7 +7147,7 @@ sdist = { url = "https://example.com/typing-extensions-4.10.0.tar.gz", hash = "s
         .with_defaults(DefaultGroups::List(vec![]));
 
         assert_eq!(
-            audited_package_names(lock.packages_for_audit(&extras, &groups)),
+            audited_package_names(lock.packages_for_audit(&extras, &groups, false)),
             vec!["sniffio".to_string()]
         );
     }
@@ -7154,8 +7160,58 @@ sdist = { url = "https://example.com/typing-extensions-4.10.0.tar.gz", hash = "s
         let groups = DependencyGroups::default().with_defaults(DefaultGroups::List(vec![]));
 
         assert_eq!(
-            audited_package_names(lock.packages_for_audit(&extras, &groups)),
+            audited_package_names(lock.packages_for_audit(&extras, &groups, false)),
             vec!["base".to_string(), "typing-extensions".to_string()]
+        );
+    }
+
+    #[test]
+    fn packages_for_audit_direct_only_excludes_transitive_dependencies() {
+        let lock: Lock = toml::from_str(
+            r#"
+version = 1
+requires-python = ">=3.8"
+
+[options]
+exclude-newer = "2024-03-01T00:00:00Z"
+
+[[package]]
+name = "project"
+version = "0.1.0"
+source = { editable = "" }
+dependencies = [
+    { name = "direct-dep" },
+]
+
+[[package]]
+name = "direct-dep"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "transitive-dep" },
+]
+
+[[package]]
+name = "transitive-dep"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+"#,
+        )
+        .unwrap();
+
+        let extras = ExtrasSpecification::default().with_defaults(DefaultExtras::default());
+        let groups = DependencyGroups::default().with_defaults(DefaultGroups::List(vec![]));
+
+        // A full audit walks transitive dependencies.
+        assert_eq!(
+            audited_package_names(lock.packages_for_audit(&extras, &groups, false)),
+            vec!["direct-dep".to_string(), "transitive-dep".to_string()]
+        );
+
+        // `--direct-only` records direct dependencies but stops before transitive ones.
+        assert_eq!(
+            audited_package_names(lock.packages_for_audit(&extras, &groups, true)),
+            vec!["direct-dep".to_string()]
         );
     }
 

--- a/crates/fyn/src/commands/project/audit.rs
+++ b/crates/fyn/src/commands/project/audit.rs
@@ -63,6 +63,7 @@ pub(crate) async fn audit(
     service: VulnerabilityServiceFormat,
     service_url: Option<String>,
     explain: bool,
+    direct_only: bool,
     ignore: Vec<VulnerabilityID>,
     ignore_until_fixed: Vec<VulnerabilityID>,
 ) -> Result<ExitStatus> {
@@ -219,7 +220,7 @@ pub(crate) async fn audit(
         )
     });
 
-    let auditable = lock.packages_for_audit(&extras, &groups);
+    let auditable = lock.packages_for_audit(&extras, &groups, direct_only);
 
     // Perform the audit.
     let reporter = AuditReporter::from(printer);

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -3326,6 +3326,7 @@ async fn run_project(
                 args.service_format,
                 args.service_url,
                 args.explain,
+                args.direct_only,
                 args.ignore,
                 args.ignore_until_fixed,
             ))

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -2889,6 +2889,7 @@ pub(crate) struct AuditSettings {
     pub(crate) service_format: VulnerabilityServiceFormat,
     pub(crate) service_url: Option<String>,
     pub(crate) explain: bool,
+    pub(crate) direct_only: bool,
     pub(crate) ignore: Vec<VulnerabilityID>,
     pub(crate) ignore_until_fixed: Vec<VulnerabilityID>,
 }
@@ -2917,6 +2918,7 @@ impl AuditSettings {
             python_version,
             python_platform,
             explain,
+            direct_only,
             locked,
             frozen,
             build,
@@ -2977,6 +2979,7 @@ impl AuditSettings {
             service_format,
             service_url,
             explain,
+            direct_only,
             ignore: {
                 let AuditOptions {
                     ignore: config_ignore,

--- a/crates/fyn/tests/it/audit.rs
+++ b/crates/fyn/tests/it/audit.rs
@@ -353,6 +353,60 @@ async fn audit_explain_direct_vulnerability() {
 }
 
 #[tokio::test]
+async fn audit_direct_only_direct_vulnerability() {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig==2.0.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+    mock_osv_vulnerability(
+        &server,
+        "iniconfig",
+        "PYSEC-2023-0001",
+        "A test vulnerability in iniconfig",
+        Some("2.1.0"),
+    )
+    .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--direct-only")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    Vulnerabilities:
+
+    iniconfig 2.0.0 has 1 known vulnerability:
+
+    - PYSEC-2023-0001: A test vulnerability in iniconfig
+
+      Fixed in: 2.1.0
+
+      Advisory information: https://osv.dev/vulnerability/PYSEC-2023-0001
+
+
+    ----- stderr -----
+    Found 1 known vulnerability and no adverse project statuses in 1 package
+    ");
+}
+
+#[tokio::test]
 async fn audit_explain_transitive_vulnerability() {
     let context = fyn_test::test_context!("3.12");
 
@@ -406,6 +460,49 @@ async fn audit_explain_transitive_vulnerability() {
 
     ----- stderr -----
     Found 1 known vulnerability and no adverse project statuses in 3 packages
+    ");
+}
+
+#[tokio::test]
+async fn audit_direct_only_excludes_transitive_vulnerability() {
+    let context = fyn_test::test_context!("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==4.3.0"]
+    "#})
+        .unwrap();
+
+    context.lock().assert().success();
+
+    let server = MockServer::start().await;
+    mock_osv_vulnerability(
+        &server,
+        "sniffio",
+        "PYSEC-2023-0002",
+        "A test vulnerability in sniffio",
+        None,
+    )
+    .await;
+
+    fyn_snapshot!(context.filters(), context
+        .audit()
+        .arg("--frozen")
+        .arg("--preview")
+        .arg("--direct-only")
+        .arg("--service-url")
+        .arg(server.uri()), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Found no known vulnerabilities and no adverse project statuses in 1 package
     ");
 }
 

--- a/crates/fyn/tests/it/build.rs
+++ b/crates/fyn/tests/it/build.rs
@@ -1812,6 +1812,138 @@ fn build_fast_path() -> Result<()> {
     Ok(())
 }
 
+/// Reject path-shaped script entry point names before writing wheel metadata.
+#[test]
+fn build_unsafe_script_entry_point_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "../script" = "project:main"
+
+        [build-system]
+        requires = ["fyn-build>=0.5.15,<10000"]
+        build-backend = "fyn_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    fyn_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (fyn build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `../script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
+/// Reject dot-only script entry point names that do not resolve below the scripts directory.
+#[test]
+fn build_dot_script_entry_point_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "." = "project:main"
+
+        [build-system]
+        requires = ["fyn-build>=0.5.15,<10000"]
+        build-backend = "fyn_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    fyn_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (fyn build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `.` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
+/// Reject script entry point names that PyPI rejects in uploaded wheels.
+#[test]
+fn build_nested_script_entry_point_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    context.init().assert().success();
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+
+        [project.scripts]
+        "nested/script" = "project:main"
+
+        [build-system]
+        requires = ["fyn-build>=0.5.15,<10000"]
+        build-backend = "fyn_build"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("project")
+        .child("__init__.py")
+        .touch()?;
+
+    fyn_snapshot!(context.filters(), context.build().arg("--wheel"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Building wheel (fyn build backend)...
+      × Failed to build `[TEMP_DIR]/`
+      ├─▶ Invalid project metadata
+      ╰─▶ Script entry point name `nested/script` must include a non-dot character and consist only of letters, numbers, dots, underscores and dashes
+    ");
+
+    Ok(())
+}
+
 /// Test the `--list` option.
 #[test]
 fn build_list_files() -> Result<()> {


### PR DESCRIPTION
## Summary

  - Add `fyn audit --direct-only` to audit only direct project dependencies.
  - Stop audit traversal before transitive dependencies when direct-only mode is enabled.

## Tests

  - `cargo test -p fyn --test it audit_direct_only`
  - `cargo test -p fyn-resolver packages_for_audit`