### PR TITLE
fix: avoid following cache cleanup symlinks

### DIFF
--- a/crates/fyn-cache/src/lib.rs
+++ b/crates/fyn-cache/src/lib.rs
@@ -567,9 +567,17 @@ impl Cache {
             summary += bucket.remove(self, name)?;
         }
 
+        if references.is_empty() {
+            return Ok(summary);
+        }
+
+        // Only remove targets in the archive bucket. Cache entries may contain unexpected links
+        // to paths outside the cache.
+        let archive_root = fs_err::canonicalize(&self.root)?.join(CacheBucket::Archive.to_str());
+
         // Remove any archives that are no longer referenced.
         for (target, references) in references {
-            if references.iter().all(|path| !path.exists()) {
+            if target.starts_with(&archive_root) && references.iter().all(|path| !path.exists()) {
                 debug!("Removing dangling cache entry: {}", target.display());
                 summary += rm_rf(target)?;
             }
@@ -709,7 +717,7 @@ impl Cache {
             Ok(entries) => {
                 for entry in entries {
                     let entry = entry?;
-                    let path = fs_err::canonicalize(entry.path())?;
+                    let path = entry.path();
                     debug!("Removing dangling cache environment: {}", path.display());
                     summary += rm_rf(path)?;
                 }
@@ -725,7 +733,7 @@ impl Cache {
                 Ok(entries) => {
                     for entry in entries {
                         let entry = entry?;
-                        let path = fs_err::canonicalize(entry.path())?;
+                        let path = entry.path();
                         if path.is_dir() {
                             debug!("Removing unzipped wheel entry: {}", path.display());
                             summary += rm_rf(path)?;
@@ -782,8 +790,9 @@ impl Cache {
             Ok(entries) => {
                 for entry in entries {
                     let entry = entry?;
-                    let path = fs_err::canonicalize(entry.path())?;
-                    if !references.contains_key(&path) {
+                    let path = entry.path();
+                    let target = fs_err::canonicalize(&path)?;
+                    if !references.contains_key(&target) {
                         debug!("Removing dangling cache archive: {}", path.display());
                         summary += rm_rf(path)?;
                     }
@@ -1548,5 +1557,83 @@ mod tests {
         assert!(Link::from_str("archive/foo").is_err());
         assert!(Link::from_str("v1/foo").is_err());
         assert!(Link::from_str("archive-v0/").is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prune_does_not_follow_environment_symlinks() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let victim_root = tempfile::tempdir().unwrap();
+        let environments = cache_root.path().join(CacheBucket::Environments.to_str());
+        let victim_dir = victim_root.path().join("victim-dir");
+
+        fs_err::create_dir_all(&environments).unwrap();
+        fs_err::create_dir_all(&victim_dir).unwrap();
+        fs_err::write(victim_dir.join("payload.txt"), "payload").unwrap();
+        fs_err::os::unix::fs::symlink(&victim_dir, environments.join("escape")).unwrap();
+
+        let summary = Cache::from_path(cache_root.path()).prune(false).unwrap();
+
+        assert_eq!(summary.num_files, 1);
+        assert_eq!(summary.num_dirs, 0);
+        assert!(victim_dir.is_dir());
+        assert!(victim_dir.join("payload.txt").is_file());
+        assert!(fs_err::symlink_metadata(environments.join("escape")).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prune_ci_does_not_follow_wheel_symlinks() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let victim_root = tempfile::tempdir().unwrap();
+        let wheels = cache_root.path().join(CacheBucket::Wheels.to_str());
+        let source_distributions = cache_root
+            .path()
+            .join(CacheBucket::SourceDistributions.to_str());
+        let victim_dir = victim_root.path().join("victim-dir");
+        let symlink = wheels.join("escape");
+
+        fs_err::create_dir_all(&wheels).unwrap();
+        fs_err::create_dir_all(&source_distributions).unwrap();
+        fs_err::create_dir_all(&victim_dir).unwrap();
+        fs_err::write(victim_dir.join("payload.txt"), "payload").unwrap();
+        fs_err::os::unix::fs::symlink(&victim_dir, &symlink).unwrap();
+
+        let summary = Cache::from_path(cache_root.path()).prune(true).unwrap();
+
+        assert_eq!(summary.num_files, 1);
+        assert_eq!(summary.num_dirs, 0);
+        assert!(victim_dir.is_dir());
+        assert!(victim_dir.join("payload.txt").is_file());
+        assert!(fs_err::symlink_metadata(symlink).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn prune_does_not_follow_archive_symlinks() {
+        use super::{Cache, CacheBucket};
+
+        let cache_root = tempfile::tempdir().unwrap();
+        let victim_root = tempfile::tempdir().unwrap();
+        let archives = cache_root.path().join(CacheBucket::Archive.to_str());
+        let victim_dir = victim_root.path().join("victim-dir");
+        let symlink = archives.join("escape");
+
+        fs_err::create_dir_all(&archives).unwrap();
+        fs_err::create_dir_all(&victim_dir).unwrap();
+        fs_err::write(victim_dir.join("payload.txt"), "payload").unwrap();
+        fs_err::os::unix::fs::symlink(&victim_dir, &symlink).unwrap();
+
+        let summary = Cache::from_path(cache_root.path()).prune(false).unwrap();
+
+        assert_eq!(summary.num_files, 1);
+        assert_eq!(summary.num_dirs, 0);
+        assert!(victim_dir.is_dir());
+        assert!(victim_dir.join("payload.txt").is_file());
+        assert!(fs_err::symlink_metadata(symlink).is_err());
     }
 }

--- a/crates/fyn/tests/it/cache_clean.rs
+++ b/crates/fyn/tests/it/cache_clean.rs
@@ -263,6 +263,45 @@ fn clean_package_index() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn clean_package_does_not_follow_symlinks() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let victim_dir = context.temp_dir.child("victim");
+    let archive_entry = context.cache_dir.child("archive-v0").child("archive");
+    let package_entry = context
+        .cache_dir
+        .child("wheels-v6")
+        .child("pypi")
+        .child("demo");
+
+    victim_dir.create_dir_all()?;
+    victim_dir.child("payload.txt").write_str("payload")?;
+    archive_entry.create_dir_all()?;
+    archive_entry.child("payload.txt").write_str("payload")?;
+    package_entry.create_dir_all()?;
+
+    // Preserve external targets while still removing unreferenced entries in the archive bucket.
+    fs_err::os::unix::fs::symlink(&victim_dir, package_entry.join("escape"))?;
+    fs_err::os::unix::fs::symlink(&archive_entry, package_entry.join("archive"))?;
+
+    fyn_snapshot!(context.filters(), context.clean().arg("demo"), @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Removed 3 files ([SIZE])
+    ");
+
+    assert!(victim_dir.is_dir());
+    assert!(victim_dir.child("payload.txt").is_file());
+    assert!(fs_err::symlink_metadata(package_entry).is_err());
+    assert!(fs_err::symlink_metadata(archive_entry).is_err());
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn cache_timeout() {
     let context = fyn_test::test_context!("3.12");


### PR DESCRIPTION
## Summary

  Backports critical upstream `uv` cache cleanup safety fixes.

  This prevents cache cleanup paths from following symlinks while pruning or cleaning cache
  entries, including symlinks that point outside the cache root.

  ## Upstream

  Adapted from upstream `uv` commits:

  - `bc1093a96` avoid following symlinks during cache prune
  - `436bf40fb` avoid following external symlinks during cache clean

  ## Tests

  ```
  cargo fmt --check
  cargo check -p fyn-cache```