### PR TITLE
fix: harden wheel install and uninstall validation

### DIFF
--- a/crates/fyn-install-wheel/src/uninstall.rs
+++ b/crates/fyn-install-wheel/src/uninstall.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use std::path::{Component, Path, PathBuf};
 
 use fyn_fs::write_atomic_sync;
+use fyn_pypi_types::Identifier;
 use fyn_warnings::warn_user;
 use std::sync::{LazyLock, Mutex, OnceLock};
 use tracing::trace;
@@ -200,7 +201,7 @@ fn is_path_in_scheme(
 /// egg's base location, not arbitrary paths. Treating them as paths can make uninstall delete
 /// directories outside `site-packages`.
 fn is_valid_top_level_entry(entry: &str, distribution: impl Display) -> bool {
-    if is_safe_top_level_entry(entry) {
+    if entry.parse::<Identifier>().is_ok() {
         true
     } else {
         if WARNED_FOR_EGG_TOP_LEVEL_PACKAGE
@@ -217,10 +218,6 @@ fn is_valid_top_level_entry(entry: &str, distribution: impl Display) -> bool {
         }
         false
     }
-}
-
-fn is_safe_top_level_entry(entry: &str) -> bool {
-    !entry.is_empty() && entry != "." && entry != ".." && !entry.contains(['/', '\\'])
 }
 
 /// Uninstall the egg represented by the `.egg-info` directory.
@@ -444,18 +441,27 @@ mod tests {
     use fyn_pypi_types::Scheme;
 
     use crate::Layout;
-    use crate::uninstall::{is_safe_top_level_entry, uninstall_egg, uninstall_wheel};
+    use crate::uninstall::{is_valid_top_level_entry, uninstall_egg, uninstall_wheel};
 
     #[test]
     fn test_top_level_entry_safe_name() {
-        assert!(is_safe_top_level_entry("package"));
+        let is_valid = |entry| is_valid_top_level_entry(entry, "package");
 
-        assert!(!is_safe_top_level_entry(""));
-        assert!(!is_safe_top_level_entry("."));
-        assert!(!is_safe_top_level_entry(".."));
-        assert!(!is_safe_top_level_entry("../package"));
-        assert!(!is_safe_top_level_entry("package/name"));
-        assert!(!is_safe_top_level_entry(r"package\name"));
+        assert!(is_valid("package"));
+        assert!(is_valid("_package2"));
+
+        assert!(!is_valid(""));
+        assert!(!is_valid("."));
+        assert!(!is_valid(".."));
+        assert!(!is_valid("1package"));
+        assert!(!is_valid("package-name"));
+        assert!(!is_valid("package.name"));
+        assert!(!is_valid("../package"));
+        assert!(!is_valid("package/name"));
+        assert!(!is_valid(r"package\name"));
+        assert!(!is_valid("C:target"));
+        assert!(!is_valid("C:."));
+        assert!(!is_valid("C:.."));
     }
 
     #[test]

--- a/crates/fyn-install-wheel/src/wheel.rs
+++ b/crates/fyn-install-wheel/src/wheel.rs
@@ -163,7 +163,11 @@ fn get_script_executable(python_executable: &Path, is_gui: bool) -> PathBuf {
     }
 }
 
-const RESERVED_SCRIPT_NAMES_ERROR: &[&str; 3] = &["python", "pythonw", "python3"];
+const RESERVED_SCRIPT_NAMES_ERROR: &[&str; 7] = &[
+    "python", "pythonw", "python3", "graalpy", "pypy", "pypy2", "pypy3",
+];
+const RESERVED_VERSIONED_SCRIPT_NAME_PREFIX_ERROR: &str = "python3.";
+const RESERVED_FREE_THREADED_SCRIPT_NAME_PREFIXES_ERROR: &[&str; 2] = &["python3.", "pythonw3."];
 const RESERVED_SCRIPT_NAMES_WARN: &[&str; 2] = &["activate", "activate_this.py"];
 
 /// A form of [`Script`] guaranteed by [`ValidatedScript::try_from_script`] to be constrained to
@@ -196,25 +200,32 @@ impl<'script> ValidatedScript<'script> {
             );
         }
 
-        if RESERVED_SCRIPT_NAMES_ERROR.contains(&name.as_str())
-            || name
-                .strip_prefix("python3.")
-                .is_some_and(|suffix| suffix.parse::<u8>().is_ok())
+        // Reserve launcher basenames emitted by `uv venv` across supported platforms.
+        // Apply the Windows launcher normalization before checking so wheel validity is portable.
+        // FIXME: What are the in-reality rules here for name normalization?
+        let normalized_name = name.strip_suffix(".py").unwrap_or(name.as_str());
+        if RESERVED_SCRIPT_NAMES_ERROR.contains(&normalized_name)
+            || normalized_name
+                .strip_prefix(RESERVED_VERSIONED_SCRIPT_NAME_PREFIX_ERROR)
+                .is_some_and(|minor| minor.parse::<u8>().is_ok())
+            || RESERVED_FREE_THREADED_SCRIPT_NAME_PREFIXES_ERROR
+                .iter()
+                .any(|prefix| {
+                    normalized_name
+                        .strip_prefix(prefix)
+                        .and_then(|minor| minor.strip_suffix('t'))
+                        .is_some_and(|minor| minor.parse::<u8>().is_ok())
+                })
         {
             return Err(Error::ReservedScriptName {
-                reserved: name,
+                reserved: normalized_name.to_string(),
                 declared: script.name.clone(),
             });
         }
 
         let path = if cfg!(windows) {
             // On Windows we actually build an `.exe` wrapper.
-            let name = name
-                // FIXME: What are the in-reality rules here for names?
-                .strip_suffix(".py")
-                .unwrap_or(&name)
-                .to_string()
-                + std::env::consts::EXE_SUFFIX;
+            let name = normalized_name.to_string() + std::env::consts::EXE_SUFFIX;
 
             layout.scheme.scripts.join(name)
         } else {
@@ -1037,8 +1048,12 @@ pub(crate) fn parse_scripts(
         .join(format!("{dist_info_prefix}.dist-info/entry_points.txt"));
 
     // Read the entry points mapping. If the file doesn't exist, we just return an empty mapping.
-    let Ok(ini) = fs::read_to_string(entry_points_path) else {
-        return Ok((Vec::new(), Vec::new()));
+    let ini = match fs::read_to_string(entry_points_path) {
+        Ok(ini) => ini,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Ok((Vec::new(), Vec::new()));
+        }
+        Err(err) => return Err(err.into()),
     };
 
     scripts_from_ini(extras, python_minor, ini)
@@ -1077,7 +1092,7 @@ impl RenameOrCopy {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
+    use std::io::{Cursor, ErrorKind};
     use std::path::Path;
 
     use anyhow::Result;
@@ -1086,7 +1101,7 @@ mod test {
 
     use super::{
         Error, RecordEntry, Script, WheelFile, format_shebang, get_script_executable,
-        parse_email_message_file, read_record_file, write_installer_metadata,
+        parse_email_message_file, parse_scripts, read_record_file, write_installer_metadata,
     };
 
     #[test]
@@ -1162,6 +1177,25 @@ mod test {
         }
         WheelFile::parse(&wheel_with_version("1.0")).unwrap();
         WheelFile::parse(&wheel_with_version("2.0")).unwrap_err();
+    }
+
+    #[test]
+    fn invalid_utf8_entry_points() -> Result<()> {
+        let wheel = assert_fs::TempDir::new()?;
+        wheel
+            .child("example-1.0.0.dist-info/entry_points.txt")
+            .write_binary(&[0xff])?;
+
+        let error = parse_scripts(&wheel, "example-1.0.0", None, 13)
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("invalid UTF-8 should fail to parse"))?;
+
+        assert!(matches!(
+            error,
+            Error::Io(err) if err.kind() == ErrorKind::InvalidData
+        ));
+
+        Ok(())
     }
 
     #[test]

--- a/crates/fyn-installer/src/plan.rs
+++ b/crates/fyn-installer/src/plan.rs
@@ -216,20 +216,18 @@ impl<'a> Planner<'a> {
                 }
                 Dist::Built(BuiltDist::DirectUrl(wheel)) => {
                     if !wheel.filename.is_compatible(tags) {
+                        let url = wheel.url.to_url();
                         let hint = generate_wheel_compatibility_hint(&wheel.filename, tags);
                         if let Some(hint) = hint {
                             bail!(
                                 "A URL dependency is incompatible with the current platform: {}\n\n{}{} {}",
-                                wheel.url,
+                                url,
                                 "hint".bold().cyan(),
                                 ":".bold(),
                                 hint
                             );
                         }
-                        bail!(
-                            "A URL dependency is incompatible with the current platform: {}",
-                            wheel.url
-                        );
+                        bail!("A URL dependency is incompatible with the current platform: {url}");
                     }
 
                     if no_binary {

--- a/crates/fyn/tests/it/pip_install.rs
+++ b/crates/fyn/tests/it/pip_install.rs
@@ -13476,6 +13476,135 @@ fn reject_normalized_reserved_gui_wheel_entrypoint_name() -> Result<()> {
 }
 
 #[test]
+fn reject_free_threaded_python_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "console_scripts", "python3.13t")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `python3.13t`, got: `python3.13t`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_windowed_free_threaded_python_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "console_scripts", "pythonw3.13t")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `pythonw3.13t`, got: `pythonw3.13t`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_windows_rewritten_python_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "python.py")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `python`, got: `python.py`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_windows_rewritten_free_threaded_python_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel =
+        repacked_wheel_with_entrypoint(&context, "console_scripts", "pythonw3.13t.py")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `pythonw3.13t`, got: `pythonw3.13t.py`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_pypy_major_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "pypy3")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `pypy3`, got: `pypy3`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_windows_rewritten_pypy_wheel_entrypoint_name() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let repacked_wheel = repacked_wheel_with_entrypoint(&context, "console_scripts", "pypy.py")?;
+
+    fyn_snapshot!(context.filters(), context.pip_install().arg(&repacked_wheel), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    error: Failed to install: foo-0.1.0-py3-none-any.whl (foo==0.1.0 (from file://[TEMP_DIR]/foo-0.1.0-py3-none-any.whl))
+      Caused by: Scripts must not use the reserved name `pypy`, got: `pypy.py`
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn warn_normalized_activation_wheel_entrypoint_name() -> Result<()> {
     let context = fyn_test::test_context!("3.12");
     let repacked_wheel =

--- a/crates/fyn/tests/it/pip_sync.rs
+++ b/crates/fyn/tests/it/pip_sync.rs
@@ -6390,6 +6390,33 @@ fn incompatible_python_version_direct_url() -> Result<()> {
 }
 
 #[test]
+fn incompatible_direct_url_redacts_credentials() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("numpy @ https://user:secret@files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl?X-Amz-Signature=signing-secret")?;
+
+    fyn_snapshot!(context.filters(), context.pip_sync()
+        .arg("requirements.txt")
+        .arg("--python-platform")
+        .arg("windows"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    error: Failed to determine installation plan
+      Caused by: A URL dependency is incompatible with the current platform: https://user:****@files.pythonhosted.org/packages/ae/11/7c546fcf42145f29b71e4d6f429e96d8d68e5a7ba1830b2e68d7418f0bbd/numpy-2.3.2-cp313-cp313-win32.whl?X-Amz-Signature=****
+
+    hint: The wheel is compatible with CPython 3.13 (`cp313`), but you're using CPython 3.12 (`cp312`)
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn incompatible_platform_direct_url() -> Result<()> {
     let context = fyn_test::test_context!("3.13");
 

--- a/crates/fyn/tests/it/pip_uninstall.rs
+++ b/crates/fyn/tests/it/pip_uninstall.rs
@@ -1,3 +1,6 @@
+#[cfg(windows)]
+use std::path::{Component, Prefix};
+
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::fixture::ChildPath;
@@ -654,4 +657,96 @@ fn dry_run_uninstall_egg_info() -> Result<()> {
     assert!(site_packages.child("zstd").child("__init__.py").exists());
 
     Ok(())
+}
+/// Windows drive-relative paths are not valid `top_level.txt` entries.
+#[cfg(windows)]
+#[test]
+fn uninstall_egg_info_top_level_drive_relative() -> Result<()> {
+    let context = fyn_test::test_context!("3.12")
+        .with_filter((r"[A-Za-z]:traversal_target", "[DRIVE]:traversal_target"));
+    let site_packages = ChildPath::new(context.site_packages());
+
+    let egg_info = site_packages.child("evilpkg-0.1.0.egg-info");
+    egg_info.create_dir_all()?;
+
+    let drive = match context.temp_dir.path().components().next() {
+        Some(Component::Prefix(prefix)) => match prefix.kind() {
+            Prefix::Disk(drive) | Prefix::VerbatimDisk(drive) => drive,
+            prefix => anyhow::bail!("expected a disk path, found {prefix:?}"),
+        },
+        component => anyhow::bail!("expected a Windows path prefix, found {component:?}"),
+    };
+    let traversal_entry = format!("{}:traversal_target", char::from(drive));
+
+    // Commands run from `context.temp_dir`, so this drive-relative path resolves there rather than
+    // below `site-packages`.
+    let target_file = context
+        .temp_dir
+        .child("traversal_target")
+        .child("secret.txt");
+    target_file.write_str("I should not be deleted")?;
+    egg_info
+        .child("top_level.txt")
+        .write_str(&format!("evilpkg\n{traversal_entry}\n"))?;
+
+    let init_py = site_packages.child("evilpkg").child("__init__.py");
+    init_py.touch()?;
+
+    fyn_snapshot!(context.filters(), context.pip_uninstall()
+        .arg("evilpkg"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Invalid `top_level.txt` entry in evilpkg==0.1.0 that is not a top-level module or package, skipping: [DRIVE]:traversal_target
+    Uninstalled 1 package in [TIME]
+     - evilpkg==0.1.0
+    ");
+
+    assert!(target_file.exists());
+    assert!(!init_py.exists());
+    assert!(!egg_info.exists());
+
+    Ok(())
+}
+
+/// `--yes` is accepted for `pip uninstall` compatibility, but emits a warning.
+#[test]
+fn yes_flag() {
+    let context = fyn_test::test_context!("3.12");
+
+    fyn_snapshot!(context.filters(), context.pip_uninstall()
+        .arg("--yes")
+        .arg("flask"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `--yes` has no effect (fyn never asks for confirmation)
+    warning: Skipping flask as it is not installed
+    warning: No packages to uninstall
+    "
+    );
+}
+
+/// `-y` is accepted for `pip uninstall` compatibility, but emits a warning.
+#[test]
+fn yes_short_flag() {
+    let context = fyn_test::test_context!("3.12");
+
+    fyn_snapshot!(context.filters(), context.pip_uninstall()
+        .arg("-y")
+        .arg("flask"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `--yes` has no effect (fyn never asks for confirmation)
+    warning: Skipping flask as it is not installed
+    warning: No packages to uninstall
+    "
+    );
 }


### PR DESCRIPTION
## Summary

  Backport upstream `uv` wheel install/uninstall hardening.

  Covers:

  - Rejecting Python interpreter names as wheel script and GUI entry points
  - Propagating errors when reading wheel entry points instead of silently ignoring them
  - Redacting direct URL wheel compatibility errors
  - Validating egg `top_level.txt` entries as safe Python identifiers before uninstall cleanup

  ## Upstream

  Adapted from upstream `uv` commits:

  - `149ef4d25` ban CPython venv entry points in wheel installs
  - `57341ee5b` ban GraalPy and PyPy script/gui entry point names
  - `143c12f38` propagate errors when reading wheel entry points
  - `f6c8df3e4` redact direct URL wheel compatibility errors
  - `ff9bf5448` validate egg top-level entries as identifiers

  ## Tests

```
  cargo fmt --check
  cargo check -p fyn-install-wheel
  cargo test -p fyn-install-wheel test_top_level_entry_safe_name
```