### PR TITLE
fix: make resolver error handling iterative

### DIFF
--- a/crates/fyn-resolver/src/error.rs
+++ b/crates/fyn-resolver/src/error.rs
@@ -1,14 +1,13 @@
 use std::collections::{BTreeMap, BTreeSet, Bound};
-use std::fmt::Formatter;
-use std::sync::Arc;
+use std::fmt::{Debug, Formatter};
+use std::ops::Deref;
+use std::sync::{Arc, OnceLock};
 
 use indexmap::IndexSet;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use pubgrub::{
-    DefaultStringReporter, DerivationTree, Derived, External, Range, Ranges, Reporter, Term,
-};
-use rustc_hash::FxHashMap;
+use pubgrub::{DerivationTree, Derived, External, Map, Range, Ranges, Term};
+use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::trace;
 
 use fyn_distribution_types::{
@@ -27,7 +26,10 @@ use crate::dependency_provider::UvDependencyProvider;
 use crate::fork_indexes::ForkIndexes;
 use crate::fork_urls::ForkUrls;
 use crate::prerelease::AllowPrerelease;
-use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter};
+use crate::pubgrub::{
+    PubGrubHint, PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter,
+    report_derivation_tree,
+};
 use crate::python_requirement::PythonRequirement;
 use crate::resolution::ConflictingDistributionError;
 use crate::resolver::{
@@ -157,10 +159,237 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {
 }
 
 pub type ErrorTree = DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>;
+type ErrorExternal = External<PubGrubPackage, Range<Version>, UnavailableReason>;
+type ErrorDerived = Derived<PubGrubPackage, Range<Version>, UnavailableReason>;
+type ErrorTerms = Map<PubGrubPackage, Term<Range<Version>>>;
+
+/// Visit each distinct package in a derivation tree without recursive calls.
+///
+/// The iteration order is unspecified, matching the set semantics of
+/// [`DerivationTree::packages`].
+pub(crate) fn derivation_tree_packages(
+    derivation_tree: &ErrorTree,
+) -> impl Iterator<Item = &PubGrubPackage> {
+    let mut packages = FxHashSet::default();
+    let mut trees = vec![derivation_tree];
+
+    while let Some(tree) = trees.pop() {
+        match tree {
+            DerivationTree::External(external) => match external {
+                External::FromDependencyOf(package, _, dependency, _) => {
+                    packages.insert(package);
+                    packages.insert(dependency);
+                }
+                External::NoVersions(package, _)
+                | External::NotRoot(package, _)
+                | External::Custom(package, _, _) => {
+                    packages.insert(package);
+                }
+            },
+            DerivationTree::Derived(derived) => {
+                packages.extend(derived.terms.keys());
+                trees.push(&derived.cause1);
+                trees.push(&derived.cause2);
+            }
+        }
+    }
+
+    packages.into_iter()
+}
+
+/// Drop an exclusively owned derivation tree without recursing through its children.
+///
+/// Shared [`Arc`] children are left for their remaining owners; once the last owner is processed,
+/// [`Arc::try_unwrap`] exposes the child for iterative destruction.
+pub(crate) fn drop_derivation_tree(derivation_tree: ErrorTree) {
+    let mut trees = vec![derivation_tree];
+
+    while let Some(tree) = trees.pop() {
+        if let DerivationTree::Derived(derived) = tree {
+            if let Ok(cause1) = Arc::try_unwrap(derived.cause1) {
+                trees.push(cause1);
+            }
+            if let Ok(cause2) = Arc::try_unwrap(derived.cause2) {
+                trees.push(cause2);
+            }
+        }
+    }
+}
+
+/// Own a derivation tree whose destruction must not recurse through the process stack.
+///
+/// The `Option` allows [`Drop`] to take ownership of the tree and applies the same iterative
+/// teardown during normal returns and unwinding.
+#[derive(Clone)]
+struct StackSafeErrorTree(Option<ErrorTree>);
+
+impl StackSafeErrorTree {
+    fn new(derivation_tree: ErrorTree) -> Self {
+        Self(Some(derivation_tree))
+    }
+
+    fn into_inner(mut self) -> ErrorTree {
+        self.0.take().expect("derivation tree is only taken once")
+    }
+}
+
+impl Deref for StackSafeErrorTree {
+    type Target = ErrorTree;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+            .as_ref()
+            .expect("derivation tree is only taken during drop")
+    }
+}
+
+impl Drop for StackSafeErrorTree {
+    fn drop(&mut self) {
+        if let Some(derivation_tree) = self.0.take() {
+            drop_derivation_tree(derivation_tree);
+        }
+    }
+}
+
+impl Debug for StackSafeErrorTree {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        debug_derivation_tree(self, f)
+    }
+}
+
+/// Preserve PubGrub's [`Debug`] representation without recursive formatting.
+fn debug_derivation_tree(
+    derivation_tree: &ErrorTree,
+    formatter: &mut Formatter<'_>,
+) -> std::fmt::Result {
+    enum Frame<'a> {
+        Tree(&'a ErrorTree),
+        Text(&'static str),
+    }
+
+    let mut frames = vec![Frame::Tree(derivation_tree)];
+
+    while let Some(frame) = frames.pop() {
+        match frame {
+            Frame::Tree(DerivationTree::External(external)) => {
+                write!(formatter, "External({external:?})")?;
+            }
+            Frame::Tree(DerivationTree::Derived(derived)) => {
+                write!(
+                    formatter,
+                    "Derived(Derived {{ terms: {:?}, shared_id: {:?}, cause1: ",
+                    derived.terms, derived.shared_id
+                )?;
+                frames.push(Frame::Text(" })"));
+                frames.push(Frame::Tree(&derived.cause2));
+                frames.push(Frame::Text(", cause2: "));
+                frames.push(Frame::Tree(&derived.cause1));
+            }
+            Frame::Text(text) => formatter.write_str(text)?,
+        }
+    }
+
+    Ok(())
+}
+
+struct DerivedMetadata {
+    terms: ErrorTerms,
+    shared_id: Option<usize>,
+}
+
+enum TreeTask {
+    Visit(StackSafeErrorTree),
+    Rebuild(DerivedMetadata),
+}
+
+fn schedule_derived(tasks: &mut Vec<TreeTask>, derived: ErrorDerived) {
+    let Derived {
+        terms,
+        shared_id,
+        cause1,
+        cause2,
+    } = derived;
+    tasks.push(TreeTask::Rebuild(DerivedMetadata { terms, shared_id }));
+    tasks.push(TreeTask::Visit(StackSafeErrorTree::new(
+        Arc::unwrap_or_clone(cause2),
+    )));
+    tasks.push(TreeTask::Visit(StackSafeErrorTree::new(
+        Arc::unwrap_or_clone(cause1),
+    )));
+}
+
+fn transform_derivation_tree(
+    derivation_tree: ErrorTree,
+    mut transform_external: impl FnMut(ErrorExternal) -> Option<ErrorTree>,
+    mut transform_derived: impl FnMut(
+        DerivedMetadata,
+        Option<ErrorTree>,
+        Option<ErrorTree>,
+    ) -> Option<ErrorTree>,
+) -> Option<ErrorTree> {
+    let mut tasks = vec![TreeTask::Visit(StackSafeErrorTree::new(derivation_tree))];
+    let mut results: Vec<Option<StackSafeErrorTree>> = Vec::new();
+
+    while let Some(task) = tasks.pop() {
+        match task {
+            TreeTask::Visit(tree) => match tree.into_inner() {
+                DerivationTree::External(external) => {
+                    results.push(transform_external(external).map(StackSafeErrorTree::new));
+                }
+                DerivationTree::Derived(derived) => schedule_derived(&mut tasks, derived),
+            },
+            TreeTask::Rebuild(metadata) => {
+                let cause2 = results
+                    .pop()
+                    .expect("every derived tree has a second transformed cause")
+                    .map(StackSafeErrorTree::into_inner);
+                let cause1 = results
+                    .pop()
+                    .expect("every derived tree has a first transformed cause")
+                    .map(StackSafeErrorTree::into_inner);
+                results
+                    .push(transform_derived(metadata, cause1, cause2).map(StackSafeErrorTree::new));
+            }
+        }
+    }
+
+    results
+        .pop()
+        .expect("the root derivation tree produces one transformed result")
+        .map(StackSafeErrorTree::into_inner)
+}
+
+fn map_derivation_tree(
+    derivation_tree: ErrorTree,
+    mut transform_external: impl FnMut(ErrorExternal) -> ErrorTree,
+    mut transform_derived: impl FnMut(DerivedMetadata, ErrorTree, ErrorTree) -> ErrorTree,
+) -> ErrorTree {
+    transform_derivation_tree(
+        derivation_tree,
+        |external| Some(transform_external(external)),
+        |metadata, cause1, cause2| {
+            Some(transform_derived(
+                metadata,
+                cause1.expect("map transformations retain the first cause"),
+                cause2.expect("map transformations retain the second cause"),
+            ))
+        },
+    )
+    .expect("map transformations retain the root")
+}
+
+fn derived_tree(metadata: DerivedMetadata, cause1: ErrorTree, cause2: ErrorTree) -> ErrorTree {
+    DerivationTree::Derived(Derived {
+        terms: metadata.terms,
+        shared_id: metadata.shared_id,
+        cause1: Arc::new(cause1),
+        cause2: Arc::new(cause2),
+    })
+}
 
 /// A wrapper around [`pubgrub::error::NoSolutionError`] that displays a resolution failure report.
 pub struct NoSolutionError {
-    error: pubgrub::NoSolutionError<UvDependencyProvider>,
+    error: StackSafeErrorTree,
     index: InMemoryIndex,
     /// The versions that were available for each package after `exclude-newer` filtering.
     ///
@@ -188,6 +417,8 @@ pub struct NoSolutionError {
     tags: Option<Tags>,
     workspace_members: BTreeSet<PackageName>,
     options: Options,
+    /// Cached report and hints, computed once on first access.
+    cached: OnceLock<(String, IndexSet<PubGrubHint>)>,
 }
 
 impl NoSolutionError {
@@ -213,7 +444,7 @@ impl NoSolutionError {
         options: Options,
     ) -> Self {
         Self {
-            error,
+            error: StackSafeErrorTree::new(error),
             index,
             included_versions,
             available_versions,
@@ -231,51 +462,39 @@ impl NoSolutionError {
             tags,
             workspace_members,
             options,
+            cached: OnceLock::new(),
         }
+    }
+
+    /// Get the cached report and hints, computing them on first access.
+    fn cached(&self) -> &(String, IndexSet<PubGrubHint>) {
+        self.cached.get_or_init(|| self.compute_report_and_hints())
     }
 
     /// Given a [`DerivationTree`], collapse any [`External::FromDependencyOf`] incompatibilities
     /// wrap an [`PubGrubPackageInner::Extra`] package.
     pub(crate) fn collapse_proxies(derivation_tree: ErrorTree) -> ErrorTree {
-        fn collapse(derivation_tree: ErrorTree) -> Option<ErrorTree> {
-            match derivation_tree {
-                DerivationTree::Derived(derived) => {
-                    match (&*derived.cause1, &*derived.cause2) {
-                        (
-                            DerivationTree::External(External::FromDependencyOf(package1, ..)),
-                            DerivationTree::External(External::FromDependencyOf(package2, ..)),
-                        ) if package1.is_proxy() && package2.is_proxy() => None,
-                        (
-                            DerivationTree::External(External::FromDependencyOf(package, ..)),
-                            cause,
-                        ) if package.is_proxy() => collapse(cause.clone()),
-                        (
-                            cause,
-                            DerivationTree::External(External::FromDependencyOf(package, ..)),
-                        ) if package.is_proxy() => collapse(cause.clone()),
-                        (cause1, cause2) => {
-                            let cause1 = collapse(cause1.clone());
-                            let cause2 = collapse(cause2.clone());
-                            match (cause1, cause2) {
-                                (Some(cause1), Some(cause2)) => {
-                                    Some(DerivationTree::Derived(Derived {
-                                        cause1: Arc::new(cause1),
-                                        cause2: Arc::new(cause2),
-                                        ..derived
-                                    }))
-                                }
-                                (Some(cause), None) | (None, Some(cause)) => Some(cause),
-                                _ => None,
-                            }
-                        }
-                    }
-                }
-                DerivationTree::External(_) => Some(derivation_tree),
-            }
+        fn is_proxy(tree: &ErrorTree) -> bool {
+            matches!(
+                tree,
+                DerivationTree::External(External::FromDependencyOf(package, ..))
+                    if package.is_proxy()
+            )
         }
 
-        collapse(derivation_tree)
-            .expect("derivation tree should contain at least one external term")
+        transform_derivation_tree(
+            derivation_tree,
+            |external| Some(DerivationTree::External(external)),
+            |metadata, cause1, cause2| match (cause1, cause2) {
+                (Some(cause1), Some(cause2)) if is_proxy(&cause1) && is_proxy(&cause2) => None,
+                (Some(cause), other) if is_proxy(&cause) => other,
+                (other, Some(cause)) if is_proxy(&cause) => other,
+                (Some(cause1), Some(cause2)) => Some(derived_tree(metadata, cause1, cause2)),
+                (Some(cause), None) | (None, Some(cause)) => Some(cause),
+                (None, None) => None,
+            },
+        )
+        .expect("derivation tree should contain at least one external term")
     }
 
     /// Simplifies the version ranges on any incompatibilities to remove the `[max]` sentinel.
@@ -284,10 +503,11 @@ impl NoSolutionError {
     /// implement PEP 440 semantics for local version equality. For example, `1.0.0+foo` needs to
     /// satisfy `==1.0.0`.
     pub(crate) fn collapse_local_version_segments(derivation_tree: ErrorTree) -> ErrorTree {
-        fn strip(derivation_tree: ErrorTree) -> Option<ErrorTree> {
-            match derivation_tree {
-                DerivationTree::External(External::NotRoot(_, _)) => Some(derivation_tree),
-                DerivationTree::External(External::NoVersions(package, versions)) => {
+        transform_derivation_tree(
+            derivation_tree,
+            |external| match external {
+                external @ External::NotRoot(_, _) => Some(DerivationTree::External(external)),
+                External::NoVersions(package, versions) => {
                     if SentinelRange::from(&versions).is_complement() {
                         return None;
                     }
@@ -297,71 +517,64 @@ impl NoSolutionError {
                         package, versions,
                     )))
                 }
-                DerivationTree::External(External::FromDependencyOf(
-                    package1,
-                    versions1,
-                    package2,
-                    versions2,
-                )) => {
+                External::FromDependencyOf(package1, versions1, package2, versions2) => {
                     let versions1 = SentinelRange::from(&versions1).strip();
                     let versions2 = SentinelRange::from(&versions2).strip();
                     Some(DerivationTree::External(External::FromDependencyOf(
                         package1, versions1, package2, versions2,
                     )))
                 }
-                DerivationTree::External(External::Custom(package, versions, reason)) => {
+                External::Custom(package, versions, reason) => {
                     let versions = SentinelRange::from(&versions).strip();
                     Some(DerivationTree::External(External::Custom(
                         package, versions, reason,
                     )))
                 }
-                DerivationTree::Derived(mut derived) => {
-                    let cause1 = strip((*derived.cause1).clone());
-                    let cause2 = strip((*derived.cause2).clone());
-                    match (cause1, cause2) {
-                        (Some(cause1), Some(cause2)) => Some(DerivationTree::Derived(Derived {
-                            cause1: Arc::new(cause1),
-                            cause2: Arc::new(cause2),
-                            terms: std::mem::take(&mut derived.terms)
-                                .into_iter()
-                                .map(|(pkg, term)| {
-                                    let term = match term {
-                                        Term::Positive(versions) => {
-                                            Term::Positive(SentinelRange::from(&versions).strip())
-                                        }
-                                        Term::Negative(versions) => {
-                                            Term::Negative(SentinelRange::from(&versions).strip())
-                                        }
-                                    };
-                                    (pkg, term)
-                                })
-                                .collect(),
-                            shared_id: derived.shared_id,
-                        })),
-                        (Some(cause), None) | (None, Some(cause)) => Some(cause),
-                        _ => None,
-                    }
-                }
-            }
-        }
+            },
+            |mut metadata, cause1, cause2| {
+                metadata.terms = metadata
+                    .terms
+                    .into_iter()
+                    .map(|(package, term)| {
+                        let term = match term {
+                            Term::Positive(versions) => {
+                                Term::Positive(SentinelRange::from(&versions).strip())
+                            }
+                            Term::Negative(versions) => {
+                                Term::Negative(SentinelRange::from(&versions).strip())
+                            }
+                        };
+                        (package, term)
+                    })
+                    .collect();
 
-        strip(derivation_tree).expect("derivation tree should contain at least one term")
+                match (cause1, cause2) {
+                    (Some(cause1), Some(cause2)) => Some(derived_tree(metadata, cause1, cause2)),
+                    (Some(cause), None) | (None, Some(cause)) => Some(cause),
+                    (None, None) => None,
+                }
+            },
+        )
+        .expect("derivation tree should contain at least one term")
     }
 
     /// Given a [`DerivationTree`], identify the largest required Python version that is missing.
     pub fn find_requires_python(&self) -> LowerBound {
-        fn find(derivation_tree: &ErrorTree, minimum: &mut LowerBound) {
+        let mut minimum = LowerBound::default();
+        let mut trees = vec![&*self.error];
+
+        while let Some(derivation_tree) = trees.pop() {
             match derivation_tree {
                 DerivationTree::Derived(derived) => {
-                    find(derived.cause1.as_ref(), minimum);
-                    find(derived.cause2.as_ref(), minimum);
+                    trees.push(&derived.cause2);
+                    trees.push(&derived.cause1);
                 }
                 DerivationTree::External(External::FromDependencyOf(.., package, version)) => {
                     if let PubGrubPackageInner::Python(_) = &**package {
                         if let Some((lower, ..)) = version.bounding_range() {
                             let lower = LowerBound::new(lower.cloned());
-                            if lower > *minimum {
-                                *minimum = lower;
+                            if lower > minimum {
+                                minimum = lower;
                             }
                         }
                     }
@@ -370,8 +583,6 @@ impl NoSolutionError {
             }
         }
 
-        let mut minimum = LowerBound::default();
-        find(&self.error, &mut minimum);
         minimum
     }
 
@@ -380,24 +591,114 @@ impl NoSolutionError {
         NoSolutionHeader::new(self.env.clone())
     }
 
-    /// Get the conflict derivation tree for external analysis
-    pub fn derivation_tree(&self) -> &ErrorTree {
-        &self.error
-    }
-
     /// Get the packages that are involved in this error.
     pub fn packages(&self) -> impl Iterator<Item = &PackageName> {
-        self.error
-            .packages()
-            .into_iter()
+        derivation_tree_packages(&self.error)
             .filter_map(|p| p.name())
             .unique()
+    }
+
+    /// Generate the report and hints for this resolution failure.
+    ///
+    /// Returns the formatted report string and structured [`PubGrubHint`] values.
+    /// The result is cached so repeated calls (e.g., from both `Display` and
+    /// explicit hint collection) don't recompute the derivation tree.
+    /// Return the formatted report string.
+    pub fn report(&self) -> &str {
+        &self.cached().0
+    }
+
+    /// Return the computed PubGrub hints.
+    fn pubgrub_hints(&self) -> &IndexSet<PubGrubHint> {
+        &self.cached().1
+    }
+
+    /// Compute the reduced derivation tree, formatted report string, and hints.
+    fn compute_report_and_hints(&self) -> (String, IndexSet<PubGrubHint>) {
+        let formatter = PubGrubReportFormatter {
+            included_versions: &self.included_versions,
+            available_versions: &self.available_versions,
+            python_requirement: &self.python_requirement,
+            workspace_members: &self.workspace_members,
+            tags: self.tags.as_ref(),
+        };
+
+        // Transform the error tree for reporting
+        let mut tree = simplify_derivation_tree_markers(
+            self.error.clone().into_inner(),
+            &self.python_requirement,
+        );
+        let should_display_tree = std::env::var_os(EnvVars::UV_INTERNAL__SHOW_DERIVATION_TREE)
+            .is_some()
+            || tracing::enabled!(tracing::Level::TRACE);
+
+        if should_display_tree {
+            display_tree(&tree, "Resolver derivation tree before reduction");
+        }
+
+        tree = collapse_no_versions_of_workspace_members(tree, &self.workspace_members);
+
+        if self.workspace_members.len() == 1 {
+            let project = self.workspace_members.iter().next().unwrap();
+            tree = drop_root_dependency_on_project(tree, project);
+        }
+
+        tree = collapse_unavailable_versions(tree);
+        tree = collapse_redundant_depends_on_no_versions(tree);
+
+        tree = simplify_derivation_tree_ranges(
+            tree,
+            &self.included_versions,
+            &self.selector,
+            &self.env,
+        );
+
+        // This needs to be applied _after_ simplification of the ranges
+        tree = collapse_redundant_no_versions(tree);
+
+        loop {
+            let (collapsed, changed) = collapse_redundant_no_versions_tree(tree);
+            tree = collapsed;
+            if !changed {
+                break;
+            }
+        }
+
+        if should_display_tree {
+            display_tree(&tree, "Resolver derivation tree after reduction");
+        }
+
+        let report = report_derivation_tree(&tree, &formatter);
+
+        let inherited_exclude_newer_ranges = FxHashMap::default();
+        let mut hints = IndexSet::default();
+        formatter.generate_hints(
+            &tree,
+            &self.index,
+            &self.selector,
+            &self.index_locations,
+            &self.index_capabilities,
+            &self.available_indexes,
+            &self.unavailable_packages,
+            &self.incomplete_packages,
+            &self.fork_urls,
+            &self.fork_indexes,
+            &self.env,
+            &self.current_environment,
+            self.tags.as_ref(),
+            &self.workspace_members,
+            &self.options,
+            &inherited_exclude_newer_ranges,
+            &mut hints,
+        );
+
+        (report, hints)
     }
 }
 
 impl std::fmt::Debug for NoSolutionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // Include every field except `index`, which doesn't implement `Debug`.
+        // Include every field except `index` (no Debug) and `cached` (derived).
         let Self {
             error,
             index: _,
@@ -417,6 +718,7 @@ impl std::fmt::Debug for NoSolutionError {
             tags,
             workspace_members,
             options,
+            cached: _,
         } = self;
         f.debug_struct("NoSolutionError")
             .field("error", error)
@@ -444,80 +746,9 @@ impl std::error::Error for NoSolutionError {}
 
 impl std::fmt::Display for NoSolutionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // Write the derivation report.
-        let formatter = PubGrubReportFormatter {
-            included_versions: &self.included_versions,
-            available_versions: &self.available_versions,
-            python_requirement: &self.python_requirement,
-            workspace_members: &self.workspace_members,
-            tags: self.tags.as_ref(),
-        };
+        write!(f, "{}", self.report())?;
 
-        // Transform the error tree for reporting
-        let mut tree = self.error.clone();
-        simplify_derivation_tree_markers(&self.python_requirement, &mut tree);
-        let should_display_tree = std::env::var_os(EnvVars::UV_INTERNAL__SHOW_DERIVATION_TREE)
-            .is_some()
-            || tracing::enabled!(tracing::Level::TRACE);
-
-        if should_display_tree {
-            display_tree(&tree, "Resolver derivation tree before reduction");
-        }
-
-        collapse_no_versions_of_workspace_members(&mut tree, &self.workspace_members);
-
-        if self.workspace_members.len() == 1 {
-            let project = self.workspace_members.iter().next().unwrap();
-            drop_root_dependency_on_project(&mut tree, project);
-        }
-
-        collapse_unavailable_versions(&mut tree);
-        collapse_redundant_depends_on_no_versions(&mut tree);
-
-        simplify_derivation_tree_ranges(
-            &mut tree,
-            &self.included_versions,
-            &self.selector,
-            &self.env,
-        );
-
-        // This needs to be applied _after_ simplification of the ranges
-        collapse_redundant_no_versions(&mut tree);
-
-        while collapse_redundant_no_versions_tree(&mut tree) {
-            // Continue collapsing until no more redundant nodes are found
-        }
-
-        if should_display_tree {
-            display_tree(&tree, "Resolver derivation tree after reduction");
-        }
-
-        let report = DefaultStringReporter::report_with_formatter(&tree, &formatter);
-        write!(f, "{report}")?;
-
-        // Include any additional hints.
-        let mut additional_hints = IndexSet::default();
-        let inherited_exclude_newer_ranges = FxHashMap::default();
-        formatter.generate_hints(
-            &tree,
-            &self.index,
-            &self.selector,
-            &self.index_locations,
-            &self.index_capabilities,
-            &self.available_indexes,
-            &self.unavailable_packages,
-            &self.incomplete_packages,
-            &self.fork_urls,
-            &self.fork_indexes,
-            &self.env,
-            &self.current_environment,
-            self.tags.as_ref(),
-            &self.workspace_members,
-            &self.options,
-            &inherited_exclude_newer_ranges,
-            &mut additional_hints,
-        );
-        for hint in additional_hints {
+        for hint in self.pubgrub_hints() {
             write!(f, "\n\n{hint}")?;
         }
 
@@ -531,7 +762,7 @@ fn display_tree(
     name: &str,
 ) {
     let mut lines = Vec::new();
-    display_tree_inner(error, &mut lines, 0);
+    display_tree_inner(error, &mut lines);
     lines.reverse();
 
     if std::env::var_os(EnvVars::UV_INTERNAL__SHOW_DERIVATION_TREE).is_some() {
@@ -544,106 +775,108 @@ fn display_tree(
 fn display_tree_inner(
     error: &DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
     lines: &mut Vec<String>,
-    depth: usize,
 ) {
-    let prefix = "  ".repeat(depth);
-    match error {
-        DerivationTree::Derived(derived) => {
-            display_tree_inner(&derived.cause1, lines, depth + 1);
-            display_tree_inner(&derived.cause2, lines, depth + 1);
-            for (package, term) in &derived.terms {
-                match term {
-                    Term::Positive(versions) => {
-                        lines.push(format!("{prefix}term {package}{versions}"));
+    enum Frame<'a> {
+        Tree(&'a ErrorTree, usize),
+        Terms(&'a ErrorTerms, usize),
+    }
+
+    let mut frames = vec![Frame::Tree(error, 0)];
+    while let Some(frame) = frames.pop() {
+        match frame {
+            Frame::Tree(DerivationTree::Derived(derived), depth) => {
+                frames.push(Frame::Terms(&derived.terms, depth));
+                frames.push(Frame::Tree(&derived.cause2, depth + 1));
+                frames.push(Frame::Tree(&derived.cause1, depth + 1));
+            }
+            Frame::Tree(DerivationTree::External(external), depth) => {
+                let prefix = "  ".repeat(depth);
+                match external {
+                    External::FromDependencyOf(
+                        package,
+                        version,
+                        dependency,
+                        dependency_version,
+                    ) => {
+                        lines.push(format!(
+                            "{prefix}{package}{version} depends on {dependency}{dependency_version}"
+                        ));
                     }
-                    Term::Negative(versions) => {
-                        lines.push(format!("{prefix}term not {package}{versions}"));
+                    External::Custom(package, versions, reason) => match reason {
+                        UnavailableReason::Package(_) => {
+                            lines.push(format!("{prefix}{package} {reason}"));
+                        }
+                        UnavailableReason::Version(_) => {
+                            lines.push(format!("{prefix}{package}{versions} {reason}"));
+                        }
+                    },
+                    External::NoVersions(package, versions) => {
+                        lines.push(format!("{prefix}no versions of {package}{versions}"));
+                    }
+                    External::NotRoot(package, versions) => {
+                        lines.push(format!("{prefix}not root {package}{versions}"));
+                    }
+                }
+            }
+            Frame::Terms(terms, depth) => {
+                let prefix = "  ".repeat(depth);
+                for (package, term) in terms {
+                    match term {
+                        Term::Positive(versions) => {
+                            lines.push(format!("{prefix}term {package}{versions}"));
+                        }
+                        Term::Negative(versions) => {
+                            lines.push(format!("{prefix}term not {package}{versions}"));
+                        }
                     }
                 }
             }
         }
-        DerivationTree::External(external) => match external {
-            External::FromDependencyOf(package, version, dependency, dependency_version) => {
-                lines.push(format!(
-                    "{prefix}{package}{version} depends on {dependency}{dependency_version}"
-                ));
-            }
-            External::Custom(package, versions, reason) => match reason {
-                UnavailableReason::Package(_) => {
-                    lines.push(format!("{prefix}{package} {reason}"));
-                }
-                UnavailableReason::Version(_) => {
-                    lines.push(format!("{prefix}{package}{versions} {reason}"));
-                }
-            },
-            External::NoVersions(package, versions) => {
-                lines.push(format!("{prefix}no versions of {package}{versions}"));
-            }
-            External::NotRoot(package, versions) => {
-                lines.push(format!("{prefix}not root {package}{versions}"));
-            }
-        },
     }
 }
 
-fn collapse_redundant_no_versions(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-) {
-    match tree {
-        DerivationTree::External(_) => {}
-        DerivationTree::Derived(derived) => {
-            match (
-                Arc::make_mut(&mut derived.cause1),
-                Arc::make_mut(&mut derived.cause2),
-            ) {
-                // If we have a node for a package with no versions...
-                (
-                    DerivationTree::External(External::NoVersions(package, versions)),
-                    ref mut other,
-                )
-                | (
-                    ref mut other,
-                    DerivationTree::External(External::NoVersions(package, versions)),
-                ) => {
-                    // First, always recursively visit the other side of the tree
-                    collapse_redundant_no_versions(other);
+fn can_drop_no_versions(
+    package: &PubGrubPackage,
+    versions: &Range<Version>,
+    other: &ErrorTree,
+    parent_terms: &ErrorTerms,
+) -> bool {
+    let package_terms = if let DerivationTree::Derived(derived) = other {
+        derived.terms.get(package)
+    } else {
+        parent_terms.get(package)
+    };
+    let Some(Term::Positive(term)) = package_terms else {
+        return false;
+    };
+    let versions = versions.complement();
 
-                    // Retrieve the nearest terms, either alongside this node or from the parent.
-                    let package_terms = if let DerivationTree::Derived(derived) = other {
-                        derived.terms.get(package)
-                    } else {
-                        derived.terms.get(package)
-                    };
+    // Retain exclusions of a single version because they produce useful messages like
+    // "only foo==1.0.0 is available". Otherwise, the clause is redundant when the conclusion
+    // covers either all versions or exactly the remaining range.
+    versions.as_singleton().is_none() && (*term == Range::full() || *term == versions)
+}
 
-                    let Some(Term::Positive(term)) = package_terms else {
-                        return;
-                    };
-
-                    let versions = versions.complement();
-
-                    // If we're disqualifying a single version, this is important to retain, e.g,
-                    // for `only foo==1.0.0 is available`
-                    if versions.as_singleton().is_some() {
-                        return;
-                    }
-
-                    // If the range in the conclusion (terms) matches the range of no versions,
-                    // then we'll drop this node. If the range is "all versions", then there's no
-                    // also no need to enumerate the available versions.
-                    if *term != Range::full() && *term != versions {
-                        return;
-                    }
-
-                    *tree = other.clone();
-                }
-                // If not, just recurse
-                _ => {
-                    collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_redundant_no_versions(Arc::make_mut(&mut derived.cause2));
-                }
+fn collapse_redundant_no_versions(tree: ErrorTree) -> ErrorTree {
+    map_derivation_tree(
+        tree,
+        DerivationTree::External,
+        |metadata, cause1, cause2| {
+            if let DerivationTree::External(External::NoVersions(package, versions)) = &cause1
+                && can_drop_no_versions(package, versions, &cause2, &metadata.terms)
+            {
+                return cause2;
             }
-        }
-    }
+
+            if let DerivationTree::External(External::NoVersions(package, versions)) = &cause2
+                && can_drop_no_versions(package, versions, &cause1, &metadata.terms)
+            {
+                return cause1;
+            }
+
+            derived_tree(metadata, cause1, cause2)
+        },
+    )
 }
 
 /// Given a [`DerivationTree`], collapse any derived trees with two `NoVersions` nodes for the same
@@ -680,94 +913,105 @@ fn collapse_redundant_no_versions(
 ///
 /// This appears to be common with the way the resolver currently models Python version
 /// incompatibilities.
-fn collapse_redundant_no_versions_tree(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-) -> bool {
-    match tree {
-        DerivationTree::External(_) => false,
-        DerivationTree::Derived(derived) => {
-            match (
-                Arc::make_mut(&mut derived.cause1),
-                Arc::make_mut(&mut derived.cause2),
-            ) {
-                // If we have a tree with two `NoVersions` nodes for the same package...
-                (
-                    DerivationTree::External(External::NoVersions(package, versions)),
-                    DerivationTree::External(External::NoVersions(other_package, other_versions)),
-                ) if package == other_package => {
-                    // Retrieve the terms from the parent.
-                    let Some(Term::Positive(term)) = derived.terms.get(package) else {
-                        return false;
-                    };
-
-                    // If they're both subsets of the term, then drop this node in favor of the term
-                    if versions.subset_of(term) && other_versions.subset_of(term) {
-                        *tree = DerivationTree::External(External::NoVersions(
-                            package.clone(),
-                            term.clone(),
-                        ));
-                        return true;
-                    }
-
-                    false
-                }
-                // If not, just recurse
-                _ => {
-                    collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause1))
-                        || collapse_redundant_no_versions_tree(Arc::make_mut(&mut derived.cause2))
-                }
+fn collapse_redundant_no_versions_tree(tree: ErrorTree) -> (ErrorTree, bool) {
+    let mut changed = false;
+    let tree = map_derivation_tree(
+        tree,
+        DerivationTree::External,
+        |metadata, cause1, cause2| {
+            if let (
+                DerivationTree::External(External::NoVersions(package, versions)),
+                DerivationTree::External(External::NoVersions(other_package, other_versions)),
+            ) = (&cause1, &cause2)
+                && package == other_package
+                && let Some(Term::Positive(term)) = metadata.terms.get(package)
+                && versions.subset_of(term)
+                && other_versions.subset_of(term)
+            {
+                changed = true;
+                DerivationTree::External(External::NoVersions(package.clone(), term.clone()))
+            } else {
+                derived_tree(metadata, cause1, cause2)
             }
-        }
-    }
+        },
+    );
+    (tree, changed)
+}
+
+fn is_workspace_member(
+    package: &PubGrubPackage,
+    workspace_members: &BTreeSet<PackageName>,
+) -> bool {
+    let (PubGrubPackageInner::Package { name, .. }
+    | PubGrubPackageInner::Extra { name, .. }
+    | PubGrubPackageInner::Group { name, .. }) = &**package
+    else {
+        return false;
+    };
+    workspace_members.contains(name)
 }
 
 /// Given a [`DerivationTree`], collapse any `NoVersion` incompatibilities for workspace members
 /// to avoid saying things like "only <workspace-member>==0.1.0 is available".
 fn collapse_no_versions_of_workspace_members(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    tree: ErrorTree,
     workspace_members: &BTreeSet<PackageName>,
-) {
-    match tree {
-        DerivationTree::External(_) => {}
-        DerivationTree::Derived(derived) => {
-            match (
-                Arc::make_mut(&mut derived.cause1),
-                Arc::make_mut(&mut derived.cause2),
-            ) {
-                // If we have a node for a package with no versions...
-                (DerivationTree::External(External::NoVersions(package, _)), ref mut other)
-                | (ref mut other, DerivationTree::External(External::NoVersions(package, _))) => {
-                    // First, always recursively visit the other side of the tree
-                    collapse_no_versions_of_workspace_members(other, workspace_members);
-
-                    // Then, if the package is a workspace member...
-                    let (PubGrubPackageInner::Package { name, .. }
-                    | PubGrubPackageInner::Extra { name, .. }
-                    | PubGrubPackageInner::Group { name, .. }) = &**package
-                    else {
-                        return;
-                    };
-                    if !workspace_members.contains(name) {
-                        return;
-                    }
-
-                    // Replace this node with the other tree
-                    *tree = other.clone();
-                }
-                // If not, just recurse
-                _ => {
-                    collapse_no_versions_of_workspace_members(
-                        Arc::make_mut(&mut derived.cause1),
-                        workspace_members,
-                    );
-                    collapse_no_versions_of_workspace_members(
-                        Arc::make_mut(&mut derived.cause2),
-                        workspace_members,
-                    );
-                }
+) -> ErrorTree {
+    map_derivation_tree(
+        tree,
+        DerivationTree::External,
+        |metadata, cause1, cause2| {
+            if let DerivationTree::External(External::NoVersions(package, _)) = &cause1
+                && is_workspace_member(package, workspace_members)
+            {
+                return cause2;
             }
+            if let DerivationTree::External(External::NoVersions(package, _)) = &cause2
+                && is_workspace_member(package, workspace_members)
+            {
+                return cause1;
+            }
+            derived_tree(metadata, cause1, cause2)
+        },
+    )
+}
+
+fn collapse_redundant_dependency_child(
+    tree: ErrorTree,
+    package: &PubGrubPackage,
+    versions: &Range<Version>,
+) -> ErrorTree {
+    let DerivationTree::Derived(derived) = &tree else {
+        return tree;
+    };
+    let dependency_clause = match (&*derived.cause1, &*derived.cause2) {
+        (
+            DerivationTree::External(External::NoVersions(no_versions_package, _)),
+            dependency_clause @ DerivationTree::External(External::FromDependencyOf(
+                _,
+                _,
+                dependency_package,
+                dependency_versions,
+            )),
+        )
+        | (
+            dependency_clause @ DerivationTree::External(External::FromDependencyOf(
+                _,
+                _,
+                dependency_package,
+                dependency_versions,
+            )),
+            DerivationTree::External(External::NoVersions(no_versions_package, _)),
+        ) if no_versions_package == dependency_package
+            && package == no_versions_package
+            && versions.subset_of(dependency_versions) =>
+        {
+            Some(dependency_clause.clone())
         }
-    }
+        _ => None,
+    };
+
+    dependency_clause.unwrap_or(tree)
 }
 
 /// Given a [`DerivationTree`], collapse `NoVersions` incompatibilities that are redundant children
@@ -779,9 +1023,9 @@ fn collapse_no_versions_of_workspace_members(
 ///     C depends on A>=1,<2
 /// ```
 ///
-/// We can simplify this to `C depends A>=1 and A>=1 depends on B so C depends on B` without
-/// explaining that there are no other versions of A. This is dependent on range of A in "A depends
-/// on" being a subset of range of A in "depends on A". For example, in a tree like:
+/// We can simplify this to `C depends on A>=1 and A>=1 depends on B so C depends on B` without
+/// explaining that there are no other versions of A. This requires the range of A in "A depends
+/// on B" to be a subset of the range in "C depends on A". For example, in a tree like:
 ///
 /// ```text
 /// A>=1,<3 depends on B
@@ -789,301 +1033,219 @@ fn collapse_no_versions_of_workspace_members(
 ///     C depends on A>=2,<3
 /// ```
 ///
-/// We cannot say `C depends on A>=2 and A>=1 depends on B so C depends on B` because there is a
-/// hole in the range — `A>=1,<3` is not a subset of `A>=2,<3`.
-fn collapse_redundant_depends_on_no_versions(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-) {
-    match tree {
-        DerivationTree::External(_) => {}
-        DerivationTree::Derived(derived) => {
-            // If one node is a dependency incompatibility...
-            match (
-                Arc::make_mut(&mut derived.cause1),
-                Arc::make_mut(&mut derived.cause2),
-            ) {
-                (
-                    DerivationTree::External(External::FromDependencyOf(package, versions, _, _)),
-                    ref mut other,
-                )
-                | (
-                    ref mut other,
-                    DerivationTree::External(External::FromDependencyOf(package, versions, _, _)),
-                ) => {
-                    // Check if the other node is the relevant form of subtree...
-                    collapse_redundant_depends_on_no_versions_inner(other, package, versions);
-                }
-                // If not, just recurse
-                _ => {
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause2));
-                }
+/// We cannot apply the same simplification because `A>=1,<3` is not a subset of `A>=2,<3`.
+fn collapse_redundant_depends_on_no_versions(tree: ErrorTree) -> ErrorTree {
+    map_derivation_tree(
+        tree,
+        DerivationTree::External,
+        |metadata, cause1, cause2| {
+            if let DerivationTree::External(External::FromDependencyOf(package, versions, _, _)) =
+                &cause1
+            {
+                let cause2 = collapse_redundant_dependency_child(cause2, package, versions);
+                return derived_tree(metadata, cause1, cause2);
             }
-        }
-    }
-}
-
-/// Helper for [`collapse_redundant_depends_on_no_versions`].
-fn collapse_redundant_depends_on_no_versions_inner(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-    package: &PubGrubPackage,
-    versions: &Range<Version>,
-) {
-    match tree {
-        DerivationTree::External(_) => {}
-        DerivationTree::Derived(derived) => {
-            // If we're a subtree with dependency and no versions incompatibilities...
-            match (&*derived.cause1, &*derived.cause2) {
-                (
-                    DerivationTree::External(External::NoVersions(no_versions_package, _)),
-                    dependency_clause @ DerivationTree::External(External::FromDependencyOf(
-                        _,
-                        _,
-                        dependency_package,
-                        dependency_versions,
-                    )),
-                )
-                | (
-                    dependency_clause @ DerivationTree::External(External::FromDependencyOf(
-                        _,
-                        _,
-                        dependency_package,
-                        dependency_versions,
-                    )),
-                    DerivationTree::External(External::NoVersions(no_versions_package, _)),
-                )
-                // And these incompatibilities (and the parent incompatibility) all are referring to
-                // the same package...
-                if no_versions_package == dependency_package
-                    && package == no_versions_package
-                // And parent dependency versions are a subset of the versions in this tree...
-                    && versions.subset_of(dependency_versions) =>
-                {
-                    // Enumerating the available versions will be redundant and we can drop the no
-                    // versions clause entirely in favor of the dependency clause.
-                    *tree = dependency_clause.clone();
-
-                    // Note we are at a leaf of the tree so there's no further recursion to do
-                }
-                // If not, just recurse
-                _ => {
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_redundant_depends_on_no_versions(Arc::make_mut(&mut derived.cause2));
-                }
+            if let DerivationTree::External(External::FromDependencyOf(package, versions, _, _)) =
+                &cause2
+            {
+                let cause1 = collapse_redundant_dependency_child(cause1, package, versions);
+                return derived_tree(metadata, cause1, cause2);
             }
-        }
-    }
+            derived_tree(metadata, cause1, cause2)
+        },
+    )
 }
 
 /// Simplifies the markers on pubgrub packages in the given derivation tree
 /// according to the given Python requirement.
 ///
-/// For example, when there's a dependency like `foo ; python_version >=
-/// '3.11'` and `requires-python = '>=3.11'`, this simplification will remove
-/// the `python_version >= '3.11'` marker since it's implied to be true by
-/// the `requires-python` setting. This simplifies error messages by reducing
-/// noise.
+/// For example, when there's a dependency like `foo ; python_version >= '3.11'` and
+/// `requires-python = '>=3.11'`, this removes the redundant `python_version >= '3.11'` marker from
+/// the error message.
 fn simplify_derivation_tree_markers(
+    tree: ErrorTree,
     python_requirement: &PythonRequirement,
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-) {
-    match tree {
-        DerivationTree::External(External::NotRoot(pkg, _)) => {
-            pkg.simplify_markers(python_requirement);
-        }
-        DerivationTree::External(External::NoVersions(pkg, _)) => {
-            pkg.simplify_markers(python_requirement);
-        }
-        DerivationTree::External(External::FromDependencyOf(pkg1, _, pkg2, _)) => {
-            pkg1.simplify_markers(python_requirement);
-            pkg2.simplify_markers(python_requirement);
-        }
-        DerivationTree::External(External::Custom(pkg, _, _)) => {
-            pkg.simplify_markers(python_requirement);
-        }
-        DerivationTree::Derived(derived) => {
-            derived.terms = std::mem::take(&mut derived.terms)
+) -> ErrorTree {
+    map_derivation_tree(
+        tree,
+        |mut external| {
+            match &mut external {
+                External::NotRoot(package, _) | External::NoVersions(package, _) => {
+                    package.simplify_markers(python_requirement);
+                }
+                External::FromDependencyOf(package1, _, package2, _) => {
+                    package1.simplify_markers(python_requirement);
+                    package2.simplify_markers(python_requirement);
+                }
+                External::Custom(package, _, _) => package.simplify_markers(python_requirement),
+            }
+            DerivationTree::External(external)
+        },
+        |mut metadata, cause1, cause2| {
+            metadata.terms = metadata
+                .terms
                 .into_iter()
-                .map(|(mut pkg, term)| {
-                    pkg.simplify_markers(python_requirement);
-                    (pkg, term)
+                .map(|(mut package, term)| {
+                    package.simplify_markers(python_requirement);
+                    (package, term)
                 })
                 .collect();
-            simplify_derivation_tree_markers(
-                python_requirement,
-                Arc::make_mut(&mut derived.cause1),
-            );
-            simplify_derivation_tree_markers(
-                python_requirement,
-                Arc::make_mut(&mut derived.cause2),
-            );
-        }
+            derived_tree(metadata, cause1, cause2)
+        },
+    )
+}
+
+fn merge_unavailable_versions(
+    package: &PubGrubPackage,
+    versions: &Range<Version>,
+    reason: &UnavailableReason,
+    other: &ErrorTree,
+) -> Option<ErrorTree> {
+    let DerivationTree::Derived(derived) = other else {
+        return None;
+    };
+    let merge = |cause: &ErrorTree| {
+        let DerivationTree::External(External::Custom(other_package, other_versions, other_reason)) =
+            cause
+        else {
+            return None;
+        };
+        (package == other_package && reason == other_reason).then(|| other_versions.union(versions))
+    };
+
+    // Keep the two cases separate to preserve the ordering of the causes.
+    let (unchanged_cause, merged_versions, merged_is_cause2) =
+        if let Some(merged_versions) = merge(&derived.cause2) {
+            (derived.cause1.clone(), merged_versions, true)
+        } else if let Some(merged_versions) = merge(&derived.cause1) {
+            (derived.cause2.clone(), merged_versions, false)
+        } else {
+            return None;
+        };
+
+    let merged_cause = Arc::new(DerivationTree::External(External::Custom(
+        package.clone(),
+        merged_versions.clone(),
+        reason.clone(),
+    )));
+    let (cause1, cause2) = if merged_is_cause2 {
+        (unchanged_cause, merged_cause)
+    } else {
+        (merged_cause, unchanged_cause)
+    };
+
+    let mut terms = derived.terms.clone();
+    if let Some(Term::Positive(range)) = terms.get_mut(package) {
+        *range = merged_versions;
     }
+    Some(DerivationTree::Derived(Derived {
+        terms,
+        shared_id: derived.shared_id,
+        cause1,
+        cause2,
+    }))
 }
 
 /// Given a [`DerivationTree`], collapse incompatibilities for versions of a package that are
 /// unavailable for the same reason to avoid repeating the same message for every unavailable
 /// version.
-fn collapse_unavailable_versions(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-) {
-    match tree {
-        DerivationTree::External(_) => {}
-        DerivationTree::Derived(derived) => {
-            match (
-                Arc::make_mut(&mut derived.cause1),
-                Arc::make_mut(&mut derived.cause2),
-            ) {
-                // If we have a node for unavailable package versions
-                (
-                    DerivationTree::External(External::Custom(package, versions, reason)),
-                    ref mut other,
-                )
-                | (
-                    ref mut other,
-                    DerivationTree::External(External::Custom(package, versions, reason)),
-                ) => {
-                    // First, recursively collapse the other side of the tree
-                    collapse_unavailable_versions(other);
-
-                    // If it's not a derived tree, nothing to do.
-                    let DerivationTree::Derived(Derived {
-                        terms,
-                        shared_id,
-                        cause1,
-                        cause2,
-                    }) = other
-                    else {
-                        return;
-                    };
-
-                    // If the other tree has an unavailable package...
-                    match (&**cause1, &**cause2) {
-                        // Note the following cases are the same, but we need two matches to retain
-                        // the ordering of the causes
-                        (
-                            _,
-                            DerivationTree::External(External::Custom(
-                                other_package,
-                                other_versions,
-                                other_reason,
-                            )),
-                        ) => {
-                            // And the package and reason are the same...
-                            if package == other_package && reason == other_reason {
-                                // Collapse both into a new node, with a union of their ranges
-                                let versions = other_versions.union(versions);
-                                let mut terms = terms.clone();
-                                if let Some(Term::Positive(range)) = terms.get_mut(package) {
-                                    *range = versions.clone();
-                                }
-                                *tree = DerivationTree::Derived(Derived {
-                                    terms,
-                                    shared_id: *shared_id,
-                                    cause1: cause1.clone(),
-                                    cause2: Arc::new(DerivationTree::External(External::Custom(
-                                        package.clone(),
-                                        versions,
-                                        reason.clone(),
-                                    ))),
-                                });
-                            }
-                        }
-                        (
-                            DerivationTree::External(External::Custom(
-                                other_package,
-                                other_versions,
-                                other_reason,
-                            )),
-                            _,
-                        ) => {
-                            // And the package and reason are the same...
-                            if package == other_package && reason == other_reason {
-                                // Collapse both into a new node, with a union of their ranges
-                                let versions = other_versions.union(versions);
-                                let mut terms = terms.clone();
-                                if let Some(Term::Positive(range)) = terms.get_mut(package) {
-                                    *range = versions.clone();
-                                }
-                                *tree = DerivationTree::Derived(Derived {
-                                    terms,
-                                    shared_id: *shared_id,
-                                    cause1: Arc::new(DerivationTree::External(External::Custom(
-                                        package.clone(),
-                                        versions,
-                                        reason.clone(),
-                                    ))),
-                                    cause2: cause2.clone(),
-                                });
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                // If not, just recurse
-                _ => {
-                    collapse_unavailable_versions(Arc::make_mut(&mut derived.cause1));
-                    collapse_unavailable_versions(Arc::make_mut(&mut derived.cause2));
-                }
+fn collapse_unavailable_versions(tree: ErrorTree) -> ErrorTree {
+    map_derivation_tree(
+        tree,
+        DerivationTree::External,
+        |metadata, cause1, cause2| {
+            if let DerivationTree::External(External::Custom(package, versions, reason)) = &cause1
+                && let Some(tree) = merge_unavailable_versions(package, versions, reason, &cause2)
+            {
+                return tree;
             }
-        }
-    }
+            if let DerivationTree::External(External::Custom(package, versions, reason)) = &cause2
+                && let Some(tree) = merge_unavailable_versions(package, versions, reason, &cause1)
+            {
+                return tree;
+            }
+            derived_tree(metadata, cause1, cause2)
+        },
+    )
 }
 
-/// Given a [`DerivationTree`], drop dependency incompatibilities from the root
-/// to the project.
+fn is_root_dependency_on_project(external: &ErrorExternal, project: &PackageName) -> bool {
+    let External::FromDependencyOf(package, _, dependency, _) = external else {
+        return false;
+    };
+    if !matches!(&**package, PubGrubPackageInner::Root(_)) {
+        return false;
+    }
+    matches!(&**dependency, PubGrubPackageInner::Package { name, .. } if name == project)
+}
+
+/// Given a [`DerivationTree`], drop dependency incompatibilities from the root to the project.
 ///
-/// Intended to effectively change the root to a workspace member in single project
-/// workspaces, avoiding a level of indirection like "And because your project
-/// requires your project, we can conclude that your project's requirements are
-/// unsatisfiable."
-fn drop_root_dependency_on_project(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-    project: &PackageName,
-) {
-    match tree {
-        DerivationTree::External(_) => {}
-        DerivationTree::Derived(derived) => {
-            match (
-                Arc::make_mut(&mut derived.cause1),
-                Arc::make_mut(&mut derived.cause2),
-            ) {
-                // If one node is a dependency incompatibility...
-                (
-                    DerivationTree::External(External::FromDependencyOf(package, _, dependency, _)),
-                    ref mut other,
-                )
-                | (
-                    ref mut other,
-                    DerivationTree::External(External::FromDependencyOf(package, _, dependency, _)),
-                ) => {
-                    // And the parent is the root package...
-                    if !matches!(&**package, PubGrubPackageInner::Root(_)) {
-                        return;
-                    }
+/// This effectively changes the root to the workspace member in a single-project workspace,
+/// avoiding an extra level of indirection like "your project requires your project".
+///
+/// A direct dependency incompatibility is also a traversal boundary: if it is not the
+/// root-to-project edge, leave that subtree unchanged. After removing a matching edge, continue
+/// through only the opposite cause.
+fn drop_root_dependency_on_project(tree: ErrorTree, project: &PackageName) -> ErrorTree {
+    let mut tasks = vec![TreeTask::Visit(StackSafeErrorTree::new(tree))];
+    let mut results = Vec::new();
 
-                    // And the dependency is the project...
-                    let PubGrubPackageInner::Package { name, .. } = &**dependency else {
-                        return;
+    while let Some(task) = tasks.pop() {
+        match task {
+            TreeTask::Visit(tree) => match tree.into_inner() {
+                DerivationTree::External(external) => {
+                    results.push(StackSafeErrorTree::new(DerivationTree::External(external)));
+                }
+                DerivationTree::Derived(derived) => {
+                    let first_dependency = match derived.cause1.as_ref() {
+                        DerivationTree::External(external @ External::FromDependencyOf(..)) => {
+                            Some((external, true))
+                        }
+                        _ => match derived.cause2.as_ref() {
+                            DerivationTree::External(external @ External::FromDependencyOf(..)) => {
+                                Some((external, false))
+                            }
+                            _ => None,
+                        },
                     };
-                    if name != project {
-                        return;
+
+                    if let Some((external, dependency_is_cause1)) = first_dependency {
+                        if is_root_dependency_on_project(external, project) {
+                            let other = if dependency_is_cause1 {
+                                Arc::unwrap_or_clone(derived.cause2)
+                            } else {
+                                Arc::unwrap_or_clone(derived.cause1)
+                            };
+                            tasks.push(TreeTask::Visit(StackSafeErrorTree::new(other)));
+                        } else {
+                            results.push(StackSafeErrorTree::new(DerivationTree::Derived(derived)));
+                        }
+                    } else {
+                        schedule_derived(&mut tasks, derived);
                     }
-
-                    // Recursively collapse the other side of the tree
-                    drop_root_dependency_on_project(other, project);
-
-                    // Then, replace this node with the other tree
-                    *tree = other.clone();
                 }
-                // If not, just recurse
-                _ => {
-                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause1), project);
-                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause2), project);
-                }
+            },
+            TreeTask::Rebuild(metadata) => {
+                let cause2 = results
+                    .pop()
+                    .expect("every derived tree has a second reduced cause")
+                    .into_inner();
+                let cause1 = results
+                    .pop()
+                    .expect("every derived tree has a first reduced cause")
+                    .into_inner();
+                results.push(StackSafeErrorTree::new(derived_tree(
+                    metadata, cause1, cause2,
+                )));
             }
         }
     }
+
+    results
+        .pop()
+        .expect("the root derivation tree produces one reduced result")
+        .into_inner()
 }
 
 /// A version range that may include local version sentinels (`+[max]`).
@@ -1098,7 +1260,7 @@ impl<'range> From<&'range Range<Version>> for SentinelRange<'range> {
 
 impl SentinelRange<'_> {
     /// Returns `true` if the range appears to be, e.g., `>=1.0.0, <1.0.0+[max]`.
-    pub fn is_sentinel(&self) -> bool {
+    pub(crate) fn is_sentinel(&self) -> bool {
         self.0.iter().all(|(lower, upper)| {
             let (Bound::Included(lower), Bound::Excluded(upper)) = (lower, upper) else {
                 return false;
@@ -1115,7 +1277,7 @@ impl SentinelRange<'_> {
 
     /// Returns `true` if the range appears to be, e.g., `>1.0.0, <1.0.0+[max]` (i.e., a sentinel
     /// range with the non-local version removed).
-    pub fn is_complement(&self) -> bool {
+    fn is_complement(&self) -> bool {
         self.0.iter().all(|(lower, upper)| {
             let (Bound::Excluded(lower), Bound::Excluded(upper)) = (lower, upper) else {
                 return false;
@@ -1287,7 +1449,7 @@ pub struct NoSolutionHeader {
 
 impl NoSolutionHeader {
     /// Create a new [`NoSolutionHeader`] with the given [`ResolverEnvironment`].
-    pub fn new(env: ResolverEnvironment) -> Self {
+    fn new(env: ResolverEnvironment) -> Self {
         Self { env, context: None }
     }
 
@@ -1319,85 +1481,75 @@ impl std::fmt::Display for NoSolutionHeader {
     }
 }
 
-/// Given a [`DerivationTree`], simplify version ranges using the available versions for each
+/// Given a [`DerivationTree`], simplify version ranges using the included versions for each
 /// package.
 fn simplify_derivation_tree_ranges(
-    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-    available_versions: &FxHashMap<PackageName, BTreeSet<Version>>,
+    tree: ErrorTree,
+    included_versions: &FxHashMap<PackageName, BTreeSet<Version>>,
     candidate_selector: &CandidateSelector,
     resolver_environment: &ResolverEnvironment,
-) {
-    match tree {
-        DerivationTree::External(external) => match external {
-            External::FromDependencyOf(package1, versions1, package2, versions2) => {
-                if let Some(simplified) = simplify_range(
-                    versions1,
-                    package1,
-                    available_versions,
-                    candidate_selector,
-                    resolver_environment,
-                ) {
-                    *versions1 = simplified;
+) -> ErrorTree {
+    map_derivation_tree(
+        tree,
+        |mut external| {
+            match &mut external {
+                External::FromDependencyOf(package1, versions1, package2, versions2) => {
+                    if let Some(simplified) = simplify_range(
+                        versions1,
+                        package1,
+                        included_versions,
+                        candidate_selector,
+                        resolver_environment,
+                    ) {
+                        *versions1 = simplified;
+                    }
+                    if let Some(simplified) = simplify_range(
+                        versions2,
+                        package2,
+                        included_versions,
+                        candidate_selector,
+                        resolver_environment,
+                    ) {
+                        *versions2 = simplified;
+                    }
                 }
-                if let Some(simplified) = simplify_range(
-                    versions2,
-                    package2,
-                    available_versions,
-                    candidate_selector,
-                    resolver_environment,
-                ) {
-                    *versions2 = simplified;
+                External::NoVersions(package, versions) => {
+                    if let Some(simplified) = simplify_range(
+                        versions,
+                        package,
+                        included_versions,
+                        candidate_selector,
+                        resolver_environment,
+                    ) {
+                        *versions = simplified;
+                    }
                 }
+                External::Custom(package, versions, _) => {
+                    if let Some(simplified) = simplify_range(
+                        versions,
+                        package,
+                        included_versions,
+                        candidate_selector,
+                        resolver_environment,
+                    ) {
+                        *versions = simplified;
+                    }
+                }
+                External::NotRoot(..) => {}
             }
-            External::NoVersions(package, versions) => {
-                if let Some(simplified) = simplify_range(
-                    versions,
-                    package,
-                    available_versions,
-                    candidate_selector,
-                    resolver_environment,
-                ) {
-                    *versions = simplified;
-                }
-            }
-            External::Custom(package, versions, _) => {
-                if let Some(simplified) = simplify_range(
-                    versions,
-                    package,
-                    available_versions,
-                    candidate_selector,
-                    resolver_environment,
-                ) {
-                    *versions = simplified;
-                }
-            }
-            External::NotRoot(..) => (),
+            DerivationTree::External(external)
         },
-        DerivationTree::Derived(derived) => {
-            // Recursively simplify both sides of the tree
-            simplify_derivation_tree_ranges(
-                Arc::make_mut(&mut derived.cause1),
-                available_versions,
-                candidate_selector,
-                resolver_environment,
-            );
-            simplify_derivation_tree_ranges(
-                Arc::make_mut(&mut derived.cause2),
-                available_versions,
-                candidate_selector,
-                resolver_environment,
-            );
-
-            // Simplify the terms
-            derived.terms = std::mem::take(&mut derived.terms)
+        |mut metadata, cause1, cause2| {
+            metadata.terms = metadata
+                .terms
                 .into_iter()
-                .map(|(pkg, term)| {
+                .map(|(package, term)| {
                     let term = match term {
                         Term::Positive(versions) => Term::Positive(
                             simplify_range(
                                 &versions,
-                                &pkg,
-                                available_versions,
+                                &package,
+                                included_versions,
                                 candidate_selector,
                                 resolver_environment,
                             )
@@ -1406,34 +1558,35 @@ fn simplify_derivation_tree_ranges(
                         Term::Negative(versions) => Term::Negative(
                             simplify_range(
                                 &versions,
-                                &pkg,
-                                available_versions,
+                                &package,
+                                included_versions,
                                 candidate_selector,
                                 resolver_environment,
                             )
                             .unwrap_or(versions),
                         ),
                     };
-                    (pkg, term)
+                    (package, term)
                 })
                 .collect();
-        }
-    }
+            derived_tree(metadata, cause1, cause2)
+        },
+    )
 }
 
-/// Helper function to simplify a version range using available versions for a package.
+/// Helper function to simplify a version range using included versions for a package.
 ///
 /// If the range cannot be simplified, `None` is returned.
 fn simplify_range(
     range: &Range<Version>,
     package: &PubGrubPackage,
-    available_versions: &FxHashMap<PackageName, BTreeSet<Version>>,
+    included_versions: &FxHashMap<PackageName, BTreeSet<Version>>,
     candidate_selector: &CandidateSelector,
     resolver_environment: &ResolverEnvironment,
 ) -> Option<Range<Version>> {
-    // If there's not a package name or available versions, we can't simplify anything
+    // If there's not a package name or included versions, we can't simplify anything
     let name = package.name()?;
-    let versions = available_versions.get(name)?;
+    let versions = included_versions.get(name)?;
 
     // If this is a full range, there's nothing to simplify
     if range == &Range::full() {
@@ -1482,4 +1635,97 @@ fn simplify_range(
         // Otherwise, include the version
         true
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deep_derivation_tree() -> ErrorTree {
+        let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+        let leaf = ErrorTree::External(External::NotRoot(package, Version::new([1_u64])));
+        let mut tree = leaf.clone();
+
+        for _ in 0..100_000 {
+            tree = ErrorTree::Derived(Derived {
+                terms: pubgrub::Map::default(),
+                shared_id: None,
+                cause1: Arc::new(tree),
+                cause2: Arc::new(leaf.clone()),
+            });
+        }
+
+        tree
+    }
+
+    #[test]
+    fn drops_transformed_derivation_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let _tree = StackSafeErrorTree::new(deep_derivation_tree());
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn derivation_tree_packages_are_unique() {
+        let tree = StackSafeErrorTree::new(deep_derivation_tree());
+        assert_eq!(derivation_tree_packages(&tree).count(), 1);
+    }
+
+    #[test]
+    fn collapse_proxies_drops_source_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let tree = NoSolutionError::collapse_proxies(deep_derivation_tree());
+                drop_derivation_tree(tree);
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn collapse_local_versions_drops_source_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let tree = NoSolutionError::collapse_local_version_segments(deep_derivation_tree());
+                drop_derivation_tree(tree);
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn formats_debug_derivation_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let tree = StackSafeErrorTree::new(deep_derivation_tree());
+                let _formatted = format!("{tree:?}");
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn iterative_debug_matches_pubgrub_debug() {
+        let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+        let leaf = ErrorTree::External(External::NotRoot(package, Version::new([1_u64])));
+        let tree = StackSafeErrorTree::new(ErrorTree::Derived(Derived {
+            terms: pubgrub::Map::default(),
+            shared_id: Some(1),
+            cause1: Arc::new(leaf.clone()),
+            cause2: Arc::new(leaf),
+        }));
+
+        assert_eq!(format!("{:?}", &*tree), format!("{tree:?}"));
+    }
 }

--- a/crates/fyn-resolver/src/exclude_newer.rs
+++ b/crates/fyn-resolver/src/exclude_newer.rs
@@ -16,7 +16,7 @@ use serde::ser::SerializeMap;
 
 /// The configuration layer that supplied the effective `exclude-newer` cutoff for a package.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum EffectiveExcludeNewerSource {
+pub enum EffectiveExcludeNewerSource {
     /// The global `exclude-newer` setting.
     Global,
     /// A package-specific `exclude-newer-package` override.

--- a/crates/fyn-resolver/src/pubgrub/mod.rs
+++ b/crates/fyn-resolver/src/pubgrub/mod.rs
@@ -1,7 +1,8 @@
 pub(crate) use crate::pubgrub::dependencies::{DependencySource, PubGrubDependency};
-pub use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
+pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
 pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority, PubGrubTiebreaker};
-pub(crate) use crate::pubgrub::report::PubGrubReportFormatter;
+pub use crate::pubgrub::report::PubGrubHint;
+pub(crate) use crate::pubgrub::report::{PubGrubReportFormatter, report as report_derivation_tree};
 
 mod dependencies;
 mod package;

--- a/crates/fyn-resolver/src/pubgrub/report.rs
+++ b/crates/fyn-resolver/src/pubgrub/report.rs
@@ -1,9 +1,11 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write;
 use std::ops::Bound;
 
 use indexmap::IndexSet;
 use itertools::Itertools;
+use jiff::Timestamp;
 use owo_colors::OwoColorize;
 use pubgrub::{DerivationTree, Derived, External, Map, Range, ReportFormatter, Term};
 use rustc_hash::FxHashMap;
@@ -30,9 +32,9 @@ use crate::resolver::{
     MetadataUnavailable, UnavailableErrorChain, UnavailablePackage, UnavailableReason,
     UnavailableVersion,
 };
-use crate::{
-    ExcludeNewerValue, Flexibility, InMemoryIndex, Options, ResolverEnvironment, VersionsResponse,
-};
+use crate::{Flexibility, InMemoryIndex, Options, ResolverEnvironment, VersionsResponse};
+
+type ReportDerived = Derived<PubGrubPackage, Range<Version>, UnavailableReason>;
 
 #[derive(Debug)]
 pub(crate) struct PubGrubReportFormatter<'a> {
@@ -50,6 +52,186 @@ pub(crate) struct PubGrubReportFormatter<'a> {
 
     /// The compatible tags for the resolution.
     pub(crate) tags: Option<&'a Tags>,
+}
+
+/// Render a PubGrub report without recursive tree traversal.
+///
+/// This preserves the output and shared-node reference behavior of
+/// [`pubgrub::DefaultStringReporter`], whose recursive entry point is private.
+pub(crate) fn report(
+    derivation_tree: &ErrorTree,
+    formatter: &PubGrubReportFormatter<'_>,
+) -> String {
+    match derivation_tree {
+        DerivationTree::External(external) => formatter.format_external(external),
+        DerivationTree::Derived(derived) => {
+            let mut reporter = IterativeReporter::default();
+            reporter.build(derived, formatter);
+            reporter.lines.join("\n")
+        }
+    }
+}
+
+/// Accumulates the report state used by [`report`].
+#[derive(Default)]
+struct IterativeReporter {
+    ref_count: usize,
+    shared_with_ref: Map<usize, usize>,
+    lines: Vec<String>,
+}
+
+impl IterativeReporter {
+    fn build(&mut self, root: &ReportDerived, formatter: &PubGrubReportFormatter<'_>) {
+        enum Task<'a> {
+            Build(&'a ReportDerived),
+            Finish(Option<usize>),
+            AfterFirstDerived {
+                current: &'a ReportDerived,
+                first: &'a ReportDerived,
+                second: &'a ReportDerived,
+            },
+            Emit(String),
+        }
+
+        let mut tasks = vec![Task::Build(root)];
+        while let Some(task) = tasks.pop() {
+            match task {
+                Task::Build(current) => {
+                    tasks.push(Task::Finish(current.shared_id));
+                    match (current.cause1.as_ref(), current.cause2.as_ref()) {
+                        (
+                            DerivationTree::External(external1),
+                            DerivationTree::External(external2),
+                        ) => {
+                            self.lines.push(formatter.explain_both_external(
+                                external1,
+                                external2,
+                                &current.terms,
+                            ));
+                        }
+                        (DerivationTree::Derived(derived), DerivationTree::External(external))
+                        | (DerivationTree::External(external), DerivationTree::Derived(derived)) => {
+                            if let Some(ref_id) = self.line_ref_of(derived.shared_id) {
+                                self.lines.push(formatter.explain_ref_and_external(
+                                    ref_id,
+                                    derived,
+                                    external,
+                                    &current.terms,
+                                ));
+                            } else {
+                                match (derived.cause1.as_ref(), derived.cause2.as_ref()) {
+                                    (
+                                        DerivationTree::Derived(prior_derived),
+                                        DerivationTree::External(prior_external),
+                                    )
+                                    | (
+                                        DerivationTree::External(prior_external),
+                                        DerivationTree::Derived(prior_derived),
+                                    ) => {
+                                        tasks.push(Task::Emit(
+                                            formatter.and_explain_prior_and_external(
+                                                prior_external,
+                                                external,
+                                                &current.terms,
+                                            ),
+                                        ));
+                                        tasks.push(Task::Build(prior_derived));
+                                    }
+                                    _ => {
+                                        tasks.push(Task::Emit(
+                                            formatter
+                                                .and_explain_external(external, &current.terms),
+                                        ));
+                                        tasks.push(Task::Build(derived));
+                                    }
+                                }
+                            }
+                        }
+                        (DerivationTree::Derived(derived1), DerivationTree::Derived(derived2)) => {
+                            match (
+                                self.line_ref_of(derived1.shared_id),
+                                self.line_ref_of(derived2.shared_id),
+                            ) {
+                                (Some(ref1), Some(ref2)) => {
+                                    self.lines.push(formatter.explain_both_ref(
+                                        ref1,
+                                        derived1,
+                                        ref2,
+                                        derived2,
+                                        &current.terms,
+                                    ));
+                                }
+                                (Some(ref1), None) => {
+                                    tasks.push(Task::Emit(formatter.and_explain_ref(
+                                        ref1,
+                                        derived1,
+                                        &current.terms,
+                                    )));
+                                    tasks.push(Task::Build(derived2));
+                                }
+                                (None, Some(ref2)) => {
+                                    tasks.push(Task::Emit(formatter.and_explain_ref(
+                                        ref2,
+                                        derived2,
+                                        &current.terms,
+                                    )));
+                                    tasks.push(Task::Build(derived1));
+                                }
+                                (None, None) => {
+                                    tasks.push(Task::AfterFirstDerived {
+                                        current,
+                                        first: derived1,
+                                        second: derived2,
+                                    });
+                                    tasks.push(Task::Build(derived1));
+                                }
+                            }
+                        }
+                    }
+                }
+                Task::Finish(shared_id) => {
+                    if let Some(shared_id) = shared_id
+                        && !self.shared_with_ref.contains_key(&shared_id)
+                    {
+                        self.add_line_ref();
+                        self.shared_with_ref.insert(shared_id, self.ref_count);
+                    }
+                }
+                Task::AfterFirstDerived {
+                    current,
+                    first,
+                    second,
+                } => {
+                    if first.shared_id.is_some() {
+                        self.lines.push(String::new());
+                        tasks.push(Task::Build(current));
+                    } else {
+                        let ref_id = self.add_line_ref();
+                        self.lines.push(String::new());
+                        tasks.push(Task::Emit(formatter.and_explain_ref(
+                            ref_id,
+                            first,
+                            &current.terms,
+                        )));
+                        tasks.push(Task::Build(second));
+                    }
+                }
+                Task::Emit(line) => self.lines.push(line),
+            }
+        }
+    }
+
+    fn add_line_ref(&mut self) -> usize {
+        self.ref_count += 1;
+        if let Some(line) = self.lines.last_mut() {
+            let _ = write!(line, " ({})", self.ref_count);
+        }
+        self.ref_count
+    }
+
+    fn line_ref_of(&self, shared_id: Option<usize>) -> Option<usize> {
+        shared_id.and_then(|id| self.shared_with_ref.get(&id).copied())
+    }
 }
 
 impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
@@ -126,7 +308,7 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                     match reason {
                         UnavailableReason::Package(reason) => {
                             let message = reason.singular_message();
-                            format!("{}{}", package, Padded::new(" ", &message, ""))
+                            format!("{}{}", package, padded(" ", &message, ""))
                         }
                         UnavailableReason::Version(reason) => {
                             let range = self.compatible_range(package, set);
@@ -140,9 +322,9 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                                 self.python_requirement.target().abi_tag(),
                             );
                             if let Some(context) = context {
-                                format!("{}{}{}", range, Padded::new(" ", &message, " "), context)
+                                format!("{}{}{}", range, padded(" ", &message, " "), context)
                             } else {
-                                format!("{}{}", range, Padded::new(" ", &message, ""))
+                                format!("{}{}", range, padded(" ", &message, ""))
                             }
                         }
                     }
@@ -178,7 +360,7 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
         let mut terms_vec: Vec<_> = terms.iter().collect();
         // We avoid relying on hashmap iteration order here by always sorting
         // by package first.
-        terms_vec.sort_by(|&(pkg1, _), &(pkg2, _)| pkg1.cmp(pkg2));
+        terms_vec.sort_by_key(|&(package, _)| package);
         match terms_vec.as_slice() {
             [] => "the requirements are unsatisfiable".into(),
             [(root, _)] if matches!(&**(*root), PubGrubPackageInner::Root(_)) => {
@@ -245,8 +427,8 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
 
         format!(
             "Because {}we can conclude that {}",
-            Padded::from_string("", &external, ", "),
-            Padded::from_string("", &terms, "."),
+            padded("", &external, ", "),
+            padded("", &terms, "."),
         )
     }
 
@@ -268,10 +450,10 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
         format!(
             "Because we know from ({}) that {}and we know from ({}) that {}{}",
             ref_id1,
-            Padded::new("", &derived1_terms, " "),
+            padded("", &derived1_terms, " "),
             ref_id2,
-            Padded::new("", &derived2_terms, ", "),
-            Padded::new("", &current_terms, "."),
+            padded("", &derived2_terms, ", "),
+            padded("", &current_terms, "."),
         )
     }
 
@@ -294,9 +476,9 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
         format!(
             "Because we know from ({}) that {}and {}we can conclude that {}",
             ref_id,
-            Padded::new("", &derived_terms, " "),
-            Padded::new("", &external, ", "),
-            Padded::new("", &current_terms, "."),
+            padded("", &derived_terms, " "),
+            padded("", &external, ", "),
+            padded("", &current_terms, "."),
         )
     }
 
@@ -311,8 +493,8 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
 
         format!(
             "And because {}we can conclude that {}",
-            Padded::from_string("", &external, ", "),
-            Padded::from_string("", &terms, "."),
+            padded("", &external, ", "),
+            padded("", &terms, "."),
         )
     }
 
@@ -329,8 +511,8 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
         format!(
             "And because we know from ({}) that {}we can conclude that {}",
             ref_id,
-            Padded::from_string("", &derived, ", "),
-            Padded::from_string("", &current, "."),
+            padded("", &derived, ", "),
+            padded("", &current, "."),
         )
     }
 
@@ -346,8 +528,8 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
 
         format!(
             "And because {}we can conclude that {}",
-            Padded::from_string("", &external, ", "),
-            Padded::from_string("", &terms, "."),
+            padded("", &external, ", "),
+            padded("", &terms, "."),
         )
     }
 }
@@ -488,7 +670,7 @@ impl PubGrubReportFormatter<'_> {
                 if let Some(root) = self.format_root_requires(package1) {
                     return format!(
                         "{root} {}and {}",
-                        Padded::new("", &dependency1, " "),
+                        padded("", &dependency1, " "),
                         dependency2,
                     );
                 }
@@ -516,11 +698,7 @@ impl PubGrubReportFormatter<'_> {
                 let external1 = self.format_external(external1);
                 let external2 = self.format_external(external2);
 
-                format!(
-                    "{}and {}",
-                    Padded::from_string("", &external1, " "),
-                    &external2,
-                )
+                format!("{}and {}", padded("", &external1, " "), &external2)
             }
         }
     }
@@ -567,252 +745,223 @@ impl PubGrubReportFormatter<'_> {
             }
         }
 
-        match derivation_tree {
-            DerivationTree::External(External::Custom(package, set, reason)) => {
-                if let Some(name) = package.name_no_root() {
-                    // Check for no versions due to pre-release options.
-                    if !fork_urls.contains_key(name) {
-                        self.prerelease_hint(name, set, selector, env, options, output_hints);
-                    }
+        let mut pending = vec![(derivation_tree, inherited_exclude_newer_ranges.clone())];
+        while let Some((derivation_tree, inherited_exclude_newer_ranges)) = pending.pop() {
+            match derivation_tree {
+                DerivationTree::External(External::Custom(package, set, reason)) => {
+                    if let Some(name) = package.name_no_root() {
+                        // Check for no versions due to pre-release options.
+                        if !fork_urls.contains_key(name) {
+                            self.prerelease_hint(name, set, selector, env, options, output_hints);
+                        }
 
-                    // Check for no versions due to no `--find-links` flat index.
-                    Self::index_hints(
-                        name,
-                        set,
-                        selector,
-                        index_locations,
-                        index_capabilities,
-                        available_indexes,
-                        unavailable_packages,
-                        incomplete_packages,
-                        output_hints,
-                    );
+                        // Check for no versions due to no `--find-links` flat index.
+                        Self::index_hints(
+                            name,
+                            set,
+                            selector,
+                            index_locations,
+                            index_capabilities,
+                            available_indexes,
+                            unavailable_packages,
+                            incomplete_packages,
+                            output_hints,
+                        );
 
-                    if let UnavailableReason::Version(UnavailableVersion::IncompatibleDist(
-                        incompatibility,
-                    )) = reason
-                    {
-                        match incompatibility {
-                            // Check for unavailable versions due to `--no-build` or `--no-binary`.
-                            IncompatibleDist::Wheel(IncompatibleWheel::NoBinary) => {
-                                output_hints.insert(PubGrubHint::NoBinary {
-                                    package: name.clone(),
-                                    option: options.build_options.no_binary().clone(),
-                                });
-                            }
-                            IncompatibleDist::Source(IncompatibleSource::NoBuild) => {
-                                output_hints.insert(PubGrubHint::NoBuild {
-                                    package: name.clone(),
-                                    option: options.build_options.no_build().clone(),
-                                });
-                            }
-                            // Check for unavailable versions due to incompatible tags.
-                            IncompatibleDist::Wheel(IncompatibleWheel::Tag(tag)) => {
-                                if let Some(hint) = self.tag_hint(
-                                    name,
-                                    set,
-                                    *tag,
-                                    index,
-                                    selector,
-                                    fork_indexes,
-                                    env,
-                                    tags,
-                                ) {
-                                    output_hints.insert(hint);
+                        if let UnavailableReason::Version(UnavailableVersion::IncompatibleDist(
+                            incompatibility,
+                        )) = reason
+                        {
+                            match incompatibility {
+                                // Check for unavailable versions due to `--no-build` or `--no-binary`.
+                                IncompatibleDist::Wheel(IncompatibleWheel::NoBinary) => {
+                                    output_hints.insert(PubGrubHint::NoBinary {
+                                        package: name.clone(),
+                                        option: options.build_options.no_binary().clone(),
+                                    });
                                 }
+                                IncompatibleDist::Source(IncompatibleSource::NoBuild) => {
+                                    output_hints.insert(PubGrubHint::NoBuild {
+                                        package: name.clone(),
+                                        option: options.build_options.no_build().clone(),
+                                    });
+                                }
+                                // Check for unavailable versions due to incompatible tags.
+                                IncompatibleDist::Wheel(IncompatibleWheel::Tag(tag)) => {
+                                    if let Some(hint) = self.tag_hint(
+                                        name,
+                                        set,
+                                        *tag,
+                                        index,
+                                        selector,
+                                        fork_indexes,
+                                        env,
+                                        tags,
+                                    ) {
+                                        output_hints.insert(hint);
+                                    }
+                                }
+                                _ => {}
                             }
-                            _ => {}
                         }
                     }
                 }
-            }
-            DerivationTree::External(External::NoVersions(package, set)) => {
-                if let Some(name) = package.name_no_root() {
-                    // Check for no versions due to pre-release options.
-                    if !fork_urls.contains_key(name) {
-                        self.prerelease_hint(name, set, selector, env, options, output_hints);
-                    }
+                DerivationTree::External(External::NoVersions(package, set)) => {
+                    if let Some(name) = package.name_no_root() {
+                        // Check for no versions due to pre-release options.
+                        if !fork_urls.contains_key(name) {
+                            self.prerelease_hint(name, set, selector, env, options, output_hints);
+                        }
 
-                    // Check for no versions due to no `--find-links` flat index.
-                    Self::index_hints(
-                        name,
-                        set,
-                        selector,
-                        index_locations,
-                        index_capabilities,
-                        available_indexes,
-                        unavailable_packages,
-                        incomplete_packages,
-                        output_hints,
-                    );
+                        // Check for no versions due to no `--find-links` flat index.
+                        Self::index_hints(
+                            name,
+                            set,
+                            selector,
+                            index_locations,
+                            index_capabilities,
+                            available_indexes,
+                            unavailable_packages,
+                            incomplete_packages,
+                            output_hints,
+                        );
 
-                    let exclude_newer = if let Some(index) = fork_indexes.get(name) {
-                        options
-                            .exclude_newer
-                            .exclude_newer_package_for_index_with_source(
-                                name,
-                                index_locations.exclude_newer_for(index.url()),
-                            )
-                    } else {
-                        options
-                            .exclude_newer
-                            .exclude_newer_package(name)
-                            .map(|exclude_newer| {
-                                let source = if options.exclude_newer.package.contains_key(name) {
-                                    EffectiveExcludeNewerSource::Package
-                                } else {
-                                    EffectiveExcludeNewerSource::Global
-                                };
-                                (exclude_newer, source)
-                            })
-                    };
+                        let exclude_newer = if let Some(index) = fork_indexes.get(name) {
+                            options
+                                .exclude_newer
+                                .exclude_newer_package_for_index_with_source(
+                                    name,
+                                    index_locations.exclude_newer_for(index.url()),
+                                )
+                        } else {
+                            options
+                                .exclude_newer
+                                .exclude_newer_package(name)
+                                .map(|exclude_newer| {
+                                    let source = if options.exclude_newer.package.contains_key(name)
+                                    {
+                                        EffectiveExcludeNewerSource::Package
+                                    } else {
+                                        EffectiveExcludeNewerSource::Global
+                                    };
+                                    (exclude_newer, source)
+                                })
+                        };
 
-                    if let Some((exclude_newer, source)) = exclude_newer {
-                        // Check if there are no included versions in the requested range, but
-                        // there are still available versions in that range (i.e., they were
-                        // filtered out by `exclude-newer`).
-                        let no_included_in_set = self
-                            .included_versions
-                            .get(name)
-                            .is_none_or(|versions| !versions.iter().any(|v| set.contains(v)));
-                        let available_has_versions_in_set = self
-                            .available_versions
-                            .get(name)
-                            .is_some_and(|versions| versions.iter().any(|v| set.contains(v)));
-                        if no_included_in_set && available_has_versions_in_set {
-                            let version_hint_set =
-                                inherited_exclude_newer_ranges.get(name).map_or_else(
-                                    || set.clone(),
-                                    |exclude_newer_range| set.union(exclude_newer_range),
+                        if let Some((exclude_newer, source)) = exclude_newer {
+                            // Check if there are no included versions in the requested
+                            // range, but there are still available versions in that range
+                            // (i.e., they were filtered out by `exclude-newer`).
+                            let no_included_in_set = self
+                                .included_versions
+                                .get(name)
+                                .is_none_or(|versions| !versions.iter().any(|v| set.contains(v)));
+                            let available_has_versions_in_set = self
+                                .available_versions
+                                .get(name)
+                                .is_some_and(|versions| versions.iter().any(|v| set.contains(v)));
+                            if no_included_in_set && available_has_versions_in_set {
+                                let version_hint_set =
+                                    inherited_exclude_newer_ranges.get(name).map_or_else(
+                                        || set.clone(),
+                                        |exclude_newer_range| set.union(exclude_newer_range),
+                                    );
+                                let matching_version = self.exclude_newer_version_hint(
+                                    name,
+                                    &version_hint_set,
+                                    index,
+                                    fork_indexes,
                                 );
-                            let matching_version = self.exclude_newer_version_hint(
-                                name,
-                                &version_hint_set,
-                                index,
-                                fork_indexes,
-                            );
-                            output_hints.insert(PubGrubHint::ExcludeNewer {
-                                package: name.clone(),
-                                source,
-                                exclude_newer,
-                                matching_version,
+                                output_hints.insert(PubGrubHint::ExcludeNewer {
+                                    package: name.clone(),
+                                    source,
+                                    exclude_newer: exclude_newer.timestamp(),
+                                    matching_version,
+                                });
+                            }
+                        }
+                    }
+                }
+                DerivationTree::External(External::FromDependencyOf(
+                    package,
+                    package_set,
+                    dependency,
+                    dependency_set,
+                )) => {
+                    // Check for a dependency on a workspace package by a non-workspace package.
+                    // Generally, this indicates that the workspace package is shadowing a transitive
+                    // dependency name.
+                    if let (Some(package_name), Some(dependency_name)) =
+                        (package.name(), dependency.name())
+                    {
+                        if workspace_members.contains(dependency_name)
+                            && !workspace_members.contains(package_name)
+                        {
+                            output_hints.insert(PubGrubHint::DependsOnWorkspacePackage {
+                                package: package_name.clone(),
+                                dependency: dependency_name.clone(),
+                                workspace: self.is_workspace()
+                                    && !self.is_single_project_workspace(),
+                            });
+                        }
+
+                        if package_name == dependency_name
+                            && (dependency.extra().is_none()
+                                || package.extra() == dependency.extra())
+                            && (dependency.group().is_none()
+                                || dependency.group() == package.group())
+                            && workspace_members.contains(package_name)
+                        {
+                            output_hints.insert(PubGrubHint::DependsOnItself {
+                                package: package_name.clone(),
+                                workspace: self.is_workspace()
+                                    && !self.is_single_project_workspace(),
+                            });
+                        }
+                    }
+                    // Check for no versions due to `Requires-Python`.
+                    if matches!(
+                        &**dependency,
+                        PubGrubPackageInner::Python(PubGrubPython::Target)
+                    ) {
+                        if let Some(name) = package.name() {
+                            output_hints.insert(PubGrubHint::RequiresPython {
+                                source: self.python_requirement.source(),
+                                requires_python: self.python_requirement.target().clone(),
+                                name: name.clone(),
+                                package_set: package_set.clone(),
+                                package_requires_python: dependency_set.clone(),
                             });
                         }
                     }
                 }
-            }
-            DerivationTree::External(External::FromDependencyOf(
-                package,
-                package_set,
-                dependency,
-                dependency_set,
-            )) => {
-                // Check for a dependency on a workspace package by a non-workspace package.
-                // Generally, this indicates that the workspace package is shadowing a transitive
-                // dependency name.
-                if let (Some(package_name), Some(dependency_name)) =
-                    (package.name(), dependency.name())
-                {
-                    if workspace_members.contains(dependency_name)
-                        && !workspace_members.contains(package_name)
-                    {
-                        output_hints.insert(PubGrubHint::DependsOnWorkspacePackage {
-                            package: package_name.clone(),
-                            dependency: dependency_name.clone(),
-                            workspace: self.is_workspace() && !self.is_single_project_workspace(),
-                        });
+                DerivationTree::External(External::NotRoot(..)) => {}
+                DerivationTree::Derived(derived) => {
+                    let cause1_exclude_newer_ranges =
+                        Self::subtree_exclude_newer_ranges(&derived.cause1);
+                    let cause2_exclude_newer_ranges =
+                        Self::subtree_exclude_newer_ranges(&derived.cause2);
+
+                    let mut cause1_inherited_exclude_newer_ranges =
+                        inherited_exclude_newer_ranges.clone();
+                    for (name, range) in &cause2_exclude_newer_ranges {
+                        cause1_inherited_exclude_newer_ranges
+                            .entry(name.clone())
+                            .and_modify(|existing| *existing = existing.union(range))
+                            .or_insert_with(|| range.clone());
                     }
 
-                    if package_name == dependency_name
-                        && (dependency.extra().is_none() || package.extra() == dependency.extra())
-                        && (dependency.group().is_none() || dependency.group() == package.group())
-                        && workspace_members.contains(package_name)
-                    {
-                        output_hints.insert(PubGrubHint::DependsOnItself {
-                            package: package_name.clone(),
-                            workspace: self.is_workspace() && !self.is_single_project_workspace(),
-                        });
+                    let mut cause2_inherited_exclude_newer_ranges = inherited_exclude_newer_ranges;
+                    for (name, range) in &cause1_exclude_newer_ranges {
+                        cause2_inherited_exclude_newer_ranges
+                            .entry(name.clone())
+                            .and_modify(|existing| *existing = existing.union(range))
+                            .or_insert_with(|| range.clone());
                     }
-                }
-                // Check for no versions due to `Requires-Python`.
-                if matches!(
-                    &**dependency,
-                    PubGrubPackageInner::Python(PubGrubPython::Target)
-                ) {
-                    if let Some(name) = package.name() {
-                        output_hints.insert(PubGrubHint::RequiresPython {
-                            source: self.python_requirement.source(),
-                            requires_python: self.python_requirement.target().clone(),
-                            name: name.clone(),
-                            package_set: package_set.clone(),
-                            package_requires_python: dependency_set.clone(),
-                        });
-                    }
-                }
-            }
-            DerivationTree::External(External::NotRoot(..)) => {}
-            DerivationTree::Derived(derived) => {
-                let cause1_exclude_newer_ranges =
-                    Self::subtree_exclude_newer_ranges(&derived.cause1);
-                let cause2_exclude_newer_ranges =
-                    Self::subtree_exclude_newer_ranges(&derived.cause2);
 
-                let mut cause1_inherited_exclude_newer_ranges =
-                    inherited_exclude_newer_ranges.clone();
-                for (name, range) in &cause2_exclude_newer_ranges {
-                    cause1_inherited_exclude_newer_ranges
-                        .entry(name.clone())
-                        .and_modify(|existing| *existing = existing.union(range))
-                        .or_insert_with(|| range.clone());
+                    pending.push((&derived.cause2, cause2_inherited_exclude_newer_ranges));
+                    pending.push((&derived.cause1, cause1_inherited_exclude_newer_ranges));
                 }
-
-                let mut cause2_inherited_exclude_newer_ranges =
-                    inherited_exclude_newer_ranges.clone();
-                for (name, range) in &cause1_exclude_newer_ranges {
-                    cause2_inherited_exclude_newer_ranges
-                        .entry(name.clone())
-                        .and_modify(|existing| *existing = existing.union(range))
-                        .or_insert_with(|| range.clone());
-                }
-
-                self.generate_hints(
-                    &derived.cause1,
-                    index,
-                    selector,
-                    index_locations,
-                    index_capabilities,
-                    available_indexes,
-                    unavailable_packages,
-                    incomplete_packages,
-                    fork_urls,
-                    fork_indexes,
-                    env,
-                    current_environment,
-                    tags,
-                    workspace_members,
-                    options,
-                    &cause1_inherited_exclude_newer_ranges,
-                    output_hints,
-                );
-                self.generate_hints(
-                    &derived.cause2,
-                    index,
-                    selector,
-                    index_locations,
-                    index_capabilities,
-                    available_indexes,
-                    unavailable_packages,
-                    incomplete_packages,
-                    fork_urls,
-                    fork_indexes,
-                    env,
-                    current_environment,
-                    tags,
-                    workspace_members,
-                    options,
-                    &cause2_inherited_exclude_newer_ranges,
-                    output_hints,
-                );
             }
         }
     }
@@ -822,10 +971,9 @@ impl PubGrubReportFormatter<'_> {
     fn subtree_exclude_newer_ranges(
         derivation_tree: &ErrorTree,
     ) -> FxHashMap<PackageName, Range<Version>> {
-        fn collect(
-            derivation_tree: &ErrorTree,
-            exclude_newer_ranges: &mut FxHashMap<PackageName, Range<Version>>,
-        ) {
+        let mut exclude_newer_ranges: FxHashMap<PackageName, Range<Version>> = FxHashMap::default();
+        let mut trees = vec![derivation_tree];
+        while let Some(derivation_tree) = trees.pop() {
             match derivation_tree {
                 DerivationTree::External(External::Custom(package, versions, reason)) => {
                     if matches!(
@@ -845,14 +993,11 @@ impl PubGrubReportFormatter<'_> {
                 }
                 DerivationTree::External(_) => {}
                 DerivationTree::Derived(derived) => {
-                    collect(&derived.cause1, exclude_newer_ranges);
-                    collect(&derived.cause2, exclude_newer_ranges);
+                    trees.push(&derived.cause2);
+                    trees.push(&derived.cause1);
                 }
             }
         }
-
-        let mut exclude_newer_ranges = FxHashMap::default();
-        collect(derivation_tree, &mut exclude_newer_ranges);
         exclude_newer_ranges
     }
 
@@ -1021,11 +1166,10 @@ impl PubGrubReportFormatter<'_> {
 
         // Add hints due to the package being entirely unavailable.
         match unavailable_packages.get(name) {
-            Some(UnavailablePackage::NoIndex) => {
-                if no_find_links {
-                    hints.insert(PubGrubHint::NoIndex);
-                }
+            Some(UnavailablePackage::NoIndex) if no_find_links => {
+                hints.insert(PubGrubHint::NoIndex);
             }
+            Some(UnavailablePackage::NoIndex) => {}
             Some(UnavailablePackage::Offline) => {
                 hints.insert(PubGrubHint::Offline);
             }
@@ -1128,6 +1272,9 @@ impl PubGrubReportFormatter<'_> {
             if index_capabilities.forbidden(&index.url) {
                 hints.insert(PubGrubHint::ForbiddenIndex {
                     index: index.url.clone(),
+                    any_successful_response: available_indexes
+                        .values()
+                        .any(|indexes| indexes.contains(&index.url)),
                 });
             }
         }
@@ -1217,24 +1364,23 @@ impl PubGrubReportFormatter<'_> {
     }
 }
 
-/// Return `true` if the version is the upper bound of a compatible release specifier.
+/// Return `true` for the excluded `.dev0` upper bounds used to desugar compatible releases.
 ///
-/// Compatible release specifiers use a development release lower bound for the exclusive upper
-/// bound (e.g., `~=2.0` is equivalent to `>=2.0,<3.dev0`). These bounds shouldn't be treated as
-/// explicit pre-release requests.
+/// For example, `~=3.6` becomes `>=3.6,<4.dev0`. The `<4.dev0` boundary preserves PEP 440's
+/// ordering semantics, but it does not mean the user requested pre-releases.
 fn is_compatible_release_upper_bound(version: &Version) -> bool {
     version.dev() == Some(0) && !version.is_pre() && !version.is_post() && !version.is_local()
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ExcludeNewerVersionDetail {
+pub struct ExcludeNewerVersionDetail {
     version: Version,
     publish_date: Option<String>,
     singleton: bool,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum PubGrubHint {
+pub enum PubGrubHint {
     /// There are pre-release versions available for a package, but pre-releases weren't enabled
     /// for that package.
     ///
@@ -1367,7 +1513,11 @@ pub(crate) enum PubGrubHint {
     /// An index returned an Unauthorized (401) response.
     UnauthorizedIndex { index: IndexUrl },
     /// An index returned a Forbidden (403) response.
-    ForbiddenIndex { index: IndexUrl },
+    ForbiddenIndex {
+        index: IndexUrl,
+        // excluded from `PartialEq` and `Hash`
+        any_successful_response: bool,
+    },
     /// None of the available wheels for a package have a compatible Python language tag (e.g.,
     /// `cp310` in `cp310-abi3-manylinux_2_17_x86_64.whl`).
     LanguageTags {
@@ -1399,12 +1549,12 @@ pub(crate) enum PubGrubHint {
         // excluded from `PartialEq` and `Hash`
         tags: BTreeSet<PlatformTag>,
     },
-    /// All versions of a package were excluded by `exclude-newer`.
+    /// Versions of a package were excluded by `exclude-newer`.
     ExcludeNewer {
         package: PackageName,
         source: EffectiveExcludeNewerSource,
         // excluded from `PartialEq` and `Hash`
-        exclude_newer: ExcludeNewerValue,
+        exclude_newer: Timestamp,
         // excluded from `PartialEq` and `Hash`
         matching_version: Option<ExcludeNewerVersionDetail>,
     },
@@ -1557,7 +1707,7 @@ impl From<PubGrubHint> for PubGrubHintCore {
             }
             PubGrubHint::UncheckedIndex { name: package, .. } => Self::UncheckedIndex { package },
             PubGrubHint::UnauthorizedIndex { index } => Self::UnauthorizedIndex { index },
-            PubGrubHint::ForbiddenIndex { index } => Self::ForbiddenIndex { index },
+            PubGrubHint::ForbiddenIndex { index, .. } => Self::ForbiddenIndex { index },
             PubGrubHint::NoBuild { package, .. } => Self::NoBuild { package },
             PubGrubHint::NoBinary { package, .. } => Self::NoBinary { package },
             PubGrubHint::LanguageTags { package, .. } => Self::LanguageTags { package },
@@ -1595,9 +1745,7 @@ impl std::fmt::Display for PubGrubHint {
             Self::PrereleaseAvailable { package, version } => {
                 write!(
                     f,
-                    "{}{} Pre-releases are available for `{}` in the requested range (e.g., {}), but pre-releases weren't enabled (try: `{}`)",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Pre-releases are available for `{}` in the requested range (e.g., {}), but pre-releases weren't enabled (try: `{}`)",
                     package.cyan(),
                     version.cyan(),
                     "--prerelease=allow".green(),
@@ -1607,9 +1755,7 @@ impl std::fmt::Display for PubGrubHint {
                 let spec = format!("{package}>={version}");
                 write!(
                     f,
-                    "{}{} Only pre-releases of `{}` (e.g., {}) match these build requirements, and build environments can't enable pre-releases automatically. Add `{}` to `build-system.requires`, `[tool.fyn.extra-build-dependencies]`, or supply it via `fyn build --build-constraint`.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Only pre-releases of `{}` (e.g., {}) match these build requirements, and build environments can't enable pre-releases automatically. Add `{}` to `build-system.requires`, `[tool.fyn.extra-build-dependencies]`, or supply it via `fyn build --build-constraint`.",
                     package.cyan(),
                     version.cyan(),
                     spec.cyan(),
@@ -1618,9 +1764,7 @@ impl std::fmt::Display for PubGrubHint {
             Self::PrereleaseRequested { name, range } => {
                 write!(
                     f,
-                    "{}{} `{}` was requested with a pre-release marker (e.g., {}), but pre-releases weren't enabled (try: `{}`)",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "`{}` was requested with a pre-release marker (e.g., {}), but pre-releases weren't enabled (try: `{}`)",
                     name.cyan(),
                     PackageRange::compatibility(&PubGrubPackage::base(name), range, None).cyan(),
                     "--prerelease=allow".green(),
@@ -1629,9 +1773,7 @@ impl std::fmt::Display for PubGrubHint {
             Self::BuildPrereleaseRequested { name, range } => {
                 write!(
                     f,
-                    "{}{} `{}` was requested with a pre-release marker (e.g., {}), but build environments can't opt into pre-releases automatically.  Add `{}` to `build-system.requires`, `[tool.fyn.extra-build-dependencies]`, or supply it via `fyn build --build-constraint`.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "`{}` was requested with a pre-release marker (e.g., {}), but build environments can't opt into pre-releases automatically.  Add `{}` to `build-system.requires`, `[tool.fyn.extra-build-dependencies]`, or supply it via `fyn build --build-constraint`.",
                     name.cyan(),
                     PackageRange::compatibility(&PubGrubPackage::base(name), range, None).cyan(),
                     PackageRange::compatibility(&PubGrubPackage::base(name), range, None).cyan(),
@@ -1640,26 +1782,20 @@ impl std::fmt::Display for PubGrubHint {
             Self::NoIndex => {
                 write!(
                     f,
-                    "{}{} Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `{}`)",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Packages were unavailable because index lookups were disabled and no additional package locations were provided (try: `{}`)",
                     "--find-links <uri>".green(),
                 )
             }
             Self::Offline => {
                 write!(
                     f,
-                    "{}{} Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Packages were unavailable because the network was disabled. When the network is disabled, registry packages may only be read from the cache.",
                 )
             }
             Self::InvalidPackageMetadata { package, reason } => {
                 write!(
                     f,
-                    "{}{} Metadata for `{}` could not be parsed.\n{}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Metadata for `{}` could not be parsed.\n{}",
                     package.cyan(),
                     textwrap::indent(reason.to_string().as_str(), "  ")
                 )
@@ -1667,9 +1803,7 @@ impl std::fmt::Display for PubGrubHint {
             Self::InvalidPackageStructure { package, reason } => {
                 write!(
                     f,
-                    "{}{} The structure of `{}` was invalid\n{}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The structure of `{}` was invalid\n{}",
                     package.cyan(),
                     textwrap::indent(reason.to_string().as_str(), "  ")
                 )
@@ -1681,9 +1815,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} Metadata for `{}` ({}) could not be parsed:\n{}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Metadata for `{}` ({}) could not be parsed:\n{}",
                     package.cyan(),
                     format!("v{version}").cyan(),
                     textwrap::indent(reason, "  ")
@@ -1696,9 +1828,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} The structure of `{}` ({}) was invalid:\n{}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The structure of `{}` ({}) was invalid:\n{}",
                     package.cyan(),
                     format!("v{version}").cyan(),
                     textwrap::indent(reason, "  ")
@@ -1711,9 +1841,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} Metadata for `{}` ({}) was inconsistent:\n{}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Metadata for `{}` ({}) was inconsistent:\n{}",
                     package.cyan(),
                     format!("v{version}").cyan(),
                     textwrap::indent(reason, "  ")
@@ -1728,9 +1856,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} The `requires-python` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a more restrictive `requires-python` value (like {}).",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The `requires-python` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a more restrictive `requires-python` value (like {}).",
                     requires_python.cyan(),
                     PackageRange::compatibility(&PubGrubPackage::base(name), package_set, None)
                         .cyan(),
@@ -1747,9 +1873,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} The `--python-version` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a higher `--python-version` value.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The `--python-version` value ({}) includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a higher `--python-version` value.",
                     requires_python.cyan(),
                     PackageRange::compatibility(&PubGrubPackage::base(name), package_set, None)
                         .cyan(),
@@ -1765,9 +1889,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} The Python interpreter uses a Python version that is not supported by your dependencies (e.g., {} only supports {}). Consider passing a `--python-version` value to raise the minimum supported version.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The Python interpreter uses a Python version that is not supported by your dependencies (e.g., {} only supports {}). Consider passing a `--python-version` value to raise the minimum supported version.",
                     PackageRange::compatibility(&PubGrubPackage::base(name), package_set, None)
                         .cyan(),
                     package_requires_python.cyan(),
@@ -1781,9 +1903,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} The source distribution for `{}` ({}) does not include static metadata. Generating metadata for this package requires Python {}, but Python {} is installed.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The source distribution for `{}` ({}) does not include static metadata. Generating metadata for this package requires Python {}, but Python {} is installed.",
                     package.cyan(),
                     format!("v{version}").cyan(),
                     requires_python.cyan(),
@@ -1807,9 +1927,7 @@ impl std::fmt::Display for PubGrubHint {
                 };
                 write!(
                     f,
-                    "{}{} The package `{}` depends on the package `{}` but the name is shadowed by {your_project}. Consider changing the name of {the_project}.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The package `{}` depends on the package `{}` but the name is shadowed by {your_project}. Consider changing the name of {the_project}.",
                     package.cyan(),
                     dependency.cyan(),
                 )
@@ -1822,9 +1940,7 @@ impl std::fmt::Display for PubGrubHint {
                 };
                 write!(
                     f,
-                    "{}{} The {project} `{}` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `{}`, consider renaming the {project} `{}` to avoid creating a conflict.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "The {project} `{}` depends on itself at an incompatible version. This is likely a mistake. If you intended to depend on a third-party package named `{}`, consider renaming the {project} `{}` to avoid creating a conflict.",
                     package.cyan(),
                     package.cyan(),
                     package.cyan(),
@@ -1838,9 +1954,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} `{}` was found on {}, but not at the requested version ({}). A compatible version may be available on a subsequent index (e.g., {}). By default, fyn will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `{}` to consider all versions from all indexes, regardless of the order in which they were defined.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "`{}` was found on {}, but not at the requested version ({}). A compatible version may be available on a subsequent index (e.g., {}). By default, fyn will only consider versions that are published on the first index that contains a given package, to avoid dependency confusion attacks. If all indexes are equally trusted, use `{}` to consider all versions from all indexes, regardless of the order in which they were defined.",
                     name.cyan(),
                     found_index.without_credentials().cyan(),
                     PackageRange::compatibility(&PubGrubPackage::base(name), range, None).cyan(),
@@ -1851,22 +1965,30 @@ impl std::fmt::Display for PubGrubHint {
             Self::UnauthorizedIndex { index } => {
                 write!(
                     f,
-                    "{}{} An index URL ({}) could not be queried due to a lack of valid authentication credentials ({}).",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "An index URL ({}) could not be queried due to a lack of valid authentication credentials ({})",
                     index.without_credentials().cyan(),
                     "401 Unauthorized".red(),
                 )
             }
-            Self::ForbiddenIndex { index } => {
-                write!(
-                    f,
-                    "{}{} An index URL ({}) returned a {} error. This could indicate lack of valid authentication credentials, or the package may not exist on this index.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
-                    index.without_credentials().cyan(),
-                    "403 Forbidden".red(),
-                )
+            Self::ForbiddenIndex {
+                index,
+                any_successful_response,
+            } => {
+                if *any_successful_response {
+                    write!(
+                        f,
+                        "An index ({}) returned a {} error, but uv received a successful response from another request to the index. If the failing package is not present on this index, consider adding `ignore-error-codes = [403]` to the index's `[[tool.fyn.index]]` entry to continue searching across indexes.",
+                        index.without_credentials().cyan(),
+                        "403 Forbidden".red(),
+                    )
+                } else {
+                    write!(
+                        f,
+                        "An index ({}) returned a {} error. Check that the index URL is correct and the credentials are valid.",
+                        index.without_credentials().cyan(),
+                        "403 Forbidden".red(),
+                    )
+                }
             }
             Self::NoBuild { package, option } => {
                 let option = match option {
@@ -1878,9 +2000,7 @@ impl std::fmt::Display for PubGrubHint {
                 };
                 write!(
                     f,
-                    "{}{} Wheels are required for `{}` because building from source is disabled {option}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Wheels are required for `{}` because building from source is disabled {option}",
                     package.cyan(),
                 )
             }
@@ -1894,9 +2014,7 @@ impl std::fmt::Display for PubGrubHint {
                 };
                 write!(
                     f,
-                    "{}{} A source distribution is required for `{}` because using pre-built wheels is disabled {option}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "A source distribution is required for `{}` because using pre-built wheels is disabled {option}",
                     package.cyan(),
                 )
             }
@@ -1915,9 +2033,7 @@ impl std::fmt::Display for PubGrubHint {
                     };
                     write!(
                         f,
-                        "{}{} You require {}, but we only found wheels for `{}` ({}) with the following Python implementation tag{s}: {}",
-                        "hint".bold().cyan(),
-                        ":".bold(),
+                        "You require {}, but we only found wheels for `{}` ({}) with the following Python implementation tag{s}: {}",
                         best,
                         package.cyan(),
                         format!("v{version}").cyan(),
@@ -1929,9 +2045,7 @@ impl std::fmt::Display for PubGrubHint {
                     let s = if tags.len() == 1 { "" } else { "s" };
                     write!(
                         f,
-                        "{}{} Wheels are available for `{}` ({}) with the following Python implementation tag{s}: {}",
-                        "hint".bold().cyan(),
-                        ":".bold(),
+                        "Wheels are available for `{}` ({}) with the following Python implementation tag{s}: {}",
                         package.cyan(),
                         format!("v{version}").cyan(),
                         tags.iter()
@@ -1955,9 +2069,7 @@ impl std::fmt::Display for PubGrubHint {
                     };
                     write!(
                         f,
-                        "{}{} You require {}, but we only found wheels for `{}` ({}) with the following Python ABI tag{s}: {}",
-                        "hint".bold().cyan(),
-                        ":".bold(),
+                        "You require {}, but we only found wheels for `{}` ({}) with the following Python ABI tag{s}: {}",
                         best,
                         package.cyan(),
                         format!("v{version}").cyan(),
@@ -1969,9 +2081,7 @@ impl std::fmt::Display for PubGrubHint {
                     let s = if tags.len() == 1 { "" } else { "s" };
                     write!(
                         f,
-                        "{}{} Wheels are available for `{}` ({}) with the following Python ABI tag{s}: {}",
-                        "hint".bold().cyan(),
-                        ":".bold(),
+                        "Wheels are available for `{}` ({}) with the following Python ABI tag{s}: {}",
                         package.cyan(),
                         format!("v{version}").cyan(),
                         tags.iter()
@@ -1988,9 +2098,7 @@ impl std::fmt::Display for PubGrubHint {
                 let s = if tags.len() == 1 { "" } else { "s" };
                 write!(
                     f,
-                    "{}{} Wheels are available for `{}` ({}) on the following platform{s}: {}",
-                    "hint".bold().cyan(),
-                    ":".bold(),
+                    "Wheels are available for `{}` ({}) on the following platform{s}: {}",
                     package.cyan(),
                     format!("v{version}").cyan(),
                     tags.iter()
@@ -2041,20 +2149,16 @@ impl std::fmt::Display for PubGrubHint {
                 match source {
                     EffectiveExcludeNewerSource::Package => write!(
                         f,
-                        "{}{} `{}` was filtered by `{}` to only include packages uploaded \
+                        "`{}` was filtered by `{}` to only include packages uploaded \
                         before {}.{latest} Consider removing the setting or updating it to a later date.",
-                        "hint".bold().cyan(),
-                        ":".bold(),
                         package.cyan(),
                         "exclude-newer-package".green(),
                         exclude_newer.cyan(),
                     ),
                     EffectiveExcludeNewerSource::Global => write!(
                         f,
-                        "{}{} `{}` was filtered by `{}` to only include packages uploaded \
+                        "`{}` was filtered by `{}` to only include packages uploaded \
                         before {}.{latest} Consider using `{}` to override the cutoff for this package.",
-                        "hint".bold().cyan(),
-                        ":".bold(),
                         package.cyan(),
                         "exclude-newer".green(),
                         exclude_newer.cyan(),
@@ -2062,11 +2166,9 @@ impl std::fmt::Display for PubGrubHint {
                     ),
                     EffectiveExcludeNewerSource::Index => write!(
                         f,
-                        "{}{} `{}` was filtered by the index-specific `{}` setting to only include \
+                        "`{}` was filtered by the index-specific `{}` setting to only include \
                         packages uploaded before {}.{latest} Consider updating that index's cutoff, setting \
                         it to `false`, or using `{}` to override the cutoff for this package.",
-                        "hint".bold().cyan(),
-                        ":".bold(),
                         package.cyan(),
                         "exclude-newer".green(),
                         exclude_newer.cyan(),
@@ -2077,22 +2179,18 @@ impl std::fmt::Display for PubGrubHint {
             Self::DisjointPythonVersion { python_version } => {
                 write!(
                     f,
-                    "{}{} While the active Python version is {}, \
+                    "While the active Python version is {}, \
                     the resolution failed for other Python versions supported by your \
                     project. Consider limiting your project's supported Python versions \
                     using `requires-python`.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
                     python_version.cyan(),
                 )
             }
             Self::DisjointEnvironment => {
                 write!(
                     f,
-                    "{}{} The resolution failed for an environment that is not the current one, \
+                    "The resolution failed for an environment that is not the current one, \
                     consider limiting the environments with `tool.fyn.environments`.",
-                    "hint".bold().cyan(),
-                    ":".bold(),
                 )
             }
         }
@@ -2255,8 +2353,6 @@ fn update_availability_range(
         versions.contains(&version)
     }
 
-    let mut new_range = Range::empty();
-
     // Construct an available range to help guide simplification. Note this is not strictly correct,
     // as the available range should have many holes in it. However, for this use-case it should be
     // okay — we just may avoid simplifying some segments _inside_ the available range.
@@ -2281,61 +2377,53 @@ fn update_availability_range(
             (None, None) => return Range::empty(),
         };
 
-    for segment in range.iter() {
-        let (lower, upper) = segment;
-        let segment_range = Range::from_range_bounds((lower.clone(), upper.clone()));
+    range
+        .iter()
+        .filter_map(|(lower, upper)| {
+            let segment_range = Range::from_range_bounds((lower.clone(), upper.clone()));
 
-        // Drop the segment if it's disjoint with the available range, e.g., if the segment is
-        // `foo>999`, and the available versions are all `<10` it's useless to show.
-        if segment_range.is_disjoint(&available_range) {
-            continue;
-        }
+            // Drop the segment if it's disjoint with the available range, e.g., if the segment is
+            // `foo>999`, and the available versions are all `<10` it's useless to show.
+            if segment_range.is_disjoint(&available_range) {
+                return None;
+            }
 
-        // Replace the segment if it's captured by the available range, e.g., if the segment is
-        // `foo<1000` and the available versions are all `<10` we can simplify to `foo<10`.
-        if available_range.subset_of(&segment_range) {
-            // If the segment only has a lower or upper bound, only take the relevant part of the
-            // available range. This avoids replacing `foo<100` with `foo>1,<2`, instead using
-            // `foo<2` to avoid extra noise.
-            if matches!(lower, Bound::Unbounded) {
-                new_range = new_range.union(&Range::from_range_bounds((
-                    Bound::Unbounded,
-                    Bound::Included(last_available.clone()),
-                )));
-            } else if matches!(upper, Bound::Unbounded) {
-                new_range = new_range.union(&Range::from_range_bounds((
+            // Replace the segment if it's captured by the available range, e.g., if the segment is
+            // `foo<1000` and the available versions are all `<10` we can simplify to `foo<10`.
+            if available_range.subset_of(&segment_range) {
+                // If the segment only has a lower or upper bound, only take the relevant part of
+                // the available range. This avoids replacing `foo<100` with `foo>1,<2`, instead
+                // using `foo<2` to avoid extra noise.
+                if matches!(lower, Bound::Unbounded) {
+                    return Some((Bound::Unbounded, Bound::Included(last_available.clone())));
+                } else if matches!(upper, Bound::Unbounded) {
+                    return Some((Bound::Included(first_available.clone()), Bound::Unbounded));
+                }
+                return Some((
                     Bound::Included(first_available.clone()),
-                    Bound::Unbounded,
-                )));
-            } else {
-                new_range = new_range.union(&available_range);
+                    Bound::Included(last_available.clone()),
+                ));
             }
-            continue;
-        }
 
-        // If the bound is inclusive, and the version is _not_ available, change it to an exclusive
-        // bound to avoid confusion, e.g., if the segment is `foo<=10` and the available versions
-        // do not include `foo 10`, we should instead say `foo<10`.
-        let lower = match lower {
-            Bound::Included(version) if !version_contained_in(version, available_versions) => {
-                Bound::Excluded(version.clone())
-            }
-            _ => (*lower).clone(),
-        };
-        let upper = match upper {
-            Bound::Included(version) if !version_contained_in(version, available_versions) => {
-                Bound::Excluded(version.clone())
-            }
-            _ => (*upper).clone(),
-        };
+            // If the bound is inclusive, and the version is _not_ available, change it to an
+            // exclusive bound to avoid confusion, e.g., if the segment is `foo<=10` and the
+            // available versions do not include `foo 10`, we should instead say `foo<10`.
+            let lower = match lower {
+                Bound::Included(version) if !version_contained_in(version, available_versions) => {
+                    Bound::Excluded(version.clone())
+                }
+                _ => (*lower).clone(),
+            };
+            let upper = match upper {
+                Bound::Included(version) if !version_contained_in(version, available_versions) => {
+                    Bound::Excluded(version.clone())
+                }
+                _ => (*upper).clone(),
+            };
 
-        // Note this repeated-union construction is not particularly efficient, but there's not
-        // better API exposed by PubGrub. Since we're just generating an error message, it's
-        // probably okay, but we should investigate a better upstream API.
-        new_range = new_range.union(&Range::from_range_bounds((lower, upper)));
-    }
-
-    new_range
+            Some((lower, upper))
+        })
+        .collect()
 }
 
 impl std::fmt::Display for PackageRange<'_> {
@@ -2451,7 +2539,7 @@ impl<'a> DependsOn<'a> {
 
 impl std::fmt::Display for DependsOn<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", Padded::new("", self.package, " "))?;
+        write!(f, "{}", padded("", self.package, " "))?;
         if self.package.plural() {
             write!(f, "depend on ")?;
         } else {
@@ -2462,8 +2550,8 @@ impl std::fmt::Display for DependsOn<'_> {
             Some(ref dependency2) => write!(
                 f,
                 "{}and{}",
-                Padded::new("", &self.dependency1, " "),
-                Padded::new(" ", &dependency2, "")
+                padded("", &self.dependency1, " "),
+                padded(" ", &dependency2, "")
             )?,
             None => write!(f, "{}", self.dependency1)?,
         }
@@ -2474,52 +2562,159 @@ impl std::fmt::Display for DependsOn<'_> {
 
 /// Inserts the given padding on the left and right sides of the content if
 /// the content does not start and end with whitespace respectively.
-#[derive(Debug)]
-struct Padded<'a, T: std::fmt::Display> {
+fn padded<'a, T: std::fmt::Display + ?Sized>(
+    left: &'a str,
+    content: &'a T,
+    right: &'a str,
+) -> Padded<'a, T> {
+    Padded {
+        left,
+        content,
+        right,
+    }
+}
+
+struct Padded<'a, T: std::fmt::Display + ?Sized> {
     left: &'a str,
     content: &'a T,
     right: &'a str,
 }
 
-impl<'a, T: std::fmt::Display> Padded<'a, T> {
-    fn new(left: &'a str, content: &'a T, right: &'a str) -> Self {
-        Padded {
-            left,
-            content,
-            right,
-        }
-    }
-}
-
-impl<'a> Padded<'a, String> {
-    fn from_string(left: &'a str, content: &'a String, right: &'a str) -> Self {
-        Padded {
-            left,
-            content,
-            right,
-        }
-    }
-}
-
-impl<T: std::fmt::Display> std::fmt::Display for Padded<'_, T> {
+impl<T: std::fmt::Display + ?Sized> std::fmt::Display for Padded<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut result = String::new();
         let content = self.content.to_string();
 
         if let Some(char) = content.chars().next() {
             if !char.is_whitespace() {
-                result.push_str(self.left);
+                f.write_str(self.left)?;
             }
         }
 
-        result.push_str(&content);
+        f.write_str(&content)?;
 
         if let Some(char) = content.chars().last() {
             if !char.is_whitespace() {
-                result.push_str(self.right);
+                f.write_str(self.right)?;
             }
         }
 
-        write!(f, "{result}")
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fyn_distribution_types::RequiresPython;
+    use fyn_pep508::{MarkerEnvironment, MarkerEnvironmentBuilder};
+    use pubgrub::{DefaultStringReporter, Reporter};
+
+    use super::*;
+
+    fn derived(
+        cause1: DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+        cause2: DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+        shared_id: Option<usize>,
+    ) -> DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason> {
+        DerivationTree::Derived(Derived {
+            terms: Map::default(),
+            shared_id,
+            cause1: cause1.into(),
+            cause2: cause2.into(),
+        })
+    }
+
+    struct FormatterFixture {
+        included_versions: FxHashMap<PackageName, BTreeSet<Version>>,
+        available_versions: FxHashMap<PackageName, BTreeSet<Version>>,
+        python_requirement: PythonRequirement,
+        workspace_members: BTreeSet<PackageName>,
+    }
+
+    impl FormatterFixture {
+        fn new() -> Self {
+            let marker_environment = MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+                implementation_name: "cpython",
+                implementation_version: "3.12.0",
+                os_name: "posix",
+                platform_machine: "x86_64",
+                platform_python_implementation: "CPython",
+                platform_release: "",
+                platform_system: "Linux",
+                platform_version: "",
+                python_full_version: "3.12.0",
+                python_version: "3.12",
+                sys_platform: "linux",
+            })
+            .expect("valid marker environment");
+            Self {
+                included_versions: FxHashMap::default(),
+                available_versions: FxHashMap::default(),
+                python_requirement: PythonRequirement::from_marker_environment(
+                    &marker_environment,
+                    RequiresPython::greater_than_equal_version(&Version::new([3_u64, 12])),
+                ),
+                workspace_members: BTreeSet::default(),
+            }
+        }
+
+        fn formatter(&self) -> PubGrubReportFormatter<'_> {
+            PubGrubReportFormatter {
+                included_versions: &self.included_versions,
+                available_versions: &self.available_versions,
+                python_requirement: &self.python_requirement,
+                workspace_members: &self.workspace_members,
+                tags: None,
+            }
+        }
+    }
+
+    #[test]
+    fn iterative_reporter_matches_pubgrub_for_shared_nodes() {
+        let fixture = FormatterFixture::new();
+        let formatter = fixture.formatter();
+        let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+        let external1 =
+            DerivationTree::External(External::NotRoot(package.clone(), Version::new([1_u64])));
+        let external2 =
+            DerivationTree::External(External::NotRoot(package.clone(), Version::new([2_u64])));
+        let external3 = DerivationTree::External(External::NotRoot(package, Version::new([3_u64])));
+        let shared = derived(external1.clone(), external2.clone(), Some(1));
+        let unshared = derived(external2.clone(), external3.clone(), None);
+
+        let trees = [
+            derived(shared.clone(), external3.clone(), None),
+            derived(external3.clone(), shared.clone(), None),
+            derived(shared.clone(), unshared, None),
+            derived(shared.clone(), shared, None),
+        ];
+
+        for tree in trees {
+            assert_eq!(
+                report(&tree, &formatter),
+                DefaultStringReporter::report_with_formatter(&tree, &formatter)
+            );
+        }
+    }
+
+    #[test]
+    fn formats_deep_derivation_tree_without_recursion() -> std::io::Result<()> {
+        let thread = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let fixture = FormatterFixture::new();
+                let formatter = fixture.formatter();
+                let package = PubGrubPackage::from(PubGrubPackageInner::Root(None));
+                let leaf =
+                    DerivationTree::External(External::NotRoot(package, Version::new([1_u64])));
+                let mut tree = leaf.clone();
+                for _ in 0..100_000 {
+                    tree = derived(tree, leaf.clone(), None);
+                }
+                let _report = report(&tree, &formatter);
+                crate::error::drop_derivation_tree(tree);
+            })?;
+
+        assert!(thread.join().is_ok());
+        Ok(())
     }
 }

--- a/crates/fyn-resolver/src/resolver/mod.rs
+++ b/crates/fyn-resolver/src/resolver/mod.rs
@@ -45,7 +45,7 @@ use fyn_warnings::warn_user_once;
 
 use crate::candidate_selector::{Candidate, CandidateDist, CandidateSelector};
 use crate::dependency_provider::UvDependencyProvider;
-use crate::error::{NoSolutionError, ResolveError};
+use crate::error::{NoSolutionError, ResolveError, derivation_tree_packages};
 use crate::fork_indexes::ForkIndexes;
 use crate::fork_strategy::ForkStrategy;
 use crate::fork_urls::ForkUrls;
@@ -2703,7 +2703,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         ));
 
         let mut unavailable_packages = FxHashMap::default();
-        for package in err.packages() {
+        for package in derivation_tree_packages(&err) {
             if let PubGrubPackageInner::Package { name, .. } = &**package {
                 if let Some(reason) = self.unavailable_packages.get(name) {
                     unavailable_packages.insert(name.clone(), reason.clone());
@@ -2712,7 +2712,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         }
 
         let mut incomplete_packages = FxHashMap::default();
-        for package in err.packages() {
+        for package in derivation_tree_packages(&err) {
             if let PubGrubPackageInner::Package { name, .. } = &**package {
                 if let Some(versions) = self.incomplete_packages.get(name) {
                     for entry in versions.iter() {
@@ -2735,7 +2735,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 .ok()
                 .and_then(|s| s.parse().ok());
 
-        for package in err.packages() {
+        for package in derivation_tree_packages(&err) {
             let Some(name) = package.name() else { continue };
             if !visited.contains(name) {
                 // Avoid including version data for packages that exist in the derivation


### PR DESCRIPTION
## Summary

  Backport upstream resolver fix that makes resolver error handling iterative instead of recursive.

  This avoids recursive traversal while constructing resolver error reports, reducing stack risk for deeply nested incompatibility causes.

## Upstream 
  
  - `6feeacc62` avoid recursive resolver error handling

  ## Tests

  ```
  cargo fmt --check
  cargo test -p fyn --test it --no-run
  cargo clippy -p fyn --test it -- -D warnings
```