### PR TITLE
docs: point security reports at fyn and fix 0.10.15 changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 0.10.15
 
-Released on 2026-06-30.
+Released on 2026-07-08.
 
 ### Other changes
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,9 +7,19 @@ nature of Python itself, there are many cases where fyn can execute arbitrary co
 - fyn builds source distributions as described by PEP 517
 - fyn may build packages from the requested package indexes
 
-These are not considered vulnerabilities in fyn. If you think uv's stance in these areas can be
+These are not considered vulnerabilities in fyn. If you think fyn's stance in these areas can be
 hardened, please file an issue for a new feature.
 
-If you believe you have found a vulnerability that is in scope for the project, please contact us as
-described in the organization
-[Security Policy](https://github.com/astral-sh/.github/blob/main/SECURITY.md).
+## Reporting a vulnerability
+
+If you believe you have found a vulnerability that is in scope for the project, please report it
+privately via
+[GitHub private vulnerability reporting](https://github.com/duriantaco/fyn/security/advisories/new).
+Please do not report security vulnerabilities through public issues, discussions, or pull requests.
+
+We will acknowledge your report as soon as possible and keep you informed as we work on a fix.
+
+fyn is a fork of [uv](https://github.com/astral-sh/uv). If a vulnerability also affects uv, please
+additionally report it to the uv maintainers as described in their
+[security policy](https://github.com/astral-sh/.github/blob/main/SECURITY.md) so that both projects
+can be fixed.


### PR DESCRIPTION
## Summary

- **SECURITY.md** still sent vulnerability reports to Astral's org-level security policy and said "if you think **uv's** stance … can be hardened" — fork leftovers. An independent fork needs its own reporting channel: reports now go to this repo's [GitHub private vulnerability reporting](https://github.com/duriantaco/fyn/security/advisories/new) (now enabled in repo settings), with a note asking reporters to also notify uv upstream when a vulnerability is shared with uv.
- **CHANGELOG.md** claimed 0.10.15 was "Released on 2026-06-30", but the Release workflow was never dispatched — GitHub and PyPI are both still on 0.10.14 (see #183). Date updated to match the actual release.

## Test plan

- `prettier --check` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)