### PR TITLE
ci: harden release publishing

### DIFF
--- a/.github/workflows/build-dev-binaries.yml
+++ b/.github/workflows/build-dev-binaries.yml
@@ -354,10 +354,11 @@ jobs:
           cross build --target x86_64-unknown-freebsd --profile no-debug
 
       - name: Test in Firecracker VM
-        uses: acj/freebsd-firecracker-action@fc385d0cbf5bd56af2a6caebc6d94b8197c874b0 # v0.8.1
+        uses: acj/freebsd-firecracker-action@e04896d2dd91f7ec7381e5f363c6fbe83ee445c3 # v0.11.0
         with:
           verbose: false
           checkout: false
+          vcpu-count: 1
           pre-run: |
             # The exclude `*` prevents examination of directories so we need to
             # include each parent directory of the binary

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Run dist plan
         run: |
           dist plan --output-format=json > plan-dist-manifest.json
+          python3 scripts/validate-release.py plan \
+            --manifest plan-dist-manifest.json \
+            --repo "${GITHUB_REPOSITORY}"
           echo "dist plan completed successfully"
           cat plan-dist-manifest.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             [[ "$file" == "rust-toolchain.toml" || "$file" =~ ^\.cargo/ ]] && rust_config_changed=1
             [[ "$file" == "pyproject.toml" || "$file" =~ ^crates/.*/pyproject\.toml$ ]] && python_config_changed=1
             [[ "$file" =~ ^\.github/workflows/.*\.yml$ ]] && workflow_changed=1
-            [[ "$file" == ".github/workflows/build-release-binaries.yml" ]] && release_workflow_changed=1
+            [[ "$file" =~ ^\.github/workflows/(build-release-binaries|release|verify-release|publish-pypi)\.yml$ || "$file" == "dist-workspace.toml" || "$file" =~ ^scripts/(validate|verify)-release\.py$ ]] && release_workflow_changed=1
             [[ "$file" == "scripts/check_uv_wheel_contents.py" ]] && release_build_changed=1
             [[ "$file" == ".github/workflows/ci.yml" ]] && ci_workflow_changed=1
             [[ "$file" == "fyn.schema.json" ]] && schema_changed=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,7 @@
 # title/body based on your changelogs.
 
 name: Release
-permissions:
-  "contents": "write"
+permissions: {}
 
 # This task will run whenever you workflow_dispatch with a tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -55,10 +54,11 @@ jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
     runs-on: "ubuntu-latest"
+    permissions:
+      "contents": "read"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ (inputs.tag != 'dry-run' && inputs.tag) || '' }}
-      tag-flag: ${{ inputs.tag && inputs.tag != 'dry-run' && format('--tag={0}', inputs.tag) || '' }}
       publishing: ${{ inputs.tag && inputs.tag != 'dry-run' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,8 +85,20 @@ jobs:
       # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          dist ${{ (inputs.tag && inputs.tag != 'dry-run' && format('host --steps=create --tag={0}', inputs.tag)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          if [[ "$RELEASE_TAG" != "dry-run" ]]; then
+            python3 scripts/validate-release.py metadata --tag "$RELEASE_TAG"
+            dist_args=(host --steps=create "--tag=$RELEASE_TAG")
+          else
+            dist_args=(plan)
+          fi
+
+          dist "${dist_args[@]}" --output-format=json > plan-dist-manifest.json
+          python3 scripts/validate-release.py plan \
+            --manifest plan-dist-manifest.json \
+            --repo "${GITHUB_REPOSITORY}"
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -103,30 +115,19 @@ jobs:
     uses: ./.github/workflows/build-release-binaries.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
-
-  custom-build-docker:
-    needs:
-      - plan
-    if: ${{ github.repository == 'astral-sh/uv' && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run') }}
-    uses: ./.github/workflows/build-docker.yml
-    with:
-      plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
     permissions:
-      "attestations": "write"
       "contents": "read"
-      "id-token": "write"
-      "packages": "write"
 
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
       - custom-build-release-binaries
-      - custom-build-docker
-    if: ${{ always() && needs.plan.result == 'success' && (needs.custom-build-release-binaries.result == 'skipped' || needs.custom-build-release-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && (needs.custom-build-release-binaries.result == 'skipped' || needs.custom-build-release-binaries.result == 'success') }}
     runs-on: "ubuntu-latest"
+    permissions:
+      "actions": "read"
+      "contents": "read"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -150,14 +151,22 @@ jobs:
           merge-multiple: true
       - id: cargo-dist
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
         run: |
-          dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json
+          dist_args=(build)
+          if [[ -n "$RELEASE_TAG" ]]; then
+            dist_args+=("--tag=$RELEASE_TAG")
+          fi
+          dist "${dist_args[@]}" --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
           # Parse out what we just built and upload it to scratch storage
-          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
-          jq --raw-output ".upload_files[]" dist-manifest.json >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "paths<<EOF"
+            jq --raw-output ".upload_files[]" dist-manifest.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
@@ -172,13 +181,15 @@ jobs:
     needs:
       - plan
       - custom-build-release-binaries
-      - custom-build-docker
       - build-global-artifacts
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-release-binaries.result == 'skipped' || needs.custom-build-release-binaries.result == 'success') && (needs.custom-build-docker.result == 'skipped' || needs.custom-build-docker.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.custom-build-release-binaries.result == 'skipped' || needs.custom-build-release-binaries.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-latest"
+    permissions:
+      "actions": "read"
+      "contents": "read"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -202,8 +213,14 @@ jobs:
       # This is a harmless no-op for GitHub Releases, hosting for that happens in "announce"
       - id: host
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
         run: |
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
+          dist_args=(host)
+          if [[ -n "$RELEASE_TAG" ]]; then
+            dist_args+=("--tag=$RELEASE_TAG")
+          fi
+          dist "${dist_args[@]}" --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -218,11 +235,10 @@ jobs:
     needs:
       - plan
       - host
-    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.host.result == 'success' && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
     uses: ./.github/workflows/publish-pypi.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
     # publish jobs get escalated permissions
     permissions:
       "actions": "read"
@@ -236,10 +252,9 @@ jobs:
       - plan
       - host
       - custom-publish-pypi
-    # use "always() && ..." to allow us to wait for all publish jobs while
-    # still allowing individual publish jobs to skip themselves (for prereleases).
-    # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.custom-publish-pypi.result == 'skipped' || needs.custom-publish-pypi.result == 'success') }}
+    # Stable releases must publish to PyPI before GitHub is announced. A skipped
+    # PyPI job is only valid for prereleases when prerelease publishing is disabled.
+    if: ${{ always() && needs.plan.result == 'success' && needs.host.result == 'success' && (needs.custom-publish-pypi.result == 'success' || (needs.custom-publish-pypi.result == 'skipped' && fromJson(needs.plan.outputs.val).announcement_is_prerelease && !fromJson(needs.plan.outputs.val).publish_prereleases)) }}
     runs-on: "ubuntu-latest"
     permissions:
       "attestations": "write"
@@ -274,46 +289,50 @@ jobs:
             artifacts/*.tar.gz
       - name: Create GitHub Release
         env:
-          PRERELEASE_FLAG: "${{ fromJson(needs.host.outputs.val).announcement_is_prerelease && '--prerelease' || '' }}"
+          IS_PRERELEASE: "${{ fromJson(needs.host.outputs.val).announcement_is_prerelease }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(needs.host.outputs.val).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(needs.host.outputs.val).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
+          RELEASE_TAG: "${{ needs.plan.outputs.tag }}"
         run: |
           # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
           python3 scripts/normalize_release_notes.py \
             --notes-file "$RUNNER_TEMP/notes.txt" \
             --artifacts-dir artifacts \
             --repo "${GITHUB_REPOSITORY}" \
-            --tag "${{ needs.plan.outputs.tag }}"
+            --tag "$RELEASE_TAG"
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          release_args=(
+            "$RELEASE_TAG"
+            --target "$RELEASE_COMMIT"
+            --title "$ANNOUNCEMENT_TITLE"
+            --notes-file "$RUNNER_TEMP/notes.txt"
+          )
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${release_args[@]}" artifacts/*
 
   custom-publish-docs:
     needs:
       - plan
       - announce
+    if: ${{ always() && needs.plan.result == 'success' && needs.announce.result == 'success' }}
     uses: ./.github/workflows/publish-docs.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
-
-  custom-publish-versions:
-    needs:
-      - plan
-      - announce
-    uses: ./.github/workflows/publish-versions.yml
-    with:
-      plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
-
-  custom-publish-mirror:
-    needs:
-      - plan
-      - announce
-    uses: ./.github/workflows/publish-mirror.yml
-    with:
-      plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
     permissions:
+      "contents": "write"
+
+  custom-verify-release:
+    needs:
+      - plan
+      - announce
+    if: ${{ always() && needs.plan.result == 'success' && needs.announce.result == 'success' }}
+    uses: ./.github/workflows/verify-release.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    permissions:
+      "actions": "read"
       "contents": "read"

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,55 @@
+name: "Verify release"
+
+on:
+  workflow_call:
+    inputs:
+      plan:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  verify-release:
+    name: Verify published release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download final release manifest
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: artifacts-dist-manifest
+          path: release-manifest
+
+      - name: Verify GitHub and PyPI publications
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_COMMIT: ${{ github.sha }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_RUN_ID: ${{ github.run_id }}
+          RELEASE_TAG: ${{ fromJson(inputs.plan).announcement_tag }}
+          VERIFY_PYPI: ${{ (!fromJson(inputs.plan).announcement_is_prerelease || fromJson(inputs.plan).publish_prereleases) && 'true' || 'false' }}
+        run: |
+          args=(
+            --repo "$RELEASE_REPOSITORY"
+            --tag "$RELEASE_TAG"
+            --commit "$RELEASE_COMMIT"
+            --run-id "$RELEASE_RUN_ID"
+            --manifest release-manifest/dist-manifest.json
+          )
+
+          if [[ "$VERIFY_PYPI" == "true" ]]; then
+            args+=(
+              --pypi-package "fyn=wheels_fyn-"
+              --pypi-package "fyn-build=wheels_fyn_build-"
+            )
+          fi
+
+          python3 scripts/verify-release.py "${args[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 0.10.15
 
-Released on 2026-07-08.
+Released on 2026-08-12.
 
 ### Other changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,5 +293,7 @@ Then, open a pull request, e.g., `Bump version to ...`.
 
 Binary builds will automatically be tested for the release.
 
-After merging the pull request, run the release workflow with the version tag. **Do not include a
-leading `v`**. The release will automatically be created on GitHub after everything else publishes.
+After merging the pull request, run the release workflow with `dry-run` and wait for every required
+build to pass. Then run it again with the version tag. **Do not include a leading `v`**. Stable
+releases publish to PyPI before GitHub is announced, and a final verification job checks the GitHub
+assets, installer URLs, and both PyPI projects.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -55,14 +55,16 @@ github-attestations-phase = "announce"
 github-attestations-filters = ["*.json", "*.sh", "*.ps1", "*.zip", "*.tar.gz"]
 # Whether CI should include auto-generated code to build local artifacts
 build-local-artifacts = false
-# Local artifacts jobs to run in CI
-local-artifacts-jobs = ["./build-release-binaries", "./build-docker"]
+# Local artifacts jobs to run in release CI. Docker publishing is intentionally
+# kept separate until fyn has its own registry configuration.
+local-artifacts-jobs = ["./build-release-binaries"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi"]
-# Post-announce jobs to run in CI
-post-announce-jobs = ["./publish-docs", "./publish-versions", "./publish-mirror"]
+# Post-announce jobs to run in CI. The upstream versions repository and R2
+# mirror require Astral-owned credentials, so they are not fyn release targets.
+post-announce-jobs = ["./publish-docs", "./verify-release"]
 # Custom permissions for GitHub Jobs
-github-custom-job-permissions = { "build-docker" = { packages = "write", contents = "read", id-token = "write", attestations = "write" }, "publish-mirror" = { contents = "read" } }
+github-custom-job-permissions = { "publish-docs" = { contents = "write" }, "verify-release" = { actions = "read", contents = "read" } }
 # Whether to install an updater program
 install-updater = false
 # Path that installers should place binaries in

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -103,6 +103,10 @@ pushd crates/fyn-trampoline; cargo update; popd
 echo "Generating JSON schema..."
 cargo dev generate-json-schema
 
+release_version="$("${fyn_cmd[@]}" version --short)"
+echo "Validating release metadata..."
+python3 scripts/validate-release.py metadata --tag "$release_version"
+
 echo "Creating release branch..."
-git checkout -b "release/$("${fyn_cmd[@]}" version --short)"
-git commit -am "Bump version to $("${fyn_cmd[@]}" version --short)"
+git checkout -b "release/$release_version"
+git commit -am "Bump version to $release_version"

--- a/scripts/validate-release.py
+++ b/scripts/validate-release.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+VERSION_FILES = {
+    Path("pyproject.toml"): ("project", "version"),
+    Path("crates/fyn/Cargo.toml"): ("package", "version"),
+    Path("crates/fyn-build/Cargo.toml"): ("package", "version"),
+    Path("crates/fyn-build/pyproject.toml"): ("project", "version"),
+    Path("crates/fyn-version/Cargo.toml"): ("package", "version"),
+    Path("Cargo.toml"): ("workspace", "dependencies", "fyn-version", "version"),
+}
+LOCKED_PACKAGES = {"fyn", "fyn-build", "fyn-version"}
+
+
+def read_toml_value(path: Path, keys: tuple[str, ...]) -> Any:
+    value: Any = tomllib.loads(path.read_text())
+    for key in keys:
+        value = value[key]
+    return value
+
+
+def validate_metadata(tag: str, release_date: date) -> list[str]:
+    errors: list[str] = []
+
+    if tag.startswith("v"):
+        errors.append(f"release tag must not have a leading 'v': {tag}")
+
+    for relative_path, keys in VERSION_FILES.items():
+        version = read_toml_value(PROJECT_ROOT / relative_path, keys)
+        if version != tag:
+            errors.append(f"{relative_path} has version {version!r}, expected {tag!r}")
+
+    cargo_lock = tomllib.loads((PROJECT_ROOT / "Cargo.lock").read_text())
+    locked_versions = {
+        package["name"]: package["version"]
+        for package in cargo_lock["package"]
+        if package["name"] in LOCKED_PACKAGES
+    }
+    for package in sorted(LOCKED_PACKAGES):
+        version = locked_versions.get(package)
+        if version != tag:
+            errors.append(
+                f"Cargo.lock package {package!r} has version {version!r}, "
+                f"expected {tag!r}"
+            )
+
+    changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text()
+    match = re.search(
+        rf"^## {re.escape(tag)}\n\nReleased on (\d{{4}}-\d{{2}}-\d{{2}})\.$",
+        changelog,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        errors.append(
+            f"CHANGELOG.md must contain '## {tag}' followed by a release date"
+        )
+    else:
+        try:
+            changelog_date = date.fromisoformat(match.group(1))
+        except ValueError:
+            errors.append(f"CHANGELOG.md has an invalid release date: {match.group(1)}")
+        else:
+            if abs((changelog_date - release_date).days) > 1:
+                errors.append(
+                    "CHANGELOG.md release date is not within one day of today: "
+                    f"{changelog_date} vs {release_date}"
+                )
+
+    return errors
+
+
+def validate_plan(manifest_path: Path, repo: str) -> list[str]:
+    errors: list[str] = []
+    manifest = json.loads(manifest_path.read_text())
+
+    try:
+        owner, repository = repo.split("/", maxsplit=1)
+    except ValueError:
+        return [f"repository must use owner/name form: {repo!r}"]
+
+    announcement_tag = manifest.get("announcement_tag")
+    if not isinstance(announcement_tag, str) or not announcement_tag:
+        errors.append("release plan does not contain an announcement_tag")
+        return errors
+    version = announcement_tag.removeprefix("v")
+
+    releases = manifest.get("releases")
+    if not isinstance(releases, list) or not releases:
+        errors.append("release plan does not contain any releases")
+        return errors
+
+    expected_base_url = (
+        f"https://github.com/{repo}/releases/download/{announcement_tag}"
+    )
+    expected_download_path = f"/{repo}/releases/download/{announcement_tag}"
+
+    for release in releases:
+        app_name = release.get("app_name")
+        if release.get("app_version") != version:
+            errors.append(
+                f"{app_name or 'release'} version {release.get('app_version')!r} "
+                f"does not match planned version {version!r}"
+            )
+
+        artifacts = set(release.get("artifacts", []))
+        for suffix in ("-installer.sh", "-installer.ps1"):
+            if not any(artifact.endswith(suffix) for artifact in artifacts):
+                errors.append(f"{app_name or 'release'} is missing a {suffix} artifact")
+
+        hosting = release.get("hosting", {})
+        github = hosting.get("github", {})
+        simple = hosting.get("simple", {})
+        if github.get("owner") != owner or github.get("repo") != repository:
+            errors.append(
+                f"{app_name or 'release'} GitHub hosting points to "
+                f"{github.get('owner')}/{github.get('repo')}, expected {repo}"
+            )
+        if github.get("artifact_download_path") != expected_download_path:
+            errors.append(
+                f"{app_name or 'release'} GitHub download path is incorrect: "
+                f"{github.get('artifact_download_path')!r}"
+            )
+        if simple.get("download_url") != expected_base_url:
+            errors.append(
+                f"{app_name or 'release'} simple download URL is incorrect: "
+                f"{simple.get('download_url')!r}"
+            )
+
+    return errors
+
+
+def report(errors: list[str]) -> None:
+    if not errors:
+        return
+    for error in errors:
+        print(f"error: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    metadata = subparsers.add_parser("metadata")
+    metadata.add_argument("--tag", required=True)
+    metadata.add_argument(
+        "--date",
+        type=date.fromisoformat,
+        default=datetime.now(UTC).date(),
+        help="Expected release date in YYYY-MM-DD format (defaults to today in UTC)",
+    )
+
+    plan = subparsers.add_parser("plan")
+    plan.add_argument("--manifest", required=True, type=Path)
+    plan.add_argument("--repo", required=True)
+
+    args = parser.parse_args()
+    if args.command == "metadata":
+        report(validate_metadata(args.tag, args.date))
+        print(f"Release metadata is valid for {args.tag} ({args.date})")
+    else:
+        report(validate_plan(args.manifest, args.repo))
+        print(f"Release plan is valid for {args.repo}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-release.py
+++ b/scripts/verify-release.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def fetch(
+    url: str,
+    *,
+    token: str | None,
+    attempts: int,
+    retry_delay: float,
+) -> bytes:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "fyn-release-verifier",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(
+                urllib.request.Request(url, headers=headers), timeout=30
+            ) as response:
+                return response.read()
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as error:
+            last_error = error
+            if attempt == attempts:
+                break
+            print(
+                f"Waiting for release data ({attempt}/{attempts}): {error}",
+                file=sys.stderr,
+            )
+            time.sleep(retry_delay)
+
+    raise VerificationError(f"failed to fetch {url}: {last_error}")
+
+
+def fetch_json(
+    url: str,
+    *,
+    token: str | None,
+    attempts: int,
+    retry_delay: float,
+) -> dict[str, Any]:
+    return json.loads(
+        fetch(
+            url,
+            token=token,
+            attempts=attempts,
+            retry_delay=retry_delay,
+        )
+    )
+
+
+def expected_release_assets(manifest_path: Path, tag: str) -> set[str]:
+    manifest = json.loads(manifest_path.read_text())
+    if manifest.get("announcement_tag") != tag:
+        raise VerificationError(
+            f"release manifest tag {manifest.get('announcement_tag')!r} "
+            f"does not match {tag!r}"
+        )
+
+    expected: set[str] = set()
+    for release in manifest.get("releases", []):
+        expected.update(release.get("artifacts", []))
+    if not expected:
+        raise VerificationError("release manifest does not list any GitHub assets")
+    return expected
+
+
+def verify_github_release(
+    *,
+    repo: str,
+    tag: str,
+    commit: str,
+    manifest_path: Path,
+    token: str | None,
+    attempts: int,
+    retry_delay: float,
+) -> None:
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    api_base = f"https://api.github.com/repos/{repo}"
+    release = fetch_json(
+        f"{api_base}/releases/tags/{encoded_tag}",
+        token=token,
+        attempts=attempts,
+        retry_delay=retry_delay,
+    )
+    if release.get("tag_name") != tag:
+        raise VerificationError(
+            f"GitHub release tag is {release.get('tag_name')!r}, expected {tag!r}"
+        )
+
+    tagged_commit = fetch_json(
+        f"{api_base}/commits/{encoded_tag}",
+        token=token,
+        attempts=attempts,
+        retry_delay=retry_delay,
+    ).get("sha")
+    if tagged_commit != commit:
+        raise VerificationError(
+            f"GitHub tag resolves to {tagged_commit!r}, expected {commit!r}"
+        )
+
+    expected_assets = expected_release_assets(manifest_path, tag)
+    assets = {asset["name"]: asset for asset in release.get("assets", [])}
+    missing_assets = sorted(expected_assets - assets.keys())
+    if missing_assets:
+        raise VerificationError(
+            "GitHub release is missing assets: " + ", ".join(missing_assets)
+        )
+
+    expected_url = f"https://github.com/{repo}/releases/download/{tag}"
+    installer_names = sorted(
+        name
+        for name in expected_assets
+        if name.endswith("-installer.sh") or name.endswith("-installer.ps1")
+    )
+    if not installer_names:
+        raise VerificationError("GitHub release does not contain installer scripts")
+
+    release_url_pattern = re.compile(
+        r"https://github\.com/([^/\s\"']+/[^/\s\"']+)/releases/download/([^/\s\"']+)"
+    )
+    for installer_name in installer_names:
+        installer = fetch(
+            assets[installer_name]["browser_download_url"],
+            token=None,
+            attempts=attempts,
+            retry_delay=retry_delay,
+        ).decode()
+        if expected_url not in installer:
+            raise VerificationError(
+                f"{installer_name} does not contain the expected URL {expected_url}"
+            )
+        wrong_urls = sorted(
+            url for url in release_url_pattern.findall(installer) if url != (repo, tag)
+        )
+        if wrong_urls:
+            raise VerificationError(
+                f"{installer_name} contains incorrect release URLs: {wrong_urls}"
+            )
+
+    print(
+        f"Verified GitHub release {tag}: {len(expected_assets)} expected assets, "
+        f"{len(installer_names)} installers"
+    )
+
+
+def github_run_artifacts(
+    *,
+    repo: str,
+    run_id: str,
+    token: str | None,
+    attempts: int,
+    retry_delay: float,
+) -> list[dict[str, Any]]:
+    artifacts: list[dict[str, Any]] = []
+    for page in range(1, 100):
+        response = fetch_json(
+            f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/artifacts"
+            f"?per_page=100&page={page}",
+            token=token,
+            attempts=attempts,
+            retry_delay=retry_delay,
+        )
+        page_artifacts = response.get("artifacts", [])
+        artifacts.extend(page_artifacts)
+        if len(page_artifacts) < 100:
+            return artifacts
+    raise VerificationError("release run has too many artifact pages")
+
+
+def verify_pypi(
+    *,
+    repo: str,
+    run_id: str,
+    tag: str,
+    package_prefixes: list[tuple[str, str]],
+    token: str | None,
+    attempts: int,
+    retry_delay: float,
+) -> None:
+    run_artifacts = github_run_artifacts(
+        repo=repo,
+        run_id=run_id,
+        token=token,
+        attempts=attempts,
+        retry_delay=retry_delay,
+    )
+    artifact_names = {
+        artifact["name"] for artifact in run_artifacts if not artifact.get("expired")
+    }
+
+    for project, prefix in package_prefixes:
+        expected_count = sum(name.startswith(prefix) for name in artifact_names)
+        if expected_count == 0:
+            raise VerificationError(
+                f"release run does not contain artifacts with prefix {prefix!r}"
+            )
+
+        encoded_project = urllib.parse.quote(project, safe="")
+        encoded_tag = urllib.parse.quote(tag, safe="")
+        response = fetch_json(
+            f"https://pypi.org/pypi/{encoded_project}/{encoded_tag}/json",
+            token=None,
+            attempts=attempts,
+            retry_delay=retry_delay,
+        )
+        if response.get("info", {}).get("version") != tag:
+            raise VerificationError(
+                f"PyPI project {project} did not publish version {tag}"
+            )
+
+        filenames = {item["filename"] for item in response.get("urls", [])}
+        if len(filenames) != expected_count:
+            raise VerificationError(
+                f"PyPI project {project} has {len(filenames)} files for {tag}; "
+                f"the release run produced {expected_count} artifacts"
+            )
+        if not any(filename.endswith(".whl") for filename in filenames):
+            raise VerificationError(f"PyPI project {project} has no wheels for {tag}")
+        if not any(filename.endswith(".tar.gz") for filename in filenames):
+            raise VerificationError(f"PyPI project {project} has no sdist for {tag}")
+
+        print(f"Verified PyPI project {project} {tag}: {len(filenames)} distributions")
+
+
+def parse_package_prefix(value: str) -> tuple[str, str]:
+    try:
+        project, prefix = value.split("=", maxsplit=1)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("expected PROJECT=ARTIFACT_PREFIX") from error
+    if not project or not prefix:
+        raise argparse.ArgumentTypeError("expected PROJECT=ARTIFACT_PREFIX")
+    return project, prefix
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument(
+        "--pypi-package",
+        action="append",
+        default=[],
+        type=parse_package_prefix,
+        metavar="PROJECT=ARTIFACT_PREFIX",
+    )
+    parser.add_argument("--attempts", type=int, default=12)
+    parser.add_argument("--retry-delay", type=float, default=5)
+    args = parser.parse_args()
+
+    token = os.environ.get("GH_TOKEN")
+
+    verify_github_release(
+        repo=args.repo,
+        tag=args.tag,
+        commit=args.commit,
+        manifest_path=args.manifest,
+        token=token,
+        attempts=args.attempts,
+        retry_delay=args.retry_delay,
+    )
+    if args.pypi_package:
+        verify_pypi(
+            repo=args.repo,
+            run_id=args.run_id,
+            tag=args.tag,
+            package_prefixes=args.pypi_package,
+            token=token,
+            attempts=args.attempts,
+            retry_delay=args.retry_delay,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- make stable release publishing wait for PyPI success
- remove fork-inapplicable Docker, Astral versions, and R2 jobs from the release chain
- validate release metadata and installer hosting before publishing
- verify GitHub assets and both PyPI projects after publishing
- update the FreeBSD Firecracker action to v0.11.0 with one vCPU
- correct the 0.10.15 changelog date

Addresses #183.

## Validation

- cargo-dist 0.31.0 dry plan
- live verification of the 0.10.15 GitHub assets and PyPI packages
- repository-wide Ruff lint and formatting
- Prettier and rustfmt
- ShellCheck, actionlint, and zizmor