### PR TITLE
fix: backport uv credential and build hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,15 +301,15 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+checksum = "08648fef353ab39a9d26f909ad53fc4f071be4c91853b78523f5cc3d9e5ebffd"
 dependencies = [
- "filetime",
  "futures-core",
  "libc",
  "portable-atomic",
  "rustc-hash",
+ "rustix 0.38.44",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -2563,7 +2563,7 @@ dependencies = [
  "percent-encoding",
  "reflink-copy",
  "rustc-hash",
- "rustix",
+ "rustix 1.1.4",
  "same-file",
  "schemars",
  "serde",
@@ -2856,7 +2856,7 @@ dependencies = [
  "insta",
  "procfs",
  "regex",
- "rustix",
+ "rustix 1.1.4",
  "target-lexicon",
  "tempfile",
  "thiserror 2.0.18",
@@ -4280,6 +4280,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -5160,7 +5166,7 @@ dependencies = [
  "bitflags 2.11.0",
  "flate2",
  "procfs-core",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -5461,7 +5467,7 @@ checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix",
+ "rustix 1.1.4",
  "windows",
 ]
 
@@ -5839,6 +5845,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -5846,7 +5865,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -6581,7 +6600,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6591,7 +6610,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -8101,7 +8120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -8179,7 +8198,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ anstream = { version = "1.0.0" }
 anyhow = { version = "1.0.89" }
 arcstr = { version = "1.2.0" }
 arrayvec = { version = "0.7.6" }
-astral-tokio-tar = { version = "0.6.2" }
+astral-tokio-tar = { version = "0.6.3" }
 async-channel = { version = "2.3.1" }
 async-compression = { version = "0.4.12", features = [
   "bzip2",

--- a/crates/fyn-auth/src/cache.rs
+++ b/crates/fyn-auth/src/cache.rs
@@ -11,7 +11,7 @@ use url::Url;
 use fyn_once_map::OnceMap;
 use fyn_redacted::DisplaySafeUrl;
 
-use crate::credentials::{Authentication, Username};
+use crate::credentials::{Authentication, CredentialsFromUrlError, Username};
 use crate::{Credentials, Realm};
 
 type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
@@ -62,13 +62,16 @@ impl CredentialsCache {
     /// Populate the global authentication store with credentials on a URL, if there are any.
     ///
     /// Returns `true` if the store was updated.
-    pub fn store_credentials_from_url(&self, url: &DisplaySafeUrl) -> bool {
-        if let Some(credentials) = Credentials::from_url(url) {
+    pub fn store_credentials_from_url(
+        &self,
+        url: &DisplaySafeUrl,
+    ) -> Result<bool, CredentialsFromUrlError> {
+        if let Some(credentials) = Credentials::from_url(url)? {
             trace!("Caching credentials for {url}");
             self.insert(url, Arc::new(Authentication::from(credentials)));
-            true
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 

--- a/crates/fyn-auth/src/credentials.rs
+++ b/crates/fyn-auth/src/credentials.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::io::Read;
 use std::io::Write;
-use std::str::FromStr;
+use std::str::{FromStr, Utf8Error};
 
 use base64::prelude::BASE64_STANDARD;
 use base64::read::DecoderReader;
@@ -14,6 +14,7 @@ use reqsign::google::DefaultSigner as GcsDefaultSigner;
 use reqwest::Request;
 use reqwest::header::HeaderValue;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use url::Url;
 
 use fyn_redacted::DisplaySafeUrl;
@@ -33,6 +34,14 @@ pub enum Credentials {
         /// The token to use for authentication.
         token: Token,
     },
+}
+
+#[derive(Debug, Error)]
+pub enum CredentialsFromUrlError {
+    #[error("URL username contains invalid UTF-8")]
+    InvalidUsernameUtf8(#[source] Utf8Error),
+    #[error("URL password contains invalid UTF-8")]
+    InvalidPasswordUtf8(#[source] Utf8Error),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
@@ -224,33 +233,37 @@ impl Credentials {
     /// Parse [`Credentials`] from a URL, if any.
     ///
     /// Returns [`None`] if both [`Url::username`] and [`Url::password`] are not populated.
-    pub fn from_url(url: &Url) -> Option<Self> {
+    pub fn from_url(url: &Url) -> Result<Option<Self>, CredentialsFromUrlError> {
         if url.username().is_empty() && url.password().is_none() {
-            return None;
+            return Ok(None);
         }
-        Some(Self::Basic {
-            // Remove percent-encoding from URL credentials
-            // See <https://github.com/pypa/pip/blob/06d21db4ff1ab69665c22a88718a4ea9757ca293/src/pip/_internal/utils/misc.py#L497-L499>
-            username: if url.username().is_empty() {
-                None
-            } else {
-                Some(
-                    percent_encoding::percent_decode_str(url.username())
-                        .decode_utf8()
-                        .expect("An encoded username should always decode")
-                        .into_owned(),
-                )
-            }
-            .into(),
-            password: url.password().map(|password| {
-                Password(
-                    percent_encoding::percent_decode_str(password)
-                        .decode_utf8()
-                        .expect("An encoded password should always decode")
-                        .into_owned(),
-                )
-            }),
-        })
+
+        // Remove percent-encoding from URL credentials.
+        // See <https://github.com/pypa/pip/blob/06d21db4ff1ab69665c22a88718a4ea9757ca293/src/pip/_internal/utils/misc.py#L497-L499>
+        let username = if url.username().is_empty() {
+            None
+        } else {
+            Some(
+                percent_encoding::percent_decode_str(url.username())
+                    .decode_utf8()
+                    .map_err(CredentialsFromUrlError::InvalidUsernameUtf8)?
+                    .into_owned(),
+            )
+        };
+        let password = url
+            .password()
+            .map(|password| {
+                percent_encoding::percent_decode_str(password)
+                    .decode_utf8()
+                    .map(|password| Password(password.into_owned()))
+                    .map_err(CredentialsFromUrlError::InvalidPasswordUtf8)
+            })
+            .transpose()?;
+
+        Ok(Some(Self::Basic {
+            username: username.into(),
+            password,
+        }))
     }
 
     /// Extract the [`Credentials`] from the environment, given a named source.
@@ -270,15 +283,17 @@ impl Credentials {
     /// Parse [`Credentials`] from an HTTP request, if any.
     ///
     /// Only HTTP Basic Authentication is supported.
-    pub(crate) fn from_request(request: &Request) -> Option<Self> {
+    pub(crate) fn from_request(request: &Request) -> Result<Option<Self>, CredentialsFromUrlError> {
         // First, attempt to retrieve the credentials from the URL
-        Self::from_url(request.url()).or(
-            // Then, attempt to pull the credentials from the headers
-            request
-                .headers()
-                .get(reqwest::header::AUTHORIZATION)
-                .map(Self::from_header_value)?,
-        )
+        if let Some(credentials) = Self::from_url(request.url())? {
+            return Ok(Some(credentials));
+        }
+
+        // Then, attempt to pull the credentials from the headers
+        Ok(request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .and_then(Self::from_header_value))
     }
 
     /// Parse [`Credentials`] from an authorization header, if any.
@@ -544,14 +559,14 @@ impl Authentication {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_debug_snapshot;
+    use insta::{assert_debug_snapshot, assert_snapshot};
 
     use super::*;
 
     #[test]
     fn from_url_no_credentials() {
         let url = &Url::parse("https://example.com/simple/first/").unwrap();
-        assert_eq!(Credentials::from_url(url), None);
+        assert!(matches!(Credentials::from_url(url), Ok(None)));
     }
 
     #[test]
@@ -560,9 +575,23 @@ mod tests {
         let mut auth_url = url.clone();
         auth_url.set_username("user").unwrap();
         auth_url.set_password(Some("password")).unwrap();
-        let credentials = Credentials::from_url(&auth_url).unwrap();
+        let credentials = Credentials::from_url(&auth_url).unwrap().unwrap();
         assert_eq!(credentials.username(), Some("user"));
         assert_eq!(credentials.password(), Some("password"));
+    }
+
+    #[test]
+    fn from_url_invalid_utf8_username() {
+        let url = Url::parse("https://%FF:password@example.com/simple/first/").unwrap();
+        let error = Credentials::from_url(&url).unwrap_err();
+        assert_snapshot!(error, @"URL username contains invalid UTF-8");
+    }
+
+    #[test]
+    fn from_url_invalid_utf8_password() {
+        let url = Url::parse("https://user:%FF@example.com/simple/first/").unwrap();
+        let error = Credentials::from_url(&url).unwrap_err();
+        assert_snapshot!(error, @"URL password contains invalid UTF-8");
     }
 
     #[test]
@@ -570,7 +599,7 @@ mod tests {
         let url = &Url::parse("https://example.com/simple/first/").unwrap();
         let mut auth_url = url.clone();
         auth_url.set_password(Some("password")).unwrap();
-        let credentials = Credentials::from_url(&auth_url).unwrap();
+        let credentials = Credentials::from_url(&auth_url).unwrap().unwrap();
         assert_eq!(credentials.username(), None);
         assert_eq!(credentials.password(), Some("password"));
     }
@@ -583,7 +612,7 @@ mod tests {
     fn from_url_empty_username_with_password() {
         // Parse a URL with the format `:password@host` directly
         let url = Url::parse("https://:token@example.com/simple/first/").unwrap();
-        let credentials = Credentials::from_url(&url).unwrap();
+        let credentials = Credentials::from_url(&url).unwrap().unwrap();
         assert_eq!(credentials.username(), None);
         assert_eq!(credentials.password(), Some("token"));
         assert!(
@@ -597,7 +626,7 @@ mod tests {
         let url = &Url::parse("https://example.com/simple/first/").unwrap();
         let mut auth_url = url.clone();
         auth_url.set_username("user").unwrap();
-        let credentials = Credentials::from_url(&auth_url).unwrap();
+        let credentials = Credentials::from_url(&auth_url).unwrap().unwrap();
         assert_eq!(credentials.username(), Some("user"));
         assert_eq!(credentials.password(), None);
     }
@@ -608,7 +637,7 @@ mod tests {
         let mut auth_url = url.clone();
         auth_url.set_username("user").unwrap();
         auth_url.set_password(Some("password")).unwrap();
-        let credentials = Credentials::from_url(&auth_url).unwrap();
+        let credentials = Credentials::from_url(&auth_url).unwrap().unwrap();
 
         let mut request = Request::new(reqwest::Method::GET, url);
         request = credentials.authenticate(request);
@@ -630,7 +659,7 @@ mod tests {
         let mut auth_url = url.clone();
         auth_url.set_username("user@domain").unwrap();
         auth_url.set_password(Some("password")).unwrap();
-        let credentials = Credentials::from_url(&auth_url).unwrap();
+        let credentials = Credentials::from_url(&auth_url).unwrap().unwrap();
 
         let mut request = Request::new(reqwest::Method::GET, url);
         request = credentials.authenticate(request);
@@ -652,7 +681,7 @@ mod tests {
         let mut auth_url = url.clone();
         auth_url.set_username("user").unwrap();
         auth_url.set_password(Some("password==")).unwrap();
-        let credentials = Credentials::from_url(&auth_url).unwrap();
+        let credentials = Credentials::from_url(&auth_url).unwrap().unwrap();
 
         let mut request = Request::new(reqwest::Method::GET, url);
         request = credentials.authenticate(request);

--- a/crates/fyn-auth/src/keyring.rs
+++ b/crates/fyn-auth/src/keyring.rs
@@ -118,7 +118,7 @@ impl KeyringProvider {
     }
 
     /// Store credentials to the system keyring.
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(service = ?service, username = ?username))]
     async fn store_native(
         &self,
         service: &str,

--- a/crates/fyn-auth/src/lib.rs
+++ b/crates/fyn-auth/src/lib.rs
@@ -1,6 +1,6 @@
 pub use access_token::AccessToken;
 pub use cache::CredentialsCache;
-pub use credentials::{Credentials, Username};
+pub use credentials::{Credentials, CredentialsFromUrlError, Username};
 pub use index::{AuthPolicy, Index, Indexes};
 pub use keyring::KeyringProvider;
 pub use middleware::AuthMiddleware;

--- a/crates/fyn-auth/src/middleware.rs
+++ b/crates/fyn-auth/src/middleware.rs
@@ -334,7 +334,9 @@ impl Middleware for AuthMiddleware {
         next: Next<'_>,
     ) -> reqwest_middleware::Result<Response> {
         // Check for credentials attached to the request already
-        let request_credentials = Credentials::from_request(&request).map(Authentication::from);
+        let request_credentials = Credentials::from_request(&request)
+            .map_err(Error::middleware)?
+            .map(Authentication::from);
 
         // In the middleware, existing credentials are already moved from the URL
         // to the headers so for display purposes we restore some information

--- a/crates/fyn-build-frontend/src/error.rs
+++ b/crates/fyn-build-frontend/src/error.rs
@@ -68,6 +68,8 @@ pub enum Error {
         "`pyproject.toml` does not match the required schema. When the `[project]` table is present, `project.name` must be present and non-empty."
     )]
     InvalidPyprojectTomlSchema(#[from] toml_edit::de::Error),
+    #[error("`backend-path` entry `{0}` does not exist or is not a directory")]
+    InvalidBackendPath(String),
     #[error("Failed to resolve requirements from {0}")]
     RequirementsResolve(&'static str, #[source] AnyErrorBuild),
     #[error("Failed to install requirements from {0}")]
@@ -104,6 +106,7 @@ impl IsBuildBackendError for Error {
             | Self::InvalidSourceDist(_)
             | Self::InvalidPyprojectTomlSyntax(_)
             | Self::InvalidPyprojectTomlSchema(_)
+            | Self::InvalidBackendPath(_)
             | Self::RequirementsResolve(_, _)
             | Self::RequirementsInstall(_, _)
             | Self::Virtualenv(_)

--- a/crates/fyn-build-frontend/src/lib.rs
+++ b/crates/fyn-build-frontend/src/lib.rs
@@ -602,6 +602,19 @@ impl SourceBuild {
             .build_system
             .as_ref()
             .and_then(|build_system| build_system.build_backend.as_deref());
+
+        if let Some(backend_path) = pyproject_toml
+            .build_system
+            .as_ref()
+            .and_then(|build_system| build_system.backend_path.as_ref())
+        {
+            for path in backend_path.iter() {
+                if !source_tree.join(path).is_dir() {
+                    return Err(Box::new(Error::InvalidBackendPath(path.to_string())));
+                }
+            }
+        }
+
         // Only show the warning for first party and URL dependencies, not for registry dependencies
         // (which have sources disabled).
         if !no_sources.all()

--- a/crates/fyn-client/src/base_client.rs
+++ b/crates/fyn-client/src/base_client.rs
@@ -30,9 +30,12 @@ use tracing::{debug, trace, warn};
 use url::ParseError;
 use url::Url;
 
-use fyn_auth::{AuthMiddleware, Credentials, CredentialsCache, Indexes, PyxTokenStore};
+use fyn_auth::{
+    AuthMiddleware, Credentials, CredentialsCache, CredentialsFromUrlError, Indexes, PyxTokenStore,
+};
 use fyn_configuration::ProxyUrlKind;
 use fyn_configuration::{KeyringProviderType, ProxyUrl, TrustedHost};
+use fyn_distribution_types::IndexCredentialsError;
 use fyn_pep508::MarkerEnvironment;
 use fyn_platform_tags::Platform;
 use fyn_preview::Preview;
@@ -68,13 +71,13 @@ pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const DEFAULT_READ_TIMEOUT_UPLOAD: Duration = Duration::from_mins(15);
 
 #[derive(Debug, Error)]
-#[error("failed to build HTTP client")]
-pub struct ClientBuildError(#[source] reqwest::Error);
-
-impl From<reqwest::Error> for ClientBuildError {
-    fn from(error: reqwest::Error) -> Self {
-        Self(error)
-    }
+pub enum ClientBuildError {
+    #[error("failed to build HTTP client")]
+    Reqwest(#[from] reqwest::Error),
+    #[error(transparent)]
+    Credentials(#[from] CredentialsFromUrlError),
+    #[error(transparent)]
+    IndexCredentials(#[from] IndexCredentialsError),
 }
 
 /// Selectively skip parts or the entire auth middleware.
@@ -371,7 +374,10 @@ impl<'a> BaseClientBuilder<'a> {
     }
 
     /// See [`CredentialsCache::store_credentials_from_url`].
-    pub fn store_credentials_from_url(&self, url: &DisplaySafeUrl) -> bool {
+    pub fn store_credentials_from_url(
+        &self,
+        url: &DisplaySafeUrl,
+    ) -> Result<bool, CredentialsFromUrlError> {
         self.credentials_cache.store_credentials_from_url(url)
     }
 
@@ -974,7 +980,9 @@ fn request_into_redirect(
     // Check if there are credentials on the redirect location itself.
     // If so, move them to Authorization header.
     if !redirect_url.username().is_empty() {
-        if let Some(credentials) = Credentials::from_url(&redirect_url) {
+        if let Some(credentials) =
+            Credentials::from_url(&redirect_url).map_err(reqwest_middleware::Error::middleware)?
+        {
             let _ = redirect_url.set_username("");
             let _ = redirect_url.set_password(None);
             headers.insert(AUTHORIZATION, credentials.to_header_value());

--- a/crates/fyn-client/src/cached_client.rs
+++ b/crates/fyn-client/src/cached_client.rs
@@ -994,7 +994,7 @@ impl DataWithCachePolicy {
             );
             return Err(ErrorKind::ArchiveRead(msg).into());
         };
-        if bytes.len() < len_usize + 8 {
+        if len_usize > cache_policy_len_start {
             let msg = format!(
                 "invalid cache entry: data-with-cache-policy has cache policy length of {}, \
                  but total buffer size is {}",

--- a/crates/fyn-client/src/registry_client.rs
+++ b/crates/fyn-client/src/registry_client.rs
@@ -150,9 +150,9 @@ impl<'a> RegistryClientBuilder<'a> {
     }
 
     /// Add all authenticated sources to the cache.
-    pub fn cache_index_credentials(&mut self) {
+    pub fn cache_index_credentials(&mut self) -> Result<(), ClientBuildError> {
         for index in self.index_locations.known_indexes() {
-            if let Some(credentials) = index.credentials() {
+            if let Some(credentials) = index.credentials()? {
                 trace!(
                     "Read credentials for index {}",
                     index
@@ -169,10 +169,11 @@ impl<'a> RegistryClientBuilder<'a> {
                     .store_credentials(index.raw_url(), credentials);
             }
         }
+        Ok(())
     }
 
     pub fn build(mut self) -> Result<RegistryClient, ClientBuildError> {
-        self.cache_index_credentials();
+        self.cache_index_credentials()?;
         let index_urls = self.index_locations.index_urls();
 
         // Build a base client
@@ -203,8 +204,11 @@ impl<'a> RegistryClientBuilder<'a> {
     }
 
     /// Share the underlying client between two different middleware configurations.
-    pub fn wrap_existing(mut self, existing: &BaseClient) -> RegistryClient {
-        self.cache_index_credentials();
+    pub fn wrap_existing(
+        mut self,
+        existing: &BaseClient,
+    ) -> Result<RegistryClient, ClientBuildError> {
+        self.cache_index_credentials()?;
         let index_urls = self.index_locations.index_urls();
 
         // Wrap in any relevant middleware and handle connectivity.
@@ -219,7 +223,7 @@ impl<'a> RegistryClientBuilder<'a> {
         // Wrap in the cache middleware.
         let client = CachedClient::new(client);
 
-        RegistryClient {
+        Ok(RegistryClient {
             index_urls,
             index_strategy: self.index_strategy,
             torch_backend: self.torch_backend,
@@ -229,7 +233,7 @@ impl<'a> RegistryClientBuilder<'a> {
             read_timeout,
             flat_indexes: Arc::default(),
             pyx_token_store: PyxTokenStore::from_settings().ok(),
-        }
+        })
     }
 }
 

--- a/crates/fyn-client/tests/it/cached_client.rs
+++ b/crates/fyn-client/tests/it/cached_client.rs
@@ -1,0 +1,12 @@
+use std::io::Cursor;
+
+use fyn_client::{DataWithCachePolicy, ErrorKind};
+
+#[test]
+fn reject_overflowing_cache_policy_length() {
+    let mut bytes = vec![0; 8];
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+
+    let err = DataWithCachePolicy::from_reader(Cursor::new(bytes)).unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::ArchiveRead(_)));
+}

--- a/crates/fyn-client/tests/it/main.rs
+++ b/crates/fyn-client/tests/it/main.rs
@@ -1,3 +1,4 @@
+mod cached_client;
 mod http_util;
 mod proxy;
 mod remote_metadata;

--- a/crates/fyn-distribution-types/src/index.rs
+++ b/crates/fyn-distribution-types/src/index.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
-use fyn_auth::{AuthPolicy, Credentials};
+use fyn_auth::{AuthPolicy, Credentials, CredentialsFromUrlError};
 use fyn_normalize::PackageName;
 use fyn_redacted::DisplaySafeUrl;
 use fyn_small_str::SmallString;
@@ -25,6 +25,14 @@ pub struct IndexCacheControl {
     pub api: Option<SmallString>,
     /// Cache control header for file downloads.
     pub files: Option<SmallString>,
+}
+
+#[derive(Debug, Error)]
+#[error("Failed to parse credentials in index URL: {url}")]
+pub struct IndexCredentialsError {
+    url: DisplaySafeUrl,
+    #[source]
+    source: CredentialsFromUrlError,
 }
 
 /// A glob pattern matched against normalized package names.
@@ -516,23 +524,37 @@ impl Index {
     /// are stripped from the stored URL.
     #[must_use]
     pub fn with_promoted_auth_policy(mut self) -> Self {
-        if matches!(self.authenticate, AuthPolicy::Auto) && self.credentials().is_some() {
+        if matches!(self.authenticate, AuthPolicy::Auto) && self.has_credentials() {
             self.authenticate = AuthPolicy::Always;
         }
         self
     }
 
+    /// Return whether credentials are present for the index, either via the environment or URL.
+    pub fn has_credentials(&self) -> bool {
+        if let Some(name) = self.name.as_ref() {
+            if Credentials::from_env(name.to_env_var()).is_some() {
+                return true;
+            }
+        }
+
+        !self.url.url().username().is_empty() || self.url.url().password().is_some()
+    }
+
     /// Retrieve the credentials for the index, either from the environment, or from the URL itself.
-    pub fn credentials(&self) -> Option<Credentials> {
+    pub fn credentials(&self) -> Result<Option<Credentials>, IndexCredentialsError> {
         // If the index is named, and credentials are provided via the environment, prefer those.
         if let Some(name) = self.name.as_ref() {
             if let Some(credentials) = Credentials::from_env(name.to_env_var()) {
-                return Some(credentials);
+                return Ok(Some(credentials));
             }
         }
 
         // Otherwise, extract the credentials from the URL.
-        Credentials::from_url(self.url.url())
+        Credentials::from_url(self.url.url()).map_err(|source| IndexCredentialsError {
+            url: self.url.url().clone(),
+            source,
+        })
     }
 
     /// Resolve the index relative to the given root directory.
@@ -824,6 +846,8 @@ pub enum IndexSourceError {
 
 #[cfg(test)]
 mod tests {
+    use std::error::Error as _;
+
     use super::*;
 
     #[test]
@@ -854,6 +878,28 @@ mod tests {
         let index: Index = toml::from_str(toml_str).unwrap();
         assert_eq!(index.name.as_ref().unwrap().as_ref(), "test-index");
         assert_eq!(index.cache_control, None);
+    }
+
+    #[test]
+    fn invalid_url_credentials_report_index_context() {
+        let index = Index::from_index_url(
+            IndexUrl::parse("https://user:%FF@example.com/simple", None).unwrap(),
+        );
+
+        assert!(index.has_credentials());
+        assert_eq!(
+            index.clone().with_promoted_auth_policy().authenticate,
+            AuthPolicy::Always
+        );
+
+        let error = index.credentials().unwrap_err();
+        assert!(error.to_string().starts_with(
+            "Failed to parse credentials in index URL: https://user:****@example.com/simple"
+        ));
+        assert_eq!(
+            error.source().map(ToString::to_string).as_deref(),
+            Some("URL password contains invalid UTF-8")
+        );
     }
 
     #[test]

--- a/crates/fyn-distribution/src/metadata/lowering.rs
+++ b/crates/fyn-distribution/src/metadata/lowering.rs
@@ -6,7 +6,8 @@ use either::Either;
 use fyn_auth::CredentialsCache;
 use fyn_distribution_filename::DistExtension;
 use fyn_distribution_types::{
-    Index, IndexLocations, IndexMetadata, IndexName, Origin, Requirement, RequirementSource,
+    Index, IndexCredentialsError, IndexLocations, IndexMetadata, IndexName, Origin, Requirement,
+    RequirementSource,
 };
 use fyn_fs::{Simplified, normalize_absolute_path};
 use fyn_git_types::{GitLfs, GitReference, GitUrl, GitUrlParseError};
@@ -232,7 +233,7 @@ impl LoweredRequirement {
                                     hint,
                                 });
                             };
-                            if let Some(credentials) = index.credentials() {
+                            if let Some(credentials) = index.credentials()? {
                                 credentials_cache.store_credentials(index.raw_url(), credentials);
                             }
                             let index = IndexMetadata {
@@ -465,7 +466,7 @@ impl LoweredRequirement {
                                     hint,
                                 });
                             };
-                            if let Some(credentials) = index.credentials() {
+                            if let Some(credentials) = index.credentials()? {
                                 credentials_cache.store_credentials(index.raw_url(), credentials);
                             }
                             let index = IndexMetadata {
@@ -570,6 +571,8 @@ pub enum LoweringError {
     WorkspaceMember,
     #[error(transparent)]
     InvalidUrl(#[from] DisplaySafeUrlError),
+    #[error(transparent)]
+    IndexCredentials(#[from] IndexCredentialsError),
     #[error(transparent)]
     InvalidVerbatimUrl(#[from] fyn_pep508::VerbatimUrlError),
     #[error("Fragments are not allowed in URLs: `{0}`")]

--- a/crates/fyn-git/src/credentials.rs
+++ b/crates/fyn-git/src/credentials.rs
@@ -1,4 +1,4 @@
-use fyn_auth::Credentials;
+use fyn_auth::{Credentials, CredentialsFromUrlError};
 use fyn_cache_key::RepositoryUrl;
 use fyn_redacted::DisplaySafeUrl;
 use std::collections::HashMap;
@@ -29,12 +29,12 @@ impl GitStore {
 /// Populate the global authentication store with credentials on a Git URL, if there are any.
 ///
 /// Returns `true` if the store was updated.
-pub fn store_credentials_from_url(url: &DisplaySafeUrl) -> bool {
-    if let Some(credentials) = Credentials::from_url(url) {
+pub fn store_credentials_from_url(url: &DisplaySafeUrl) -> Result<bool, CredentialsFromUrlError> {
+    if let Some(credentials) = Credentials::from_url(url)? {
         trace!("Caching credentials for {url}");
         GIT_STORE.insert(RepositoryUrl::new(url), credentials);
-        true
+        Ok(true)
     } else {
-        false
+        Ok(false)
     }
 }

--- a/crates/fyn-install-wheel/src/wheel.rs
+++ b/crates/fyn-install-wheel/src/wheel.rs
@@ -993,20 +993,26 @@ fn parse_email_message_file(
 /// See: <https://github.com/pypa/pip/blob/36823099a9cdd83261fdbc8c1d2a24fa2eea72ca/src/pip/_internal/utils/wheel.py#L38>
 pub(crate) fn find_dist_info(path: impl AsRef<Path>) -> Result<String, Error> {
     // Iterate over `path` to find the `.dist-info` directory. It should be at the top-level.
-    let Some(dist_info) = fs::read_dir(path.as_ref())?.find_map(|entry| {
-        let entry = entry.ok()?;
-        let file_type = entry.file_type().ok()?;
-        if file_type.is_dir() {
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "dist-info") {
-                Some(path)
+    let mut dist_infos = fs::read_dir(path.as_ref())?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let file_type = entry.file_type().ok()?;
+            if file_type.is_dir() {
+                let path = entry.path();
+                if path.extension().is_some_and(|ext| ext == "dist-info") {
+                    Some(path)
+                } else {
+                    None
+                }
             } else {
                 None
             }
-        } else {
-            None
-        }
-    }) else {
+        })
+        .collect::<Vec<_>>();
+
+    dist_infos.sort();
+
+    let Some(dist_info) = dist_infos.first() else {
         return Err(Error::InvalidWheel(
             "Missing .dist-info directory".to_string(),
         ));
@@ -1017,6 +1023,17 @@ pub(crate) fn find_dist_info(path: impl AsRef<Path>) -> Result<String, Error> {
             "Missing .dist-info directory".to_string(),
         ));
     };
+
+    if dist_infos.len() > 1 {
+        let dist_info_stems = dist_infos
+            .iter()
+            .filter_map(|dist_info| dist_info.file_stem())
+            .map(|stem| stem.to_string_lossy())
+            .join(", ");
+        return Err(Error::InvalidWheel(format!(
+            "Multiple .dist-info directories found: {dist_info_stems}"
+        )));
+    }
 
     Ok(dist_info_prefix.to_string_lossy().to_string())
 }
@@ -1100,8 +1117,9 @@ mod test {
     use indoc::{formatdoc, indoc};
 
     use super::{
-        Error, RecordEntry, Script, WheelFile, format_shebang, get_script_executable,
-        parse_email_message_file, parse_scripts, read_record_file, write_installer_metadata,
+        Error, RecordEntry, Script, WheelFile, find_dist_info, format_shebang,
+        get_script_executable, parse_email_message_file, parse_scripts, read_record_file,
+        write_installer_metadata,
     };
 
     #[test]
@@ -1193,6 +1211,25 @@ mod test {
         assert!(matches!(
             error,
             Error::Io(err) if err.kind() == ErrorKind::InvalidData
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn multiple_dist_info_directories_are_rejected() -> Result<()> {
+        let wheel = assert_fs::TempDir::new()?;
+        wheel.child("example-1.0.0.dist-info").create_dir_all()?;
+        wheel.child("other-1.0.0.dist-info").create_dir_all()?;
+
+        let error = find_dist_info(&wheel)
+            .err()
+            .ok_or_else(|| anyhow::anyhow!("multiple .dist-info directories should fail"))?;
+
+        assert!(matches!(
+            error,
+            Error::InvalidWheel(message)
+                if message == "Multiple .dist-info directories found: example-1.0.0, other-1.0.0"
         ));
 
         Ok(())

--- a/crates/fyn-publish/src/lib.rs
+++ b/crates/fyn-publish/src/lib.rs
@@ -26,8 +26,8 @@ use url::Url;
 use fyn_auth::{Credentials, PyxTokenStore, Realm};
 use fyn_cache::{Cache, Refresh};
 use fyn_client::{
-    BaseClient, DEFAULT_MAX_REDIRECTS, MetadataFormat, OwnedArchive, RegistryClientBuilder,
-    RequestBuilder, RetryParsingError, RetryState,
+    BaseClient, ClientBuildError, DEFAULT_MAX_REDIRECTS, MetadataFormat, OwnedArchive,
+    RegistryClientBuilder, RequestBuilder, RetryParsingError, RetryState,
 };
 use fyn_configuration::{KeyringProviderType, TrustedPublishing};
 use fyn_distribution_filename::{DistFilename, SourceDistExtension, SourceDistFilename};
@@ -78,6 +78,8 @@ pub enum PublishError {
     MixedCredentials(String),
     #[error("Failed to query check URL")]
     CheckUrlIndex(#[source] fyn_client::Error),
+    #[error(transparent)]
+    ClientBuild(#[from] ClientBuildError),
     #[error(
         "Local file and index file do not match for {filename}. \
         Local: {hash_algorithm}={local}, Remote: {hash_algorithm}={remote}"
@@ -957,7 +959,7 @@ pub async fn check_url(
     let registry_client = registry_client_builder
         .clone()
         .cache(cache_refresh)
-        .wrap_existing(client);
+        .wrap_existing(client)?;
 
     debug!("Checking for {filename} in the registry");
     let response = match registry_client

--- a/crates/fyn-python/src/downloads.rs
+++ b/crates/fyn-python/src/downloads.rs
@@ -1146,7 +1146,7 @@ impl ManagedPythonDownload {
     /// For CPython without a user-configured mirror, the default Astral mirror is tried first.
     /// Each attempt tries all URLs in sequence without backoff between them; backoff is only
     /// applied after all URLs have been exhausted.
-    #[instrument(skip(client, installation_dir, scratch_dir, reporter), fields(download = % self.key()))]
+    #[instrument(skip_all, fields(download = % self.key()))]
     pub async fn fetch_with_retry(
         &self,
         client: &BaseClient,
@@ -1176,7 +1176,7 @@ impl ManagedPythonDownload {
     }
 
     /// Download and extract a Python distribution.
-    #[instrument(skip(client, installation_dir, scratch_dir, reporter), fields(download = % self.key()))]
+    #[instrument(skip_all, fields(download = % self.key()))]
     pub async fn fetch(
         &self,
         client: &BaseClient,

--- a/crates/fyn-requirements-txt/src/lib.rs
+++ b/crates/fyn-requirements-txt/src/lib.rs
@@ -52,7 +52,7 @@ use fyn_configuration::{NoBinary, NoBuild, PackageNameSpecifier};
 use fyn_distribution_types::{
     Requirement, UnresolvedRequirement, UnresolvedRequirementSpecification,
 };
-use fyn_fs::Simplified;
+use fyn_fs::{Simplified, normalize_path};
 use fyn_pep508::{Pep508Error, RequirementOrigin, VerbatimUrl, expand_env_vars};
 use fyn_pypi_types::VerbatimParsedUrl;
 #[cfg(feature = "http")]
@@ -400,7 +400,7 @@ impl RequirementsTxt {
                         };
                     match visited {
                         VisitedFiles::Requirements { requirements, .. } => {
-                            if !requirements.insert(sub_file.clone()) {
+                            if !requirements.insert(visited_file(&sub_file)) {
                                 continue;
                             }
                         }
@@ -408,7 +408,7 @@ impl RequirementsTxt {
                         // from `pip`, which seems to treat `-r` requirements in constraints files as
                         // _requirements_, but we don't want to support that.
                         VisitedFiles::Constraints { constraints } => {
-                            if !constraints.insert(sub_file.clone()) {
+                            if !constraints.insert(visited_file(&sub_file)) {
                                 continue;
                             }
                         }
@@ -477,13 +477,13 @@ impl RequirementsTxt {
                     // Switch to constraints mode, if we aren't in it already.
                     let mut visited = match visited {
                         VisitedFiles::Requirements { constraints, .. } => {
-                            if !constraints.insert(sub_file.clone()) {
+                            if !constraints.insert(visited_file(&sub_file)) {
                                 continue;
                             }
                             VisitedFiles::Constraints { constraints }
                         }
                         VisitedFiles::Constraints { constraints } => {
-                            if !constraints.insert(sub_file.clone()) {
+                            if !constraints.insert(visited_file(&sub_file)) {
                                 continue;
                             }
                             VisitedFiles::Constraints { constraints }
@@ -1517,6 +1517,15 @@ enum VisitedFiles<'a> {
     Constraints {
         constraints: &'a mut FxHashSet<PathBuf>,
     },
+}
+
+/// Return a stable identity for a requirements file without changing the path used to read it.
+fn visited_file(path: &Path) -> PathBuf {
+    if path.starts_with("http://") || path.starts_with("https://") {
+        path.to_path_buf()
+    } else {
+        normalize_path(path).into_owned()
+    }
 }
 
 /// Calculates the column and line offset of a given cursor based on the
@@ -2994,6 +3003,32 @@ mod test {
             "pkg-constraints-only",
             "pkg-constraints-only-recursive",
             "pkg-requirements-in-constraints",
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn recursive_inclusion_path_alias() -> Result<()> {
+        let temp_dir = assert_fs::TempDir::new()?;
+        temp_dir.child("nested").create_dir_all()?;
+        let requirements = temp_dir.child("requirements.txt");
+        requirements.write_str(indoc! {"
+            pkg
+            -r nested/../requirements.txt
+        "})?;
+
+        let parsed = RequirementsTxt::parse(&requirements, temp_dir.path()).await?;
+        let requirements: BTreeSet<String> = parsed
+            .requirements
+            .iter()
+            .map(|entry| entry.requirement.to_string())
+            .collect();
+
+        assert_debug_snapshot!(requirements, @r#"
+        {
+            "pkg",
         }
         "#);
 

--- a/crates/fyn-shell/src/shlex.rs
+++ b/crates/fyn-shell/src/shlex.rs
@@ -6,13 +6,15 @@ pub fn shlex_posix(executable: impl AsRef<Path>) -> String {
     // Convert to a display path.
     let executable = executable.as_ref().portable_display().to_string();
 
-    // Like Python's `shlex.quote`:
-    // > Use single quotes, and put single quotes into double quotes
-    // > The string $'b is then quoted as '$'"'"'b'
-    if executable.contains(' ') {
-        format!("'{}'", escape_posix_for_single_quotes(&executable))
-    } else {
+    // Match Python's `shlex.quote` and leave only shell-safe ASCII characters unquoted.
+    if !executable.is_empty()
+        && executable
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || b"@%+=:,./-_".contains(&byte))
+    {
         executable
+    } else {
+        format!("'{}'", escape_posix_for_single_quotes(&executable))
     }
 }
 
@@ -46,5 +48,28 @@ pub fn shlex_windows(executable: impl AsRef<Path>, shell: Shell) -> String {
         }
     } else {
         executable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::shlex_posix;
+
+    #[test]
+    fn posix_safe_path() {
+        assert_eq!(shlex_posix("/usr/bin/python3.12"), "/usr/bin/python3.12");
+    }
+
+    #[test]
+    fn posix_empty_path() {
+        assert_eq!(shlex_posix(""), "''");
+    }
+
+    #[test]
+    fn posix_path_with_metacharacters() {
+        assert_eq!(
+            shlex_posix("Testing's/$venv;activate"),
+            r#"'Testing'"'"'s/$venv;activate'"#
+        );
     }
 }

--- a/crates/fyn/src/commands/auth/helper.rs
+++ b/crates/fyn/src/commands/auth/helper.rs
@@ -68,7 +68,7 @@ async fn credentials_for_url(
     let pyx_store = PyxTokenStore::from_settings()?;
 
     // Use only the username from the URL, if present - discarding the password
-    let url_credentials = Credentials::from_url(url);
+    let url_credentials = Credentials::from_url(url)?;
     let username = url_credentials.as_ref().and_then(|c| c.username());
     if url_credentials
         .as_ref()

--- a/crates/fyn/src/commands/auth/login.rs
+++ b/crates/fyn/src/commands/auth/login.rs
@@ -71,7 +71,7 @@ pub(crate) async fn login(
     };
 
     // Extract credentials from URL if present
-    let url_credentials = Credentials::from_url(&url);
+    let url_credentials = Credentials::from_url(&url)?;
     let url_username = url_credentials.as_ref().and_then(|c| c.username());
     let url_password = url_credentials.as_ref().and_then(|c| c.password());
 

--- a/crates/fyn/src/commands/auth/logout.rs
+++ b/crates/fyn/src/commands/auth/logout.rs
@@ -39,7 +39,7 @@ pub(crate) async fn logout(
     };
 
     // Extract credentials from URL if present
-    let url_credentials = Credentials::from_url(&url);
+    let url_credentials = Credentials::from_url(&url)?;
     let url_username = url_credentials.as_ref().and_then(|c| c.username());
 
     let username = match (username, url_username) {

--- a/crates/fyn/src/commands/auth/token.rs
+++ b/crates/fyn/src/commands/auth/token.rs
@@ -37,7 +37,7 @@ pub(crate) async fn token(
     let url = service.url();
 
     // Extract credentials from URL if present
-    let url_credentials = Credentials::from_url(url);
+    let url_credentials = Credentials::from_url(url)?;
     let url_username = url_credentials.as_ref().and_then(|c| c.username());
 
     let username = match (username, url_username) {

--- a/crates/fyn/src/commands/build_frontend.rs
+++ b/crates/fyn/src/commands/build_frontend.rs
@@ -348,6 +348,20 @@ async fn build_impl(
         vec![AnnotatedSource::from(src)]
     };
 
+    // Build backends can include arbitrary files from the source directory in the distribution.
+    // Reject an active cache within the source to avoid including cache contents in the build.
+    for source in &packages {
+        if let Source::Directory(source_dir) = &source.source
+            && is_path_within(cache.root(), source_dir)
+        {
+            return Err(anyhow::anyhow!(
+                "The cache directory `{}` is inside the build source directory `{}`",
+                cache.root().user_display(),
+                source_dir.user_display()
+            ));
+        }
+    }
+
     let results: Vec<_> = futures::future::join_all(packages.into_iter().map(|source| {
         let future = build_package(
             source.clone(),
@@ -1232,6 +1246,21 @@ impl Source<'_> {
             Self::File(path) => path.parent().unwrap(),
             Self::Directory(path) => path,
         }
+    }
+}
+
+/// Return `true` if `path` is within `directory`, resolving symlinks when possible.
+fn is_path_within(path: &Path, directory: &Path) -> bool {
+    if path.starts_with(directory) {
+        return true;
+    }
+
+    if let Ok(path) = fs_err::canonicalize(path)
+        && let Ok(directory) = fs_err::canonicalize(directory)
+    {
+        path.starts_with(directory)
+    } else {
+        false
     }
 }
 

--- a/crates/fyn/src/commands/project/add.rs
+++ b/crates/fyn/src/commands/project/add.rs
@@ -866,7 +866,7 @@ fn edits(
                 extra,
                 group,
             }) => {
-                let credentials = fyn_auth::Credentials::from_url(&git);
+                let credentials = fyn_auth::Credentials::from_url(&git)?;
                 if let Some(credentials) = credentials {
                     debug!("Caching credentials for: {git}");
                     GIT_STORE.insert(RepositoryUrl::new(&git), credentials);

--- a/crates/fyn/src/commands/project/lock.rs
+++ b/crates/fyn/src/commands/project/lock.rs
@@ -803,7 +803,7 @@ async fn do_lock(
     let client_builder = client_builder.clone().keyring(*keyring_provider);
 
     for index in target.indexes() {
-        if let Some(credentials) = index.credentials() {
+        if let Some(credentials) = index.credentials()? {
             if let Some(root_url) = index.root_url() {
                 client_builder.store_credentials(&root_url, credentials.clone());
             }

--- a/crates/fyn/src/commands/project/mod.rs
+++ b/crates/fyn/src/commands/project/mod.rs
@@ -346,6 +346,12 @@ pub(crate) enum ProjectError {
     ExtraBuildRequires(#[from] fyn_distribution_types::ExtraBuildRequiresError),
 
     #[error(transparent)]
+    IndexCredentials(#[from] fyn_distribution_types::IndexCredentialsError),
+
+    #[error(transparent)]
+    Credentials(#[from] fyn_auth::CredentialsFromUrlError),
+
+    #[error(transparent)]
     Fmt(#[from] std::fmt::Error),
 
     #[error(transparent)]

--- a/crates/fyn/src/commands/project/sync.rs
+++ b/crates/fyn/src/commands/project/sync.rs
@@ -788,7 +788,7 @@ pub(super) async fn do_sync(
     let extra_build_requires = extra_build_requires.match_runtime(&resolution)?;
 
     // Populate credentials from the target.
-    store_credentials_from_target(target, &client_builder);
+    store_credentials_from_target(target, &client_builder)?;
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(client_builder, cache.clone())
@@ -1017,10 +1017,13 @@ fn apply_no_virtual_project(resolution: Resolution) -> Resolution {
 ///
 /// These credentials can come from any of `tool.fyn.sources`, `tool.fyn.dev-dependencies`,
 /// `project.dependencies`, and `project.optional-dependencies`.
-fn store_credentials_from_target(target: InstallTarget<'_>, client_builder: &BaseClientBuilder) {
+fn store_credentials_from_target(
+    target: InstallTarget<'_>,
+    client_builder: &BaseClientBuilder,
+) -> Result<(), ProjectError> {
     // Iterate over any indexes in the target.
     for index in target.indexes() {
-        if let Some(credentials) = index.credentials() {
+        if let Some(credentials) = index.credentials()? {
             if let Some(root_url) = index.root_url() {
                 client_builder.store_credentials(&root_url, credentials.clone());
             }
@@ -1032,10 +1035,10 @@ fn store_credentials_from_target(target: InstallTarget<'_>, client_builder: &Bas
     for source in target.sources() {
         match source {
             Source::Git { git, .. } => {
-                fyn_git::store_credentials_from_url(git);
+                fyn_git::store_credentials_from_url(git)?;
             }
             Source::Url { url, .. } => {
-                client_builder.store_credentials_from_url(url);
+                client_builder.store_credentials_from_url(url)?;
             }
             _ => {}
         }
@@ -1048,14 +1051,15 @@ fn store_credentials_from_target(target: InstallTarget<'_>, client_builder: &Bas
         };
         match &url.parsed_url {
             ParsedUrl::Git(ParsedGitUrl { url, .. }) => {
-                fyn_git::store_credentials_from_url(url.repository());
+                fyn_git::store_credentials_from_url(url.repository())?;
             }
             ParsedUrl::Archive(ParsedArchiveUrl { url, .. }) => {
-                client_builder.store_credentials_from_url(url);
+                client_builder.store_credentials_from_url(url)?;
             }
             _ => {}
         }
     }
+    Ok(())
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/fyn/tests/it/build.rs
+++ b/crates/fyn/tests/it/build.rs
@@ -129,6 +129,72 @@ fn build_basic() -> Result<()> {
 }
 
 #[test]
+fn build_rejects_cache_dir_inside_source() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let source = context.temp_dir.path().parent().unwrap();
+
+    fs_err::write(
+        source.join("pyproject.toml"),
+        indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+    "#},
+    )?;
+    fs_err::create_dir_all(source.join("src/project"))?;
+    fs_err::write(source.join("src/project/__init__.py"), "")?;
+
+    context
+        .build()
+        .arg(source)
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains("The cache directory"))
+        .stderr(predicate::str::contains(
+            "is inside the build source directory",
+        ));
+
+    Ok(())
+}
+
+#[test]
+fn build_rejects_missing_backend_path() -> Result<()> {
+    let context = fyn_test::test_context!("3.12");
+    let project = context.temp_dir.child("project");
+
+    project.child("pyproject.toml").write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+
+        [build-system]
+        requires = []
+        backend-path = ["backend"]
+        build-backend = "backend"
+    "#})?;
+    project.child("src/project/__init__.py").touch()?;
+
+    context
+        .build()
+        .arg(project.path())
+        .assert()
+        .failure()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "`backend-path` entry `backend` does not exist or is not a directory",
+        ));
+
+    Ok(())
+}
+
+#[test]
 fn build_sdist() -> Result<()> {
     let context = fyn_test::test_context!("3.12");
     let filters = context


### PR DESCRIPTION
## Summary

  - bump `astral-tokio-tar` to `0.6.3`
  - reject invalid UTF-8 in URL credentials and propagate those errors through auth, index, git, project, publish, and client paths
  - reject builds when active cache directory is inside build source tree
  - validate PEP 517 `backend-path` entries before backend import
  - reject wheels with multiple top-level `.dist-info` directories
  - reject malformed HTTP cache entries without integer overflow
  - avoid recursive requirements include loops through path aliases
  - quote POSIX activation paths with shell metacharacters
  - avoid tracing secret-bearing keyring/download fields

  ## Tests

  - `cargo check -p fyn -p fyn-auth -p fyn-client -p fyn-distribution-types -p fyn-distribution -p fyn-git -p fyn-publish -p fyn-build-frontend -p fyn-shell -p fyn-requirements-txt -p fyn-install-wheel -p fyn-python`
  - `cargo test -p fyn-auth from_url --lib`
  - `cargo test -p fyn-distribution-types invalid_url_credentials_report_index_context --lib`
  - `cargo test -p fyn-shell --lib`
  - `cargo test -p fyn-client --test it`
  - `cargo test -p fyn-install-wheel multiple_dist_info_directories_are_rejected --lib`
  - `cargo test -p fyn-requirements-txt recursive_inclusion_path_alias --lib`
  - `cargo test -p fyn --test it build_rejects_`