### PR TITLE
feat: upgrade project dependency constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,17 +164,24 @@ Upgrade all or specific dependencies in one command:
 
 ```console
 $ fyn upgrade
-info: Upgrading all dependencies...
 success: Dependencies upgraded successfully.
 
 $ fyn upgrade requests flask
-info: Upgrading: requests, flask
+success: Dependencies upgraded successfully.
+
+$ fyn upgrade --exclude django
 success: Dependencies upgraded successfully.
 ```
 
-Supports `--dry-run` and `--no-sync`.
+`fyn upgrade` resolves the newest versions of the selected direct dependencies, widens only the
+version constraints that block those versions, updates `pyproject.toml` and `fyn.lock`, and syncs
+the environment. Lower bounds, exclusions, extras, markers, and the existing constraint style are
+preserved where possible.
 
-`fyn upgrade` is the convenience form of running `fyn lock --upgrade` and then `fyn sync`.
+Use `--dry-run` to preview both lock and requirement changes, `--no-sync` to update the manifest and
+lockfile without touching the environment, and `--exclude PACKAGE` to omit dependencies from an
+all-package upgrade. Manifest and lockfile changes are rolled back if locking or syncing fails. This
+first version upgrades `[project].dependencies` in single-project workspaces.
 
 ### Explain dependencies
 
@@ -430,19 +437,19 @@ behavior. Projects still need `[tool.uv]` renamed to `[tool.fyn]` and `uv.lock` 
 See [MANIFESTO.md](https://github.com/duriantaco/fyn/blob/main/MANIFESTO.md) for the fuller
 comparison, or the table below for some of the larger user-visible differences:
 
-| Area                          | uv                                    | fyn                                           |
-| ----------------------------- | ------------------------------------- | --------------------------------------------- |
-| Config namespace and lockfile | `[tool.uv]`, `uv.lock`                | `[tool.fyn]`, `fyn.lock`                      |
-| Package index User-Agent      | `uv/<version>` plus LineHaul metadata | Minimal `fyn/<version>`                       |
-| Task runner                   | No `[tool.uv.tasks]`                  | `[tool.fyn.tasks]`                            |
-| `shell` command               | No `uv shell`                         | `fyn shell`                                   |
-| `upgrade` command             | No `uv upgrade`                       | `fyn upgrade`                                 |
-| `why` command                 | No `uv why`                           | `fyn why`                                     |
-| `status` command              | No `uv status`                        | `fyn status`                                  |
-| `torch doctor` command        | No `uv torch doctor`                  | `fyn torch doctor`                            |
-| Managed-project `pip` policy  | No `pip-in-project` setting           | `pip-in-project`: `warn`, `error`, or `allow` |
-| Cache size limit              | No `UV_CACHE_MAX_SIZE`                | `UV_CACHE_MAX_SIZE`                           |
-| Custom lockfile name          | No `UV_LOCKFILE`                      | `UV_LOCKFILE`                                 |
+| Area                          | uv                                    | fyn                                             |
+| ----------------------------- | ------------------------------------- | ----------------------------------------------- |
+| Config namespace and lockfile | `[tool.uv]`, `uv.lock`                | `[tool.fyn]`, `fyn.lock`                        |
+| Package index User-Agent      | `uv/<version>` plus LineHaul metadata | Minimal `fyn/<version>`                         |
+| Task runner                   | No `[tool.uv.tasks]`                  | `[tool.fyn.tasks]`                              |
+| `shell` command               | No `uv shell`                         | `fyn shell`                                     |
+| `upgrade` command             | Hidden, manifest-only experiment      | Public; updates manifest, lock, and environment |
+| `why` command                 | No `uv why`                           | `fyn why`                                       |
+| `status` command              | No `uv status`                        | `fyn status`                                    |
+| `torch doctor` command        | No `uv torch doctor`                  | `fyn torch doctor`                              |
+| Managed-project `pip` policy  | No `pip-in-project` setting           | `pip-in-project`: `warn`, `error`, or `allow`   |
+| Cache size limit              | No `UV_CACHE_MAX_SIZE`                | `UV_CACHE_MAX_SIZE`                             |
+| Custom lockfile name          | No `UV_LOCKFILE`                      | `UV_LOCKFILE`                                   |
 
 ## Acknowledgements
 

--- a/crates/fyn-cli/src/lib.rs
+++ b/crates/fyn-cli/src/lib.rs
@@ -5354,7 +5354,12 @@ pub struct UpgradeArgs {
     ///
     /// If not provided, all packages in the project will be upgraded to
     /// their latest compatible versions.
-    pub packages: Vec<String>,
+    #[arg(value_hint = ValueHint::Other)]
+    pub packages: Vec<PackageName>,
+
+    /// Exclude the named package from upgrades.
+    #[arg(long, value_hint = ValueHint::Other)]
+    pub exclude: Vec<PackageName>,
 
     /// Perform a dry run, showing what would be upgraded without making changes.
     #[arg(long)]
@@ -5363,6 +5368,15 @@ pub struct UpgradeArgs {
     /// Do not sync the environment after upgrading the lockfile.
     #[arg(long)]
     pub no_sync: bool,
+
+    #[command(flatten)]
+    pub installer: ResolverInstallerArgs,
+
+    #[command(flatten)]
+    pub build: BuildOptionsArgs,
+
+    #[command(flatten)]
+    pub refresh: RefreshArgs,
 
     /// The Python interpreter to use during resolution.
     #[arg(

--- a/crates/fyn-test/src/lib.rs
+++ b/crates/fyn-test/src/lib.rs
@@ -1477,6 +1477,14 @@ impl TestContext {
         command
     }
 
+    /// Create a `fyn upgrade` command with options shared across scenarios.
+    pub fn upgrade(&self) -> Command {
+        let mut command = self.new_command();
+        command.arg("upgrade");
+        self.add_shared_options(&mut command, false);
+        command
+    }
+
     /// Create a `fyn workspace metadata` command with options shared across scenarios.
     pub fn workspace_metadata(&self) -> Command {
         let mut command = self.new_command();

--- a/crates/fyn-workspace/src/pyproject_mut.rs
+++ b/crates/fyn-workspace/src/pyproject_mut.rs
@@ -357,6 +357,50 @@ impl PyProjectTomlMut {
         Ok(edit)
     }
 
+    /// Replaces a dependency in `project.dependencies` without modifying its source.
+    ///
+    /// Returns `Some` if the dependency was replaced, or `None` if it was not found.
+    pub fn replace_dependency(
+        &mut self,
+        req: &Requirement,
+        raw: bool,
+    ) -> Result<Option<ArrayEdit>, Error> {
+        let Some(dependencies) = self
+            .project_mut()?
+            .and_then(|project| project.get_mut("dependencies"))
+            .map(|dependencies| {
+                dependencies
+                    .as_array_mut()
+                    .ok_or(Error::MalformedDependencies)
+            })
+            .transpose()?
+        else {
+            return Ok(None);
+        };
+        let mut to_replace = find_dependencies(&req.name, Some(&req.marker), dependencies);
+
+        match to_replace.as_slice() {
+            [] => Ok(None),
+            [_] => {
+                let (index, _) = to_replace.remove(0);
+                let req_string = if raw {
+                    req.displayable_with_credentials().to_string()
+                } else {
+                    req.to_string()
+                };
+                dependencies.replace(index, req_string);
+                Ok(Some(ArrayEdit::Update(index)))
+            }
+            _ => Err(Error::Ambiguous {
+                package_name: req.name.clone(),
+                requirements: to_replace
+                    .into_iter()
+                    .map(|(_, requirement)| requirement)
+                    .collect(),
+            }),
+        }
+    }
+
     /// Adds a development dependency to `tool.fyn.dev-dependencies`.
     ///
     /// Returns `true` if the dependency was added, `false` if it was updated.
@@ -1790,9 +1834,13 @@ fn split_specifiers(req: &str) -> (&str, &str) {
 
 #[cfg(test)]
 mod test {
-    use super::{AddBoundsKind, reformat_array_multiline, remove_dependency, split_specifiers};
+    use super::{
+        AddBoundsKind, DependencyTarget, PyProjectTomlMut, reformat_array_multiline,
+        remove_dependency, split_specifiers,
+    };
     use fyn_normalize::PackageName;
     use fyn_pep440::Version;
+    use fyn_pep508::Requirement;
     use insta::assert_snapshot;
     use std::str::FromStr;
     use toml_edit::DocumentMut;
@@ -1814,6 +1862,39 @@ mod test {
                 "flask",
                 "@ https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl"
             )
+        );
+    }
+
+    #[test]
+    fn replace_dependency_preserves_source() {
+        let mut pyproject = PyProjectTomlMut::from_toml(
+            r#"[project]
+dependencies = ["anyio<=2"]
+
+[tool.fyn.sources]
+anyio = { index = "internal" }
+"#,
+            DependencyTarget::PyProjectToml,
+        )
+        .unwrap();
+        let requirement = Requirement::from_str("anyio<5").unwrap();
+
+        assert!(
+            pyproject
+                .replace_dependency(&requirement, false)
+                .unwrap()
+                .is_some()
+        );
+
+        assert_snapshot!(
+            pyproject.to_string(),
+            @r#"
+[project]
+dependencies = ["anyio<5"]
+
+[tool.fyn.sources]
+anyio = { index = "internal" }
+"#
         );
     }
 

--- a/crates/fyn/src/commands/project/add.rs
+++ b/crates/fyn/src/commands/project/add.rs
@@ -973,7 +973,7 @@ fn edits(
 
 /// Re-lock and re-sync the project after a series of edits.
 #[expect(clippy::fn_params_excessive_bools)]
-async fn lock_and_sync(
+pub(super) async fn lock_and_sync(
     mut target: AddTarget,
     toml: &mut PyProjectTomlMut,
     edits: &[DependencyEdit],
@@ -1268,7 +1268,7 @@ pub(super) enum PythonTarget {
 
 impl PythonTarget {
     /// Return the [`Interpreter`] for the project.
-    fn interpreter(&self) -> &Interpreter {
+    pub(super) fn interpreter(&self) -> &Interpreter {
         match self {
             Self::Interpreter(interpreter) => interpreter,
             Self::Environment(venv) => venv.interpreter(),
@@ -1317,7 +1317,7 @@ impl AddTarget {
     /// Write the updated content to the target.
     ///
     /// Returns `true` if the content was modified.
-    fn write(&self, content: &str) -> Result<bool, io::Error> {
+    pub(super) fn write(&self, content: &str) -> Result<bool, io::Error> {
         match self {
             Self::Script(script, _) => {
                 if content == script.metadata.raw {
@@ -1342,7 +1342,7 @@ impl AddTarget {
     }
 
     /// Update the target in-memory to incorporate the new content.
-    fn update(self, content: &str) -> Result<Self, ProjectError> {
+    pub(super) fn update(self, content: &str) -> Result<Self, ProjectError> {
         match self {
             Self::Script(mut script, interpreter) => {
                 script.metadata = Pep723Metadata::from_str(content)
@@ -1361,7 +1361,7 @@ impl AddTarget {
     }
 
     /// Take a snapshot of the target.
-    async fn snapshot(&self) -> Result<AddTargetSnapshot, io::Error> {
+    pub(super) async fn snapshot(&self) -> Result<AddTargetSnapshot, io::Error> {
         // Read the lockfile into memory.
         let target = match self {
             Self::Script(script, _) => LockTarget::from(script),
@@ -1379,14 +1379,14 @@ impl AddTarget {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
-enum AddTargetSnapshot {
+pub(super) enum AddTargetSnapshot {
     Script(Pep723Script, Option<Vec<u8>>),
     Project(VirtualProject, Option<Vec<u8>>),
 }
 
 impl AddTargetSnapshot {
     /// Write the snapshot back to disk (e.g., to a `pyproject.toml` and `fyn.lock`).
-    fn revert(&self) -> Result<(), io::Error> {
+    pub(super) fn revert(&self) -> Result<(), io::Error> {
         match self {
             Self::Script(script, lock) => {
                 // Write the PEP 723 script back to disk.
@@ -1438,7 +1438,7 @@ impl AddTargetSnapshot {
 }
 
 #[derive(Debug, Clone)]
-struct DependencyEdit {
+pub(super) struct DependencyEdit {
     dependency_type: DependencyType,
     requirement: fyn_pep508::Requirement,
     source: Option<Source>,

--- a/crates/fyn/src/commands/project/lock.rs
+++ b/crates/fyn/src/commands/project/lock.rs
@@ -1554,7 +1554,7 @@ impl ValidatedLock {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct LockEventVersion<'lock> {
+pub(super) struct LockEventVersion<'lock> {
     /// The version of the package, or `None` if the package has a dynamic version.
     version: Option<&'lock Version>,
     /// The short Git SHA of the package, if it was installed from a Git repository.
@@ -1583,7 +1583,7 @@ impl std::fmt::Display for LockEventVersion<'_> {
 
 /// A modification to a lockfile.
 #[derive(Debug, Clone)]
-enum LockEvent<'lock> {
+pub(super) enum LockEvent<'lock> {
     Update(
         DryRun,
         PackageName,
@@ -1596,7 +1596,7 @@ enum LockEvent<'lock> {
 
 impl<'lock> LockEvent<'lock> {
     /// Detect the change events between an (optional) existing and updated lockfile.
-    fn detect_changes(
+    pub(super) fn detect_changes(
         existing_lock: Option<&'lock Lock>,
         new_lock: &'lock Lock,
         dry_run: DryRun,
@@ -1656,6 +1656,14 @@ impl<'lock> LockEvent<'lock> {
                 }
             }
         })
+    }
+
+    pub(super) fn package(&self) -> &PackageName {
+        match self {
+            Self::Update(_, package, ..)
+            | Self::Add(_, package, ..)
+            | Self::Remove(_, package, ..) => package,
+        }
     }
 }
 

--- a/crates/fyn/src/commands/project/upgrade.rs
+++ b/crates/fyn/src/commands/project/upgrade.rs
@@ -1,106 +1,870 @@
+use std::collections::BTreeSet;
 use std::fmt::Write;
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result, bail};
 use owo_colors::OwoColorize;
+use tracing::warn;
 
-use crate::commands::ExitStatus;
+use fyn_cache::{Cache, Refresh};
+use fyn_client::BaseClientBuilder;
+use fyn_configuration::{Concurrency, DependencyGroups, DryRun, ExtrasSpecification, Upgrade};
+use fyn_distribution::{ArchiveMetadata, Metadata};
+use fyn_distribution_types::Identifier;
+use fyn_normalize::{DefaultExtras, PackageName};
+use fyn_pep440::{Operator, Version, VersionSpecifier, VersionSpecifiers};
+use fyn_pep508::{MarkerTree, Requirement, VerbatimUrl, VersionOrUrl};
+use fyn_preview::Preview;
+use fyn_pypi_types::{PyProjectToml, ResolutionMetadata, VerbatimParsedUrl};
+use fyn_python::{PythonDownloads, PythonPreference, PythonRequest};
+use fyn_redacted::DisplaySafeUrl;
+use fyn_resolver::MetadataResponse;
+use fyn_settings::{MalwareCheckSettings, PythonInstallMirrors};
+use fyn_workspace::pyproject::Source;
+use fyn_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
+use fyn_workspace::{DiscoveryOptions, VirtualProject, WorkspaceCache, WorkspaceError};
+
+use crate::commands::pip::loggers::DefaultResolveLogger;
+use crate::commands::project::add::{AddTarget, PythonTarget, lock_and_sync};
+use crate::commands::project::lock::{LockEvent, LockMode, LockOperation, LockResult};
+use crate::commands::project::{
+    PlatformState, ProjectEnvironment, ProjectError, ProjectInterpreter, UniversalState,
+    default_dependency_groups,
+};
+use crate::commands::{ExitStatus, diagnostics};
 use crate::printer::Printer;
+use crate::settings::{LockCheck, ResolverInstallerSettings};
 
-/// Upgrade project dependencies by re-locking with --upgrade semantics and syncing.
-///
-/// This is a convenience command that combines `fyn lock --upgrade` and `fyn sync`.
+/// A production dependency selected for upgrading.
+struct SelectedRequirement {
+    original_text: String,
+    requirement: Requirement<VerbatimParsedUrl>,
+    resolved_versions: BTreeSet<Version>,
+}
+
+/// A dependency requirement that will be written to `pyproject.toml`.
+struct RequirementUpdate {
+    original_text: String,
+    replacement: Requirement<VerbatimUrl>,
+}
+
+/// Upgrade project dependencies, their constraints, the lockfile, and the environment.
+#[expect(clippy::too_many_arguments)]
 pub(crate) async fn upgrade(
-    packages: Vec<String>,
-    dry_run: bool,
+    project_dir: &Path,
+    packages: Vec<PackageName>,
+    exclude: Vec<PackageName>,
+    dry_run: DryRun,
     no_sync: bool,
+    python: Option<String>,
+    install_mirrors: PythonInstallMirrors,
+    refresh: Refresh,
+    mut settings: ResolverInstallerSettings,
+    client_builder: BaseClientBuilder<'_>,
+    python_preference: PythonPreference,
+    python_downloads: PythonDownloads,
+    installer_metadata: bool,
+    concurrency: Concurrency,
+    no_config: bool,
+    cache: &Cache,
+    workspace_cache: &WorkspaceCache,
     printer: Printer,
+    preview: Preview,
+    malware_settings: MalwareCheckSettings,
 ) -> Result<ExitStatus> {
-    if packages.is_empty() {
-        writeln!(
-            printer.stderr(),
-            "{}{} Upgrading all dependencies...",
-            "info".cyan().bold(),
-            ":".bold()
-        )?;
+    let project =
+        match VirtualProject::discover(project_dir, &DiscoveryOptions::default(), workspace_cache)
+            .await
+        {
+            Ok(VirtualProject::Project(project)) => project,
+            Ok(VirtualProject::NonProject(_))
+            | Err(WorkspaceError::MissingPyprojectToml | WorkspaceError::MissingProject(_)) => {
+                bail!("`fyn upgrade` requires a project with a `[project]` table");
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+    let mut requirements = select_requirements(&project, &packages, &exclude)?;
+    let selected_packages = requirements
+        .iter()
+        .map(|selected| selected.requirement.name.clone())
+        .collect::<Vec<_>>();
+    settings.resolver.upgrade = selected_packages
+        .iter()
+        .cloned()
+        .fold(Upgrade::none(), |upgrade, package| {
+            upgrade.combine(Upgrade::package(package))
+        });
+
+    let refresh = refresh.combine(Refresh::from(settings.resolver.upgrade.clone()));
+    let cache = cache.clone().with_refresh(refresh.clone());
+    let groups = DependencyGroups::default().with_defaults(default_dependency_groups(
+        project.current_project().pyproject_toml(),
+    )?);
+    let extras = ExtrasSpecification::default().with_defaults(DefaultExtras::default());
+    let project = VirtualProject::Project(project);
+
+    let target = if no_sync || dry_run.enabled() {
+        let interpreter = ProjectInterpreter::discover(
+            project.workspace(),
+            project_dir,
+            &groups,
+            python.as_deref().map(PythonRequest::parse),
+            &client_builder,
+            python_preference,
+            python_downloads,
+            &install_mirrors,
+            false,
+            no_config,
+            None,
+            &cache,
+            printer,
+            preview,
+        )
+        .await?
+        .into_interpreter();
+        AddTarget::Project(project, Box::new(PythonTarget::Interpreter(interpreter)))
     } else {
-        writeln!(
-            printer.stderr(),
-            "{}{} Upgrading: {}",
-            "info".cyan().bold(),
-            ":".bold(),
-            packages.join(", ").green()
+        let environment = ProjectEnvironment::get_or_init(
+            project.workspace(),
+            &groups,
+            python.as_deref().map(PythonRequest::parse),
+            &install_mirrors,
+            &client_builder,
+            python_preference,
+            python_downloads,
+            false,
+            no_config,
+            None,
+            &cache,
+            DryRun::Disabled,
+            printer,
+            preview,
+        )
+        .await?
+        .into_environment()?;
+        AddTarget::Project(project, Box::new(PythonTarget::Environment(environment)))
+    };
+
+    let _lock = target
+        .acquire_lock()
+        .await
+        .inspect_err(|err| warn!("Failed to acquire environment lock: {err}"))
+        .ok();
+    let snapshot = target.snapshot().await?;
+    let client_builder = client_builder
+        .clone()
+        .keyring(settings.resolver.keyring_provider);
+
+    // Resolve against an in-memory manifest with blocking constraints relaxed. The user's
+    // manifest and lockfile remain untouched until all proposed constraints have been validated.
+    let mut relaxed_toml = PyProjectTomlMut::from_toml(
+        &target_project(&target).pyproject_toml().raw,
+        DependencyTarget::PyProjectToml,
+    )?;
+    for selected in &requirements {
+        let relaxed = into_verbatim_requirement(
+            relax_requirement(&selected.requirement),
+            &selected.requirement.name,
         )?;
-    }
-
-    if dry_run {
-        writeln!(
-            printer.stderr(),
-            "{}{} Dry run — no changes will be made.",
-            "info".cyan().bold(),
-            ":".bold()
-        )?;
-    }
-
-    // Re-exec ourselves with `lock --upgrade`. This inherits all env vars
-    // (UV_CACHE_DIR, UV_OFFLINE, etc.) and the working directory, so the
-    // child process picks up the same settings the user set.
-    let exe = std::env::current_exe()?;
-
-    let mut lock_args = vec!["lock".to_string()];
-    if packages.is_empty() {
-        lock_args.push("--upgrade".to_string());
-    } else {
-        for pkg in &packages {
-            lock_args.push("--upgrade-package".to_string());
-            lock_args.push(pkg.clone());
+        if relaxed_toml.replace_dependency(&relaxed, false)?.is_none() {
+            bail!(
+                "Dependency `{}` was not found in `project.dependencies`",
+                selected.requirement.name
+            );
         }
     }
-    if dry_run {
-        lock_args.push("--dry-run".to_string());
+    let relaxed_content = relaxed_toml.to_string();
+    let resolution_workspace_cache = WorkspaceCache::default();
+    let pyproject_path = target_project(&target).root().join("pyproject.toml");
+    let pyproject = PyProjectToml::from_toml(&relaxed_content, pyproject_path.display())?;
+    if pyproject
+        .project
+        .as_ref()
+        .is_some_and(|project| project.version.is_none())
+    {
+        bail!("`fyn upgrade` does not support projects with dynamic versions yet");
+    }
+    let metadata = ResolutionMetadata::parse_pyproject_toml(pyproject, None)?;
+    let metadata = Metadata::from_workspace(
+        metadata,
+        target_project(&target).root(),
+        None,
+        &settings.resolver.index_locations,
+        settings.resolver.sources.clone(),
+        &resolution_workspace_cache,
+        client_builder.credentials_cache(),
+    )
+    .await?;
+
+    let state = UniversalState::default();
+    let distribution_id = DisplaySafeUrl::from_file_path(target_project(&target).root())
+        .map_err(|()| anyhow::anyhow!("Project root is not a valid file URL"))?
+        .distribution_id();
+    state.index().distributions().done(
+        distribution_id,
+        Arc::new(MetadataResponse::Found(ArchiveMetadata::from(metadata))),
+    );
+    let result = match Box::pin(
+        LockOperation::new(
+            LockMode::DryRun(target.interpreter()),
+            &settings.resolver,
+            &client_builder,
+            &state,
+            Box::new(DefaultResolveLogger),
+            &concurrency,
+            &cache,
+            &resolution_workspace_cache,
+            printer,
+            preview,
+        )
+        .with_refresh(&refresh)
+        .execute((&target).into()),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(ProjectError::Operation(err)) => {
+            return diagnostics::OperationDiagnostic::native_tls(client_builder.is_native_tls())
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()));
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    let install_path = target_project(&target).workspace().install_path();
+    for resolved_package in result.lock().packages() {
+        let Some(selected) = requirements
+            .iter_mut()
+            .find(|selected| resolved_package.name() == &selected.requirement.name)
+        else {
+            continue;
+        };
+        if resolved_package.index(install_path)?.is_some()
+            && package_applies_to_marker(resolved_package, selected.requirement.marker)
+            && let Some(version) = resolved_package.version()
+        {
+            selected.resolved_versions.insert(version.clone());
+        }
     }
 
-    // Forward any global flags that were set via env vars — the child process
-    // reads them automatically since we don't clear the environment.
-    let lock_status = std::process::Command::new(&exe).args(&lock_args).status()?;
+    let mut final_toml = PyProjectTomlMut::from_toml(
+        &target_project(&target).pyproject_toml().raw,
+        DependencyTarget::PyProjectToml,
+    )?;
+    let mut updates = Vec::new();
+    for selected in &requirements {
+        let proposed = propose_requirement(&selected.requirement, &selected.resolved_versions)?;
+        if proposed == selected.requirement {
+            continue;
+        }
+        let replacement = into_verbatim_requirement(proposed, &selected.requirement.name)?;
+        if final_toml
+            .replace_dependency(&replacement, false)?
+            .is_none()
+        {
+            bail!(
+                "Dependency `{}` was not found in `project.dependencies`",
+                selected.requirement.name
+            );
+        }
+        updates.push(RequirementUpdate {
+            original_text: selected.original_text.clone(),
+            replacement,
+        });
+    }
 
-    if !lock_status.success() {
+    if dry_run.enabled() {
+        render_changes(&result, &selected_packages, dry_run, printer)?;
+        for update in updates {
+            writeln!(
+                printer.stderr(),
+                "Would update requirement: `{}` -> `{}`",
+                update.original_text,
+                update.replacement
+            )?;
+        }
+        writeln!(printer.stderr(), "{}", "No changes were made".bold())?;
+        return Ok(ExitStatus::Success);
+    }
+
+    let content = final_toml.to_string();
+    if let Err(err) = target.write(&content) {
+        let _ = snapshot.revert();
+        return Err(err.into());
+    }
+    let target = match target.update(&content) {
+        Ok(target) => target,
+        Err(err) => {
+            let _ = snapshot.revert();
+            return Err(err.into());
+        }
+    };
+
+    // Restore both the manifest and lockfile if the operation is interrupted.
+    let _ = ctrlc::set_handler({
+        let snapshot = snapshot.clone();
+        move || {
+            let _ = snapshot.revert();
+            #[expect(clippy::exit, clippy::cast_possible_wrap)]
+            std::process::exit(if cfg!(windows) {
+                0xC000_013A_u32 as i32
+            } else {
+                130
+            });
+        }
+    });
+
+    let sync_state = PlatformState::default();
+    let lock_state = sync_state.fork();
+    let operation = Box::pin(lock_and_sync(
+        target,
+        &mut final_toml,
+        &[],
+        lock_state,
+        sync_state,
+        LockCheck::Disabled,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        Vec::new(),
+        Vec::new(),
+        &extras,
+        &groups,
+        true,
+        None,
+        false,
+        Vec::new(),
+        &settings,
+        &client_builder,
+        installer_metadata,
+        &concurrency,
+        &cache,
+        printer,
+        preview,
+        &malware_settings,
+    ))
+    .await;
+
+    if let Err(err) = operation {
+        let _ = snapshot.revert();
+        return match err {
+            ProjectError::Operation(err) => {
+                diagnostics::OperationDiagnostic::native_tls(client_builder.is_native_tls())
+                    .report(err)
+                    .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
+            }
+            err => Err(err.into()),
+        };
+    }
+
+    render_changes(&result, &selected_packages, DryRun::Disabled, printer)?;
+    for update in updates {
         writeln!(
             printer.stderr(),
-            "{}{} Lock failed",
-            "error".red().bold(),
-            ":".bold()
+            "Updated requirement: `{}` -> `{}`",
+            update.original_text,
+            update.replacement
         )?;
-        return Ok(ExitStatus::Failure);
     }
-
-    if no_sync || dry_run {
+    if no_sync {
         writeln!(
             printer.stderr(),
             "{}{} Lockfile updated (sync skipped).",
             "success".green().bold(),
             ":".bold()
         )?;
-        return Ok(ExitStatus::Success);
-    }
-
-    let sync_status = std::process::Command::new(&exe).arg("sync").status()?;
-
-    if !sync_status.success() {
+    } else {
         writeln!(
             printer.stderr(),
-            "{}{} Sync failed",
-            "error".red().bold(),
+            "{}{} Dependencies upgraded successfully.",
+            "success".green().bold(),
             ":".bold()
         )?;
-        return Ok(ExitStatus::Failure);
     }
 
-    writeln!(
-        printer.stderr(),
-        "{}{} Dependencies upgraded successfully.",
-        "success".green().bold(),
-        ":".bold()
-    )?;
-
     Ok(ExitStatus::Success)
+}
+
+fn target_project(target: &AddTarget) -> &VirtualProject {
+    let AddTarget::Project(project, _) = target else {
+        unreachable!("`fyn upgrade` only supports projects");
+    };
+    project
+}
+
+/// Select unique production dependency declarations targeted by `fyn upgrade`.
+fn select_requirements(
+    project: &fyn_workspace::ProjectWorkspace,
+    packages: &[PackageName],
+    exclude: &[PackageName],
+) -> Result<Vec<SelectedRequirement>> {
+    if project.workspace().packages().len() != 1 {
+        bail!("`fyn upgrade` does not support workspaces with multiple members yet");
+    }
+
+    let explicit = !packages.is_empty();
+    let dependencies = project
+        .current_project()
+        .project()
+        .dependencies
+        .as_deref()
+        .unwrap_or_default();
+    let pyproject_path = project.project_root().join("pyproject.toml");
+    let mut selected = Vec::new();
+    let mut found = BTreeSet::new();
+    for dependency in dependencies {
+        let requirement =
+            Requirement::<VerbatimParsedUrl>::from_str(dependency).with_context(|| {
+                format!(
+                    "Failed to parse dependency `{dependency}` from `project.dependencies` in `{}`",
+                    pyproject_path.display()
+                )
+            })?;
+        if exclude.contains(&requirement.name)
+            || (explicit && !packages.contains(&requirement.name))
+        {
+            continue;
+        }
+        found.insert(requirement.name.clone());
+        selected.push(SelectedRequirement {
+            original_text: dependency.clone(),
+            requirement,
+            resolved_versions: BTreeSet::new(),
+        });
+    }
+
+    for package in packages
+        .iter()
+        .filter(|package| !exclude.contains(*package))
+    {
+        if !found.contains(package) {
+            bail!("Dependency `{package}` was not found in `project.dependencies`");
+        }
+    }
+    if selected.is_empty() {
+        bail!("No dependencies selected for upgrade");
+    }
+
+    let mut seen = BTreeSet::new();
+    for requirement in &selected {
+        let package = &requirement.requirement.name;
+        if !seen.insert(package.clone()) {
+            bail!("Dependency `{package}` is declared multiple times in `project.dependencies`");
+        }
+        validate_requirement(project, &requirement.requirement)?;
+    }
+
+    // Preserve explicit CLI order while keeping manifest order for an all-package upgrade.
+    if explicit {
+        selected.sort_by_key(|selected| {
+            packages
+                .iter()
+                .position(|package| package == &selected.requirement.name)
+                .unwrap_or(usize::MAX)
+        });
+    }
+    Ok(selected)
+}
+
+fn validate_requirement(
+    project: &fyn_workspace::ProjectWorkspace,
+    requirement: &Requirement<VerbatimParsedUrl>,
+) -> Result<()> {
+    let package = &requirement.name;
+    if matches!(requirement.version_or_url, Some(VersionOrUrl::Url(_))) {
+        bail!("Dependency `{package}` is a direct URL requirement and cannot be upgraded");
+    }
+    if package == project.project_name() {
+        bail!("Dependency `{package}` refers to the current project and cannot be upgraded");
+    }
+
+    let sources = project
+        .current_project()
+        .pyproject_toml()
+        .tool_fyn()
+        .and_then(|fyn| fyn.sources.as_ref())
+        .and_then(|sources| sources.inner().get(package))
+        .or_else(|| project.workspace().sources().get(package));
+    if sources.is_some_and(|sources| {
+        sources.iter().any(|source| {
+            source_is_applicable(source, requirement.marker)
+                && matches!(source, Source::Git { rev: Some(_), .. })
+        })
+    }) {
+        bail!(
+            "Dependency `{package}` is pinned to a Git revision and cannot be upgraded commit-to-commit"
+        );
+    }
+    if sources.is_some_and(|sources| {
+        sources.iter().any(|source| {
+            source_is_applicable(source, requirement.marker)
+                && !matches!(source, Source::Registry { .. })
+        })
+    }) {
+        bail!(
+            "Dependency `{package}` uses a non-registry source in `tool.fyn.sources` and cannot be upgraded"
+        );
+    }
+    Ok(())
+}
+
+fn source_is_applicable(source: &Source, requirement_marker: MarkerTree) -> bool {
+    let extra = requirement_marker.top_level_extra_name();
+    source
+        .extra()
+        .is_none_or(|target| extra.as_deref() == Some(target))
+        && source.group().is_none()
+        && !source.marker().is_disjoint(requirement_marker)
+}
+
+fn package_applies_to_marker(
+    package: &fyn_resolver::Package,
+    requirement_marker: MarkerTree,
+) -> bool {
+    package.fork_markers().is_empty()
+        || package
+            .fork_markers()
+            .iter()
+            .any(|fork_marker| !fork_marker.pep508().is_disjoint(requirement_marker))
+}
+
+fn into_verbatim_requirement(
+    requirement: Requirement<VerbatimParsedUrl>,
+    package: &PackageName,
+) -> Result<Requirement<VerbatimUrl>> {
+    let Requirement {
+        name,
+        extras,
+        version_or_url,
+        marker,
+        origin,
+    } = requirement;
+    let version_or_url = match version_or_url {
+        Some(VersionOrUrl::VersionSpecifier(specifiers)) => {
+            Some(VersionOrUrl::VersionSpecifier(specifiers))
+        }
+        Some(VersionOrUrl::Url(_)) => {
+            bail!("Dependency `{package}` is a direct URL requirement and cannot be upgraded");
+        }
+        None => None,
+    };
+    Ok(Requirement::<VerbatimUrl> {
+        name,
+        extras,
+        version_or_url,
+        marker,
+        origin,
+    })
+}
+
+fn render_changes(
+    result: &LockResult,
+    packages: &[PackageName],
+    dry_run: DryRun,
+    printer: Printer,
+) -> Result<()> {
+    let events = match result {
+        LockResult::Changed(previous, lock) => {
+            LockEvent::detect_changes(previous.as_ref(), lock, dry_run)
+                .filter(|event| packages.contains(event.package()))
+                .collect::<Vec<_>>()
+        }
+        LockResult::Unchanged(_) => Vec::new(),
+    };
+    for package in packages {
+        if let Some(event) = events.iter().find(|event| event.package() == package) {
+            writeln!(printer.stderr(), "{event}")?;
+        } else {
+            writeln!(printer.stderr(), "No version change for {package}")?;
+        }
+    }
+    Ok(())
+}
+
+/// Return a requirement that admits every applicable resolved version.
+fn propose_requirement(
+    requirement: &Requirement<VerbatimParsedUrl>,
+    resolved_versions: &BTreeSet<Version>,
+) -> Result<Requirement<VerbatimParsedUrl>> {
+    if resolved_versions.is_empty() {
+        return Ok(requirement.clone());
+    }
+    let Some(VersionOrUrl::VersionSpecifier(specifiers)) = &requirement.version_or_url else {
+        return Ok(requirement.clone());
+    };
+    if resolved_versions
+        .iter()
+        .all(|version| specifiers.contains(version))
+    {
+        return Ok(requirement.clone());
+    }
+
+    let specifiers = specifiers
+        .iter()
+        .cloned()
+        .map(|specifier| rewrite_specifier(specifier, resolved_versions))
+        .collect::<Result<VersionSpecifiers>>()?;
+    if !resolved_versions
+        .iter()
+        .all(|version| specifiers.contains(version))
+    {
+        let versions = resolved_versions
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("`, `");
+        bail!(
+            "Dependency `{}` resolved to version(s) `{versions}` which cannot be represented by the upgraded requirement",
+            requirement.name
+        );
+    }
+    let mut proposed = requirement.clone();
+    proposed.version_or_url = Some(VersionOrUrl::VersionSpecifier(specifiers));
+    Ok(proposed)
+}
+
+fn rewrite_specifier(
+    specifier: VersionSpecifier,
+    resolved_versions: &BTreeSet<Version>,
+) -> Result<VersionSpecifier> {
+    if resolved_versions
+        .iter()
+        .all(|version| specifier.contains(version))
+    {
+        return Ok(specifier);
+    }
+    let (Some(lowest), Some(highest)) = (resolved_versions.first(), resolved_versions.last())
+    else {
+        return Ok(specifier);
+    };
+
+    Ok(match specifier.operator() {
+        Operator::GreaterThan
+        | Operator::GreaterThanEqual
+        | Operator::NotEqual
+        | Operator::NotEqualStar => specifier,
+        Operator::TildeEqual => VersionSpecifier::from_version(
+            Operator::TildeEqual,
+            compatible_version_at_precision(lowest, specifier.version().release().len())?,
+        )?,
+        Operator::Equal => VersionSpecifier::equals_version(lowest.clone()),
+        Operator::EqualStar => VersionSpecifier::equals_star_version(
+            only_release_at_precision(lowest, specifier.version().release().len())
+                .context("Cannot rewrite a version constraint without a release segment")?,
+        ),
+        Operator::ExactEqual => {
+            VersionSpecifier::from_version(Operator::ExactEqual, lowest.clone())?
+        }
+        Operator::LessThan => VersionSpecifier::less_than_version(increment_version_at_precision(
+            highest,
+            specifier.version().release().len(),
+        )?),
+        Operator::LessThanEqual => VersionSpecifier::from_version(
+            Operator::LessThanEqual,
+            highest.clone().without_local(),
+        )?,
+    })
+}
+
+fn compatible_version_at_precision(version: &Version, precision: usize) -> Result<Version> {
+    let release = version
+        .release()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat(0))
+        .take(precision)
+        .collect::<Vec<_>>();
+    if release.is_empty() {
+        bail!("Cannot rewrite a version constraint without a release segment");
+    }
+    Ok(version.clone().with_release(release).without_local())
+}
+
+fn only_release_at_precision(version: &Version, precision: usize) -> Option<Version> {
+    let release = version
+        .release()
+        .iter()
+        .copied()
+        .chain(std::iter::repeat(0))
+        .take(precision)
+        .collect::<Vec<_>>();
+    (!release.is_empty()).then(|| Version::new(release).with_epoch(version.epoch()))
+}
+
+fn increment_version_at_precision(version: &Version, precision: usize) -> Result<Version> {
+    let projected = only_release_at_precision(version, precision)
+        .context("Cannot rewrite a version constraint without a release segment")?;
+    let mut release = projected.release().to_vec();
+    let segment_index = release.len();
+    let Some(last) = release.last_mut() else {
+        bail!("Cannot rewrite a version constraint without a release segment");
+    };
+    let segment = *last;
+    *last = segment.checked_add(1).with_context(|| {
+        format!(
+            "Cannot expand version `{version}` at release segment {segment_index} (`{segment}`) beyond its maximum value"
+        )
+    })?;
+    Ok(projected.with_release(release))
+}
+
+/// Remove upper and exact constraints while retaining lower bounds and exclusions.
+fn relax_requirement(
+    requirement: &Requirement<VerbatimParsedUrl>,
+) -> Requirement<VerbatimParsedUrl> {
+    let mut relaxed = requirement.clone();
+    let Some(VersionOrUrl::VersionSpecifier(specifiers)) = &requirement.version_or_url else {
+        return relaxed;
+    };
+    let specifiers = specifiers
+        .iter()
+        .filter_map(|specifier| match specifier.operator() {
+            Operator::GreaterThan
+            | Operator::GreaterThanEqual
+            | Operator::NotEqual
+            | Operator::NotEqualStar => Some(specifier.clone()),
+            Operator::TildeEqual => Some(VersionSpecifier::greater_than_equal_version(
+                specifier.version().clone(),
+            )),
+            Operator::Equal
+            | Operator::EqualStar
+            | Operator::ExactEqual
+            | Operator::LessThan
+            | Operator::LessThanEqual => None,
+        })
+        .collect::<VersionSpecifiers>();
+    relaxed.version_or_url = if specifiers.is_empty() {
+        None
+    } else {
+        Some(VersionOrUrl::VersionSpecifier(specifiers))
+    };
+    relaxed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{increment_version_at_precision, propose_requirement, relax_requirement};
+    use std::collections::BTreeSet;
+    use std::str::FromStr;
+
+    use fyn_pep440::Version;
+    use fyn_pep508::Requirement;
+    use fyn_pypi_types::VerbatimParsedUrl;
+
+    fn resolved_versions(versions: &[&str]) -> BTreeSet<Version> {
+        versions
+            .iter()
+            .map(|version| Version::from_str(version).expect("valid version"))
+            .collect()
+    }
+
+    #[test]
+    fn relax_requirement_preserves_lower_bounds_and_metadata() {
+        let requirement = Requirement::<VerbatimParsedUrl>::from_str(
+            "Requests[security]>=1,>1.5,!=2,!=2.1.*,==2.5,<=3,<4 ; python_version >= '3.12'",
+        )
+        .expect("valid requirement");
+
+        let relaxed = relax_requirement(&requirement);
+
+        assert_eq!(
+            relaxed.to_string(),
+            "requests[security]>=1,>1.5,!=2,!=2.1.* ; python_full_version >= '3.12'"
+        );
+    }
+
+    #[test]
+    fn propose_requirement_preserves_operator_style() {
+        for (requirement, version, expected) in [
+            ("requests==1.2.3", "2.4.5", "requests==2.4.5"),
+            ("requests===1.2.3", "2.4.5", "requests===2.4.5"),
+            ("requests~=1.2", "2.4.5", "requests~=2.4"),
+            ("requests==1.2.*", "2.4.5", "requests==2.4.*"),
+            ("requests<2", "2.4.5", "requests<3"),
+            ("requests<=2", "2.4.5", "requests<=2.4.5"),
+        ] {
+            let requirement =
+                Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
+            let versions = resolved_versions(&[version]);
+
+            let proposed =
+                propose_requirement(&requirement, &versions).expect("valid requirement update");
+
+            assert_eq!(proposed.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn propose_requirement_only_rewrites_blocking_specifiers() {
+        let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests>=1,<2,<4")
+            .expect("valid requirement");
+
+        let proposed = propose_requirement(&requirement, &resolved_versions(&["2.4.0"]))
+            .expect("valid requirement update");
+
+        assert_eq!(proposed.to_string(), "requests>=1,<3,<4");
+    }
+
+    #[test]
+    fn propose_requirement_admits_multiple_resolved_versions() {
+        for (requirement, versions, expected) in [
+            ("requests<2", &["1.5.0", "2.4.0"][..], "requests<3"),
+            ("requests~=1.2", &["2.4", "2.5"][..], "requests~=2.4"),
+        ] {
+            let requirement =
+                Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
+
+            let proposed = propose_requirement(&requirement, &resolved_versions(versions))
+                .expect("resolved versions can be represented");
+
+            assert_eq!(proposed.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn propose_requirement_rejects_unrepresentable_constraint() {
+        let requirement = Requirement::<VerbatimParsedUrl>::from_str("requests!=2.4,<2")
+            .expect("valid requirement");
+
+        let error = propose_requirement(&requirement, &resolved_versions(&["2.4"]))
+            .expect_err("the exclusion must remain in place");
+
+        assert!(error.to_string().contains("cannot be represented"));
+    }
+
+    #[test]
+    fn propose_requirement_preserves_suffixes_and_strips_local_upper_bound() {
+        for (requirement, version, expected) in [
+            (
+                "requests~=1.2",
+                "1!2.4rc1.post2.dev3+local",
+                "requests~=1!2.4rc1.post2.dev3",
+            ),
+            ("requests<=1.2.3", "2.4.5+local", "requests<=2.4.5"),
+        ] {
+            let requirement =
+                Requirement::<VerbatimParsedUrl>::from_str(requirement).expect("valid requirement");
+
+            let proposed = propose_requirement(&requirement, &resolved_versions(&[version]))
+                .expect("valid requirement update");
+
+            assert_eq!(proposed.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn increment_version_reports_upper_bound_overflow() {
+        let version = Version::new([1, 2, u64::MAX]);
+
+        let error = increment_version_at_precision(&version, 3)
+            .expect_err("maximum release segment cannot be incremented");
+
+        assert!(error.to_string().contains("beyond its maximum value"));
+    }
 }

--- a/crates/fyn/src/lib.rs
+++ b/crates/fyn/src/lib.rs
@@ -2907,7 +2907,42 @@ async fn run_project(
             .await
         }
         ProjectCommand::Upgrade(args) => {
-            commands::upgrade(args.packages, args.dry_run, args.no_sync, printer).await
+            // Resolve the settings from the command-line arguments and workspace configuration.
+            let args = settings::UpgradeSettings::resolve(args, filesystem, environment);
+            show_settings!(args);
+
+            // Check for conflicts between offline and refresh.
+            globals
+                .network_settings
+                .check_refresh_conflict(&args.refresh);
+
+            // Initialize the cache. The command further narrows refreshes to the selected direct
+            // dependencies after discovering the project manifest.
+            let cache = cache.init().await?;
+
+            Box::pin(commands::upgrade(
+                project_dir,
+                args.packages,
+                args.exclude,
+                fyn_configuration::DryRun::from_args(args.dry_run),
+                args.no_sync,
+                args.python,
+                args.install_mirrors,
+                args.refresh,
+                args.settings,
+                client_builder.subcommand(vec!["upgrade".to_owned()]),
+                globals.python_preference,
+                globals.python_downloads,
+                globals.installer_metadata,
+                globals.concurrency,
+                no_config,
+                &cache,
+                workspace_cache,
+                printer,
+                globals.preview,
+                args.malware_settings,
+            ))
+            .await
         }
         ProjectCommand::Add(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.

--- a/crates/fyn/src/settings.rs
+++ b/crates/fyn/src/settings.rs
@@ -21,8 +21,8 @@ use fyn_cli::{
     PipSyncArgs, PipTreeArgs, PipUninstallArgs, PipUpgradeArgs, PipWheelArgs, PythonFindArgs,
     PythonInstallArgs, PythonListArgs, PythonListFormat, PythonPinArgs, PythonUninstallArgs,
     PythonUpgradeArgs, RemoveArgs, RunArgs, SyncArgs, SyncFormat, ToolDirArgs, ToolInstallArgs,
-    ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs, VenvArgs, VersionArgs, VersionBumpSpec,
-    VersionFormat, WhyArgs,
+    ToolListArgs, ToolRunArgs, ToolUninstallArgs, TreeArgs, UpgradeArgs, VenvArgs, VersionArgs,
+    VersionBumpSpec, VersionFormat, WhyArgs,
 };
 use fyn_cli::{
     AuthorFrom, BuildArgs, ExportArgs, FormatArgs, PublishArgs, PythonDirArgs,
@@ -1868,6 +1868,62 @@ impl LockSettings {
             install_mirrors: environment
                 .install_mirrors
                 .combine(filesystem_install_mirrors),
+        }
+    }
+}
+
+/// The resolved settings to use for an `upgrade` invocation.
+#[derive(Debug, Clone)]
+pub(crate) struct UpgradeSettings {
+    pub(crate) packages: Vec<PackageName>,
+    pub(crate) exclude: Vec<PackageName>,
+    pub(crate) dry_run: bool,
+    pub(crate) no_sync: bool,
+    pub(crate) python: Option<String>,
+    pub(crate) install_mirrors: PythonInstallMirrors,
+    pub(crate) refresh: Refresh,
+    pub(crate) settings: ResolverInstallerSettings,
+    pub(crate) malware_settings: MalwareCheckSettings,
+}
+
+impl UpgradeSettings {
+    /// Resolve the [`UpgradeSettings`] from the CLI and filesystem configuration.
+    pub(crate) fn resolve(
+        args: UpgradeArgs,
+        filesystem: Option<FilesystemOptions>,
+        environment: EnvironmentOptions,
+    ) -> Self {
+        let UpgradeArgs {
+            packages,
+            exclude,
+            dry_run,
+            no_sync,
+            installer,
+            build,
+            refresh,
+            python,
+        } = args;
+        let filesystem_install_mirrors = filesystem
+            .clone()
+            .map(|fs| fs.install_mirrors.clone())
+            .unwrap_or_default();
+        let malware_settings = MalwareCheckSettings::from(&environment);
+
+        Self {
+            packages,
+            exclude,
+            dry_run,
+            no_sync,
+            python: python.and_then(Maybe::into_option),
+            install_mirrors: environment
+                .install_mirrors
+                .combine(filesystem_install_mirrors),
+            settings: ResolverInstallerSettings::combine(
+                resolver_installer_options(installer, build),
+                filesystem,
+            ),
+            refresh: Refresh::from(refresh),
+            malware_settings,
         }
     }
 }

--- a/crates/fyn/tests/it/main.rs
+++ b/crates/fyn/tests/it/main.rs
@@ -160,6 +160,9 @@ mod tool_upgrade;
 #[cfg(all(feature = "test-python", feature = "test-pypi"))]
 mod tree;
 
+#[cfg(all(feature = "test-python", feature = "test-pypi"))]
+mod upgrade;
+
 #[cfg(feature = "test-python")]
 mod venv;
 

--- a/crates/fyn/tests/it/upgrade.rs
+++ b/crates/fyn/tests/it/upgrade.rs
@@ -1,0 +1,160 @@
+use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+#[test]
+fn project_upgrade_updates_constraint_lock_and_environment() -> Result<()> {
+    let context = fyn_test::test_context_with_versions!(&["3.12"]);
+    let pyproject = context.temp_dir.child("pyproject.toml");
+    pyproject.write_str(
+        r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["anyio<3"]
+"#,
+    )?;
+
+    context.lock().assert().success();
+    let lockfile = context.temp_dir.child("fyn.lock");
+    let original_lock = fs_err::read_to_string(&lockfile)?;
+
+    context
+        .upgrade()
+        .arg("anyio")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Updated requirement: `anyio<3` -> `anyio<5`",
+        ))
+        .stderr(predicate::str::contains(
+            "Dependencies upgraded successfully.",
+        ));
+
+    assert!(fs_err::read_to_string(&pyproject)?.contains("anyio<5"));
+    assert_ne!(fs_err::read_to_string(&lockfile)?, original_lock);
+    assert!(context.temp_dir.child(".venv").exists());
+    context
+        .assert_command(
+            "import importlib.metadata; print(importlib.metadata.version('anyio'), end='')",
+        )
+        .success()
+        .stdout("4.3.0");
+    Ok(())
+}
+
+#[test]
+fn project_upgrade_updates_constraint_and_lock_without_syncing() -> Result<()> {
+    let context = fyn_test::test_context_with_versions!(&["3.12"]);
+    let pyproject = context.temp_dir.child("pyproject.toml");
+    pyproject.write_str(
+        r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["AnyIO>=2,<3,!=2.1 ; python_version >= '3.12'"]
+"#,
+    )?;
+
+    context
+        .upgrade()
+        .arg("anyio")
+        .arg("--no-sync")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Updated requirement:"));
+
+    let content = fs_err::read_to_string(&pyproject)?;
+    assert!(content.contains("anyio>=2,!=2.1,<5 ; python_full_version >= '3.12'"));
+    assert!(context.temp_dir.child("fyn.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
+fn project_upgrade_dry_run_does_not_mutate_project() -> Result<()> {
+    let context = fyn_test::test_context_with_versions!(&["3.12"]);
+    let pyproject = context.temp_dir.child("pyproject.toml");
+    let original = r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["anyio<3"]
+"#;
+    pyproject.write_str(original)?;
+
+    context
+        .upgrade()
+        .arg("anyio")
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Would update requirement:"))
+        .stderr(predicate::str::contains("No changes were made"));
+
+    assert_eq!(fs_err::read_to_string(&pyproject)?, original);
+    assert!(!context.temp_dir.child("fyn.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}
+
+#[test]
+fn project_upgrade_all_respects_exclusions() -> Result<()> {
+    let context = fyn_test::test_context_with_versions!(&["3.12"]);
+    let pyproject = context.temp_dir.child("pyproject.toml");
+    pyproject.write_str(
+        r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["anyio<3", "sniffio<1"]
+"#,
+    )?;
+
+    context
+        .upgrade()
+        .arg("--exclude")
+        .arg("anyio")
+        .arg("--no-sync")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Updated requirement: `sniffio<1`"))
+        .stderr(predicate::str::contains("anyio").not());
+
+    let content = fs_err::read_to_string(&pyproject)?;
+    assert!(content.contains("anyio<3"));
+    assert!(content.contains("sniffio<2"));
+    assert!(context.temp_dir.child("fyn.lock").exists());
+    Ok(())
+}
+
+#[test]
+fn project_upgrade_resolution_failure_leaves_project_unchanged() -> Result<()> {
+    let context = fyn_test::test_context_with_versions!(&["3.12"]);
+    let pyproject = context.temp_dir.child("pyproject.toml");
+    let original = r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["anyio<3", "sniffio==9999"]
+"#;
+    pyproject.write_str(original)?;
+
+    context
+        .upgrade()
+        .arg("anyio")
+        .arg("--no-sync")
+        .assert()
+        .failure();
+
+    assert_eq!(fs_err::read_to_string(&pyproject)?, original);
+    assert!(!context.temp_dir.child("fyn.lock").exists());
+    assert!(!context.temp_dir.child(".venv").exists());
+    Ok(())
+}

--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -37,7 +37,8 @@ Creating and working on Python projects, i.e., with a `pyproject.toml`.
 - `fyn remove`: Remove a dependency from the project.
 - `fyn sync`: Sync the project's dependencies with the environment.
 - `fyn lock`: Create a lockfile for the project's dependencies.
-- `fyn upgrade`: Upgrade all or selected project dependencies.
+- `fyn upgrade`: Upgrade all or selected project dependencies across `pyproject.toml`, `fyn.lock`,
+  and the project environment.
 - `fyn run`: Run a command in the project environment, with task- and tool-aware missing-command
   hints.
 - `fyn shell`: Open a shell with the project environment activated.

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -154,13 +154,23 @@ To upgrade a package, run `fyn upgrade` with the package name:
 $ fyn upgrade requests
 ```
 
-`fyn upgrade` is a convenience command that re-locks with upgrade semantics and then syncs the
-environment. If you want to preview the change first, use `--dry-run`. If you want to update the
-lockfile without syncing the environment yet, use `--no-sync`.
+`fyn upgrade` resolves the newest version of each selected direct dependency, updates any blocking
+version constraint in `pyproject.toml`, writes the matching `fyn.lock`, and syncs the environment.
+It preserves lower bounds, exclusions, extras, markers, and the existing constraint style where
+possible. If locking or syncing fails, the manifest and lockfile are restored.
+
+If you want to preview the manifest and lock changes first, use `--dry-run`. If you want to update
+the manifest and lockfile without syncing the environment yet, use `--no-sync`. When upgrading all
+direct dependencies, use `--exclude` to leave specific packages alone.
+
+The command currently upgrades declarations in `[project].dependencies` for single-project
+workspaces. Optional dependencies, dependency groups, and multi-member workspaces are not yet
+supported.
 
 ```console
 $ fyn upgrade --dry-run
 $ fyn upgrade --no-sync requests
+$ fyn upgrade --exclude django
 ```
 
 If you want the lower-level equivalent, run `fyn lock` with the `--upgrade-package` flag:

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,6 +114,10 @@ $ fyn upgrade
 $ fyn upgrade requests flask
 ```
 
+The command also updates blocking constraints in `pyproject.toml`; use `--dry-run` to preview the
+manifest and lock changes, `--no-sync` to skip the environment update, or `--exclude` to omit a
+package from an all-dependency upgrade.
+
 Use `fyn why` to explain the dependency paths that include a package:
 
 ```console


### PR DESCRIPTION
## Summary

  Make `fyn upgrade` a native, transactional project upgrade workflow instead of a subprocess wrapper around `fyn
  lock --upgrade` and `fyn sync`.

  - Resolve newer versions for all or selected direct dependencies
  - Rewrite blocking constraints in `pyproject.toml`
  - Update `fyn.lock` and sync the project environment
  - Add `--exclude`, while retaining `--dry-run` and `--no-sync`
  - Respect resolver, installer, index, cache, and `exclude-newer` settings
  - Restore `pyproject.toml` and `fyn.lock` if locking or syncing fails

  ## Tests

  - Full workspace Clippy with all targets and features
  - Rustfmt, Prettier, and Ruff checks
  - Generated-file and JSON schema checks