### PR TITLE
Bump version to 0.10.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 <!-- prettier-ignore-start -->
 
 
+## 0.10.16
+
+Released on 2026-08-14.
+
+### Other changes
+
+- ci: harden release publishing ([#188](https://github.com/duriantaco/fyn/pull/188))
+- feat: upgrade project dependency constraints ([#189](https://github.com/duriantaco/fyn/pull/189))
+
 ## 0.10.15
 
 Released on 2026-08-12.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "fyn"
-version = "0.10.15"
+version = "0.10.16"
 dependencies = [
  "anstream 1.0.0",
  "anyhow",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-audit"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "astral-reqwest-middleware",
  "clap",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-auth"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "arcstr",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-bench"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "codspeed-criterion-compat",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-bin-install"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-build"
-version = "0.10.15"
+version = "0.10.16"
 dependencies = [
  "anstream 1.0.0",
  "anyhow",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-build-backend"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "astral-version-ranges",
  "base64 0.22.1",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-build-frontend"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anstream 1.0.0",
  "fs-err",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-cache"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "clap",
  "fs-err",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-cache-info"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-cache-key"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fyn-redacted",
  "hex",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-cli"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anstream 1.0.0",
  "anyhow",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-client"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-configuration"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -2299,14 +2299,14 @@ dependencies = [
 
 [[package]]
 name = "fyn-console"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "console 0.16.2",
 ]
 
 [[package]]
 name = "fyn-dev"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anstream 1.0.0",
  "anyhow",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-dirs"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "assert_fs",
  "etcetera",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-dispatch"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "futures",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-distribution"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-distribution-filename"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fyn-cache-key",
  "fyn-normalize",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-distribution-types"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-extract"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -2540,14 +2540,14 @@ dependencies = [
 
 [[package]]
 name = "fyn-flags"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "fyn-fs"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "backon",
  "clap",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-git"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-git-types"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fyn-redacted",
  "fyn-static",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-globfilter"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anstream 1.0.0",
  "fs-err",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-install-wheel"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2669,7 +2669,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-installer"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anstream 1.0.0",
  "anyhow",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-keyring"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-logging"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anstream 1.0.0",
  "jiff",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-macros"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-metadata"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "astral_async_zip",
  "fs-err",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-normalize"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fyn-small-str",
  "rkyv",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-once-map"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "dashmap",
  "futures",
@@ -2786,14 +2786,14 @@ dependencies = [
 
 [[package]]
 name = "fyn-options-metadata"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "fyn-pep440"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "astral-version-ranges",
  "fyn-cache-key",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-pep508"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "arcstr",
  "astral-version-ranges",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-performance-memory-allocator"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "mimalloc",
  "tikv-jemalloc-ctl",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-platform"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fs-err",
  "fyn-fs",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-platform-tags"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "bitflags 2.11.0",
  "fyn-small-str",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-preview"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "enumflags2",
  "fyn-preview",
@@ -2891,7 +2891,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-publish"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "ambient-id",
  "anstream 1.0.0",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-pypi-types"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "fyn-cache-key",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-python"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-redacted"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "ref-cast",
  "schemars",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-requirements"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "configparser",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-requirements-txt"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-resolver"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "arcstr",
  "astral-pubgrub",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-scripts"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fs-err",
  "fyn-configuration",
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-settings"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "clap",
  "configparser",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-shell"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "fs-err",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-small-str"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "arcstr",
  "rkyv",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-state"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fs-err",
  "fyn-dirs",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-static"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fyn-macros",
  "thiserror 2.0.18",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-test"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-tool"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fs-err",
  "fyn-cache",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-torch"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "clap",
  "either",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-trampoline-builder"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-types"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-unix"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "nix 0.31.2",
  "thiserror 2.0.18",
@@ -3406,11 +3406,11 @@ dependencies = [
 
 [[package]]
 name = "fyn-version"
-version = "0.10.15"
+version = "0.10.16"
 
 [[package]]
 name = "fyn-virtualenv"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "console 0.16.2",
  "fs-err",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "fyn-warnings"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anstream 1.0.0",
  "anyhow",
@@ -3444,14 +3444,14 @@ dependencies = [
 
 [[package]]
 name = "fyn-windows"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "windows",
 ]
 
 [[package]]
 name = "fyn-workspace"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,77 +17,77 @@ authors = ["fyn"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-fyn-audit = { version = "0.0.36", path = "crates/fyn-audit" }
-fyn-auth = { version = "0.0.36", path = "crates/fyn-auth" }
-fyn-bin-install = { version = "0.0.36", path = "crates/fyn-bin-install" }
-fyn-build-backend = { version = "0.0.36", path = "crates/fyn-build-backend" }
-fyn-build-frontend = { version = "0.0.36", path = "crates/fyn-build-frontend" }
-fyn-cache = { version = "0.0.36", path = "crates/fyn-cache" }
-fyn-cache-info = { version = "0.0.36", path = "crates/fyn-cache-info" }
-fyn-cache-key = { version = "0.0.36", path = "crates/fyn-cache-key" }
-fyn-cli = { version = "0.0.36", path = "crates/fyn-cli" }
-fyn-client = { version = "0.0.36", path = "crates/fyn-client" }
-fyn-configuration = { version = "0.0.36", path = "crates/fyn-configuration" }
-fyn-console = { version = "0.0.36", path = "crates/fyn-console" }
-fyn-dirs = { version = "0.0.36", path = "crates/fyn-dirs" }
-fyn-dispatch = { version = "0.0.36", path = "crates/fyn-dispatch" }
-fyn-distribution = { version = "0.0.36", path = "crates/fyn-distribution" }
-fyn-distribution-filename = { version = "0.0.36", path = "crates/fyn-distribution-filename" }
-fyn-distribution-types = { version = "0.0.36", path = "crates/fyn-distribution-types" }
-fyn-extract = { version = "0.0.36", path = "crates/fyn-extract" }
-fyn-flags = { version = "0.0.36", path = "crates/fyn-flags" }
-fyn-fs = { version = "0.0.36", path = "crates/fyn-fs", features = [
+fyn-audit = { version = "0.0.37", path = "crates/fyn-audit" }
+fyn-auth = { version = "0.0.37", path = "crates/fyn-auth" }
+fyn-bin-install = { version = "0.0.37", path = "crates/fyn-bin-install" }
+fyn-build-backend = { version = "0.0.37", path = "crates/fyn-build-backend" }
+fyn-build-frontend = { version = "0.0.37", path = "crates/fyn-build-frontend" }
+fyn-cache = { version = "0.0.37", path = "crates/fyn-cache" }
+fyn-cache-info = { version = "0.0.37", path = "crates/fyn-cache-info" }
+fyn-cache-key = { version = "0.0.37", path = "crates/fyn-cache-key" }
+fyn-cli = { version = "0.0.37", path = "crates/fyn-cli" }
+fyn-client = { version = "0.0.37", path = "crates/fyn-client" }
+fyn-configuration = { version = "0.0.37", path = "crates/fyn-configuration" }
+fyn-console = { version = "0.0.37", path = "crates/fyn-console" }
+fyn-dirs = { version = "0.0.37", path = "crates/fyn-dirs" }
+fyn-dispatch = { version = "0.0.37", path = "crates/fyn-dispatch" }
+fyn-distribution = { version = "0.0.37", path = "crates/fyn-distribution" }
+fyn-distribution-filename = { version = "0.0.37", path = "crates/fyn-distribution-filename" }
+fyn-distribution-types = { version = "0.0.37", path = "crates/fyn-distribution-types" }
+fyn-extract = { version = "0.0.37", path = "crates/fyn-extract" }
+fyn-flags = { version = "0.0.37", path = "crates/fyn-flags" }
+fyn-fs = { version = "0.0.37", path = "crates/fyn-fs", features = [
   "serde",
   "tokio",
 ] }
-fyn-git = { version = "0.0.36", path = "crates/fyn-git" }
-fyn-git-types = { version = "0.0.36", path = "crates/fyn-git-types" }
-fyn-globfilter = { version = "0.0.36", path = "crates/fyn-globfilter" }
-fyn-install-wheel = { version = "0.0.36", path = "crates/fyn-install-wheel", default-features = false }
-fyn-installer = { version = "0.0.36", path = "crates/fyn-installer" }
-fyn-keyring = { version = "0.0.36", path = "crates/fyn-keyring" }
-fyn-logging = { version = "0.0.36", path = "crates/fyn-logging" }
-fyn-macros = { version = "0.0.36", path = "crates/fyn-macros" }
-fyn-metadata = { version = "0.0.36", path = "crates/fyn-metadata" }
-fyn-normalize = { version = "0.0.36", path = "crates/fyn-normalize" }
-fyn-once-map = { version = "0.0.36", path = "crates/fyn-once-map" }
-fyn-options-metadata = { version = "0.0.36", path = "crates/fyn-options-metadata" }
-fyn-performance-memory-allocator = { version = "0.0.36", path = "crates/fyn-performance-memory-allocator" }
-fyn-pep440 = { version = "0.0.36", path = "crates/fyn-pep440", features = [
+fyn-git = { version = "0.0.37", path = "crates/fyn-git" }
+fyn-git-types = { version = "0.0.37", path = "crates/fyn-git-types" }
+fyn-globfilter = { version = "0.0.37", path = "crates/fyn-globfilter" }
+fyn-install-wheel = { version = "0.0.37", path = "crates/fyn-install-wheel", default-features = false }
+fyn-installer = { version = "0.0.37", path = "crates/fyn-installer" }
+fyn-keyring = { version = "0.0.37", path = "crates/fyn-keyring" }
+fyn-logging = { version = "0.0.37", path = "crates/fyn-logging" }
+fyn-macros = { version = "0.0.37", path = "crates/fyn-macros" }
+fyn-metadata = { version = "0.0.37", path = "crates/fyn-metadata" }
+fyn-normalize = { version = "0.0.37", path = "crates/fyn-normalize" }
+fyn-once-map = { version = "0.0.37", path = "crates/fyn-once-map" }
+fyn-options-metadata = { version = "0.0.37", path = "crates/fyn-options-metadata" }
+fyn-performance-memory-allocator = { version = "0.0.37", path = "crates/fyn-performance-memory-allocator" }
+fyn-pep440 = { version = "0.0.37", path = "crates/fyn-pep440", features = [
   "tracing",
   "rkyv",
   "version-ranges",
 ] }
-fyn-pep508 = { version = "0.0.36", path = "crates/fyn-pep508", features = [
+fyn-pep508 = { version = "0.0.37", path = "crates/fyn-pep508", features = [
   "non-pep508-extensions",
 ] }
-fyn-platform = { version = "0.0.36", path = "crates/fyn-platform" }
-fyn-platform-tags = { version = "0.0.36", path = "crates/fyn-platform-tags" }
-fyn-preview = { version = "0.0.36", path = "crates/fyn-preview" }
-fyn-publish = { version = "0.0.36", path = "crates/fyn-publish" }
-fyn-pypi-types = { version = "0.0.36", path = "crates/fyn-pypi-types" }
-fyn-python = { version = "0.0.36", path = "crates/fyn-python" }
-fyn-redacted = { version = "0.0.36", path = "crates/fyn-redacted" }
-fyn-requirements = { version = "0.0.36", path = "crates/fyn-requirements" }
-fyn-requirements-txt = { version = "0.0.36", path = "crates/fyn-requirements-txt" }
-fyn-resolver = { version = "0.0.36", path = "crates/fyn-resolver" }
-fyn-scripts = { version = "0.0.36", path = "crates/fyn-scripts" }
-fyn-settings = { version = "0.0.36", path = "crates/fyn-settings" }
-fyn-shell = { version = "0.0.36", path = "crates/fyn-shell" }
-fyn-small-str = { version = "0.0.36", path = "crates/fyn-small-str" }
-fyn-state = { version = "0.0.36", path = "crates/fyn-state" }
-fyn-static = { version = "0.0.36", path = "crates/fyn-static" }
-fyn-test = { version = "0.0.36", path = "crates/fyn-test" }
-fyn-tool = { version = "0.0.36", path = "crates/fyn-tool" }
-fyn-torch = { version = "0.0.36", path = "crates/fyn-torch" }
-fyn-trampoline-builder = { version = "0.0.36", path = "crates/fyn-trampoline-builder" }
-fyn-types = { version = "0.0.36", path = "crates/fyn-types" }
-fyn-unix = { version = "0.0.36", path = "crates/fyn-unix" }
-fyn-version = { version = "0.10.15", path = "crates/fyn-version" }
-fyn-virtualenv = { version = "0.0.36", path = "crates/fyn-virtualenv" }
-fyn-warnings = { version = "0.0.36", path = "crates/fyn-warnings" }
-fyn-windows = { version = "0.0.36", path = "crates/fyn-windows" }
-fyn-workspace = { version = "0.0.36", path = "crates/fyn-workspace" }
+fyn-platform = { version = "0.0.37", path = "crates/fyn-platform" }
+fyn-platform-tags = { version = "0.0.37", path = "crates/fyn-platform-tags" }
+fyn-preview = { version = "0.0.37", path = "crates/fyn-preview" }
+fyn-publish = { version = "0.0.37", path = "crates/fyn-publish" }
+fyn-pypi-types = { version = "0.0.37", path = "crates/fyn-pypi-types" }
+fyn-python = { version = "0.0.37", path = "crates/fyn-python" }
+fyn-redacted = { version = "0.0.37", path = "crates/fyn-redacted" }
+fyn-requirements = { version = "0.0.37", path = "crates/fyn-requirements" }
+fyn-requirements-txt = { version = "0.0.37", path = "crates/fyn-requirements-txt" }
+fyn-resolver = { version = "0.0.37", path = "crates/fyn-resolver" }
+fyn-scripts = { version = "0.0.37", path = "crates/fyn-scripts" }
+fyn-settings = { version = "0.0.37", path = "crates/fyn-settings" }
+fyn-shell = { version = "0.0.37", path = "crates/fyn-shell" }
+fyn-small-str = { version = "0.0.37", path = "crates/fyn-small-str" }
+fyn-state = { version = "0.0.37", path = "crates/fyn-state" }
+fyn-static = { version = "0.0.37", path = "crates/fyn-static" }
+fyn-test = { version = "0.0.37", path = "crates/fyn-test" }
+fyn-tool = { version = "0.0.37", path = "crates/fyn-tool" }
+fyn-torch = { version = "0.0.37", path = "crates/fyn-torch" }
+fyn-trampoline-builder = { version = "0.0.37", path = "crates/fyn-trampoline-builder" }
+fyn-types = { version = "0.0.37", path = "crates/fyn-types" }
+fyn-unix = { version = "0.0.37", path = "crates/fyn-unix" }
+fyn-version = { version = "0.10.16", path = "crates/fyn-version" }
+fyn-virtualenv = { version = "0.0.37", path = "crates/fyn-virtualenv" }
+fyn-warnings = { version = "0.0.37", path = "crates/fyn-warnings" }
+fyn-windows = { version = "0.0.37", path = "crates/fyn-windows" }
+fyn-workspace = { version = "0.0.37", path = "crates/fyn-workspace" }
 
 ambient-id = { version = "0.0.10", default-features = false, features = [
   "astral-reqwest-middleware",

--- a/crates/fyn-audit/Cargo.toml
+++ b/crates/fyn-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-audit"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/fyn-audit/README.md
+++ b/crates/fyn-audit/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-audit).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-audit).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-auth/Cargo.toml
+++ b/crates/fyn-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-auth"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-auth/README.md
+++ b/crates/fyn-auth/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-auth).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-auth).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-bench/Cargo.toml
+++ b/crates/fyn-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-bench"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 publish = false
 authors = { workspace = true }

--- a/crates/fyn-bench/README.md
+++ b/crates/fyn-bench/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-bench).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-bench).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-bin-install/Cargo.toml
+++ b/crates/fyn-bin-install/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-bin-install"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-bin-install/README.md
+++ b/crates/fyn-bin-install/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-bin-install).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-bin-install).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-build-backend/Cargo.toml
+++ b/crates/fyn-build-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-build-backend"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-build-backend/README.md
+++ b/crates/fyn-build-backend/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-build-backend).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-build-backend).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-build-frontend/Cargo.toml
+++ b/crates/fyn-build-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-build-frontend"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-build-frontend/README.md
+++ b/crates/fyn-build-frontend/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
 source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-build-frontend).
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-build-frontend).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-build/Cargo.toml
+++ b/crates/fyn-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-build"
-version = "0.10.15"
+version = "0.10.16"
 description = "A Python build backend"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-build/pyproject.toml
+++ b/crates/fyn-build/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fyn-build"
-version = "0.10.15"
+version = "0.10.16"
 description = "The fyn build backend"
 authors = [{ name = "fyn contributors" }]
 requires-python = ">=3.8"

--- a/crates/fyn-cache-info/Cargo.toml
+++ b/crates/fyn-cache-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-cache-info"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-cache-info/README.md
+++ b/crates/fyn-cache-info/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-cache-info).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-cache-info).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-cache-key/Cargo.toml
+++ b/crates/fyn-cache-key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-cache-key"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-cache-key/README.md
+++ b/crates/fyn-cache-key/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-cache-key).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-cache-key).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-cache/Cargo.toml
+++ b/crates/fyn-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-cache"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-cache/README.md
+++ b/crates/fyn-cache/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-cache).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-cache).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-cli/Cargo.toml
+++ b/crates/fyn-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-cli"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-cli/README.md
+++ b/crates/fyn-cli/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-cli).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-cli).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-client/Cargo.toml
+++ b/crates/fyn-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-client"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-client/README.md
+++ b/crates/fyn-client/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-client).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-client).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-configuration/Cargo.toml
+++ b/crates/fyn-configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-configuration"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-configuration/README.md
+++ b/crates/fyn-configuration/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-configuration).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-configuration).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-console/Cargo.toml
+++ b/crates/fyn-console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-console"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-console/README.md
+++ b/crates/fyn-console/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-console).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-console).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-dev/Cargo.toml
+++ b/crates/fyn-dev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-dev"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 publish = false
 

--- a/crates/fyn-dev/README.md
+++ b/crates/fyn-dev/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-dev).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-dev).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-dirs/Cargo.toml
+++ b/crates/fyn-dirs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-dirs"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-dirs/README.md
+++ b/crates/fyn-dirs/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-dirs).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-dirs).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-dispatch/Cargo.toml
+++ b/crates/fyn-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-dispatch"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-dispatch/README.md
+++ b/crates/fyn-dispatch/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-dispatch).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-dispatch).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-distribution-filename/Cargo.toml
+++ b/crates/fyn-distribution-filename/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-distribution-filename"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-distribution-filename/README.md
+++ b/crates/fyn-distribution-filename/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
 source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-distribution-filename).
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-distribution-filename).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-distribution-types/Cargo.toml
+++ b/crates/fyn-distribution-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-distribution-types"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-distribution-types/README.md
+++ b/crates/fyn-distribution-types/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
 source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-distribution-types).
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-distribution-types).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-distribution/Cargo.toml
+++ b/crates/fyn-distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-distribution"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-distribution/README.md
+++ b/crates/fyn-distribution/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-distribution).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-distribution).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-extract/Cargo.toml
+++ b/crates/fyn-extract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-extract"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-extract/README.md
+++ b/crates/fyn-extract/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-extract).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-extract).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-flags/Cargo.toml
+++ b/crates/fyn-flags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-flags"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-flags/README.md
+++ b/crates/fyn-flags/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-flags).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-flags).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-fs/Cargo.toml
+++ b/crates/fyn-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-fs"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-fs/README.md
+++ b/crates/fyn-fs/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-fs).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-fs).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-git-types/Cargo.toml
+++ b/crates/fyn-git-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-git-types"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-git-types/README.md
+++ b/crates/fyn-git-types/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-git-types).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-git-types).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-git/Cargo.toml
+++ b/crates/fyn-git/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-git"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-git/README.md
+++ b/crates/fyn-git/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-git).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-git).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-globfilter/Cargo.toml
+++ b/crates/fyn-globfilter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-globfilter"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 readme = "README.md"
 edition = { workspace = true }

--- a/crates/fyn-install-wheel/Cargo.toml
+++ b/crates/fyn-install-wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-install-wheel"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 keywords = ["wheel", "python"]
 

--- a/crates/fyn-install-wheel/README.md
+++ b/crates/fyn-install-wheel/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-install-wheel).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-install-wheel).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-installer/Cargo.toml
+++ b/crates/fyn-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-installer"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-installer/README.md
+++ b/crates/fyn-installer/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-installer).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-installer).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-keyring/Cargo.toml
+++ b/crates/fyn-keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-keyring"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-logging/Cargo.toml
+++ b/crates/fyn-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-logging"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-logging/README.md
+++ b/crates/fyn-logging/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-logging).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-logging).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-macros/Cargo.toml
+++ b/crates/fyn-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-macros"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-macros/README.md
+++ b/crates/fyn-macros/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-macros).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-macros).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-metadata/Cargo.toml
+++ b/crates/fyn-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-metadata"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-metadata/README.md
+++ b/crates/fyn-metadata/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-metadata).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-metadata).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-normalize/Cargo.toml
+++ b/crates/fyn-normalize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-normalize"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-normalize/README.md
+++ b/crates/fyn-normalize/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-normalize).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-normalize).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-once-map/Cargo.toml
+++ b/crates/fyn-once-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-once-map"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-once-map/README.md
+++ b/crates/fyn-once-map/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-once-map).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-once-map).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-options-metadata/Cargo.toml
+++ b/crates/fyn-options-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-options-metadata"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-options-metadata/README.md
+++ b/crates/fyn-options-metadata/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
 source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-options-metadata).
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-options-metadata).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-pep440/Cargo.toml
+++ b/crates/fyn-pep440/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-pep440"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 license = "Apache-2.0 OR BSD-2-Clause"
 include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md", "pyproject.toml"]

--- a/crates/fyn-pep440/README.md
+++ b/crates/fyn-pep440/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-pep440).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-pep440).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-pep508/Cargo.toml
+++ b/crates/fyn-pep508/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-pep508"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md", "pyproject.toml"]
 license = "Apache-2.0 OR BSD-2-Clause"

--- a/crates/fyn-pep508/README.md
+++ b/crates/fyn-pep508/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-pep508).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-pep508).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-performance-memory-allocator/Cargo.toml
+++ b/crates/fyn-performance-memory-allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-performance-memory-allocator"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-performance-memory-allocator/README.md
+++ b/crates/fyn-performance-memory-allocator/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
 source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-performance-memory-allocator).
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-performance-memory-allocator).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-platform-tags/Cargo.toml
+++ b/crates/fyn-platform-tags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-platform-tags"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-platform-tags/README.md
+++ b/crates/fyn-platform-tags/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-platform-tags).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-platform-tags).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-platform/Cargo.toml
+++ b/crates/fyn-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-platform"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-platform/README.md
+++ b/crates/fyn-platform/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-platform).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-platform).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-preview/Cargo.toml
+++ b/crates/fyn-preview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-preview"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-preview/README.md
+++ b/crates/fyn-preview/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-preview).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-preview).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-publish/Cargo.toml
+++ b/crates/fyn-publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-publish"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-publish/README.md
+++ b/crates/fyn-publish/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-publish).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-publish).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-pypi-types/Cargo.toml
+++ b/crates/fyn-pypi-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-pypi-types"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-pypi-types/README.md
+++ b/crates/fyn-pypi-types/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-pypi-types).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-pypi-types).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-python/Cargo.toml
+++ b/crates/fyn-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-python"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-python/README.md
+++ b/crates/fyn-python/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-python).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-python).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-redacted/Cargo.toml
+++ b/crates/fyn-redacted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-redacted"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-redacted/README.md
+++ b/crates/fyn-redacted/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-redacted).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-redacted).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-requirements-txt/Cargo.toml
+++ b/crates/fyn-requirements-txt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-requirements-txt"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-requirements-txt/README.md
+++ b/crates/fyn-requirements-txt/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
 source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-requirements-txt).
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-requirements-txt).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-requirements/Cargo.toml
+++ b/crates/fyn-requirements/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-requirements"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-requirements/README.md
+++ b/crates/fyn-requirements/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-requirements).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-requirements).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-resolver/Cargo.toml
+++ b/crates/fyn-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-resolver"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-resolver/README.md
+++ b/crates/fyn-resolver/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-resolver).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-resolver).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-scripts/Cargo.toml
+++ b/crates/fyn-scripts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-scripts"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-scripts/README.md
+++ b/crates/fyn-scripts/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-scripts).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-scripts).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-settings/Cargo.toml
+++ b/crates/fyn-settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-settings"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-settings/README.md
+++ b/crates/fyn-settings/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-settings).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-settings).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-shell/Cargo.toml
+++ b/crates/fyn-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-shell"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-shell/README.md
+++ b/crates/fyn-shell/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-shell).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-shell).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-small-str/Cargo.toml
+++ b/crates/fyn-small-str/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-small-str"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-small-str/README.md
+++ b/crates/fyn-small-str/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-small-str).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-small-str).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-state/Cargo.toml
+++ b/crates/fyn-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-state"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-state/README.md
+++ b/crates/fyn-state/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-state).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-state).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-static/Cargo.toml
+++ b/crates/fyn-static/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-static"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-static/README.md
+++ b/crates/fyn-static/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-static).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-static).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-test/Cargo.toml
+++ b/crates/fyn-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-test"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-test/README.md
+++ b/crates/fyn-test/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-test).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-test).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-tool/Cargo.toml
+++ b/crates/fyn-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-tool"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-tool/README.md
+++ b/crates/fyn-tool/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-tool).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-tool).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-torch/Cargo.toml
+++ b/crates/fyn-torch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-torch"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-torch/README.md
+++ b/crates/fyn-torch/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-torch).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-torch).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-trampoline-builder/Cargo.toml
+++ b/crates/fyn-trampoline-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-trampoline-builder"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 
 edition = { workspace = true }

--- a/crates/fyn-trampoline-builder/README.md
+++ b/crates/fyn-trampoline-builder/README.md
@@ -5,8 +5,8 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
 source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-trampoline-builder).
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-trampoline-builder).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-trampoline/Cargo.lock
+++ b/crates/fyn-trampoline/Cargo.lock
@@ -16,17 +16,17 @@ checksum = "94cdc65b1cf9e871453ce2f86f5aaec24ff2eaa36a1fa3e02e441dddc3613b99"
 
 [[package]]
 name = "fyn-macros"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "textwrap",
 ]
 
 [[package]]
 name = "fyn-static"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "fyn-macros",
  "thiserror",
@@ -47,25 +47,25 @@ dependencies = [
 
 [[package]]
 name = "fyn-windows"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "windows",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -89,9 +89,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -111,22 +122,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -228,7 +239,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -239,7 +250,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/fyn-types/Cargo.toml
+++ b/crates/fyn-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-types"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-types/README.md
+++ b/crates/fyn-types/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-types).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-types).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-unix/Cargo.toml
+++ b/crates/fyn-unix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-unix"
-version = "0.0.36"
+version = "0.0.37"
 description = "Unix-specific functionality for fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-unix/README.md
+++ b/crates/fyn-unix/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-unix).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-unix).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-version/Cargo.toml
+++ b/crates/fyn-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-version"
-version = "0.10.15"
+version = "0.10.16"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-version/README.md
+++ b/crates/fyn-version/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.10.15) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-version).
+This version (0.10.16) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-version).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-virtualenv/Cargo.toml
+++ b/crates/fyn-virtualenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-virtualenv"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 keywords = ["virtualenv", "venv", "python"]
 

--- a/crates/fyn-warnings/Cargo.toml
+++ b/crates/fyn-warnings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-warnings"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-warnings/README.md
+++ b/crates/fyn-warnings/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-warnings).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-warnings).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-windows/Cargo.toml
+++ b/crates/fyn-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-windows"
-version = "0.0.36"
+version = "0.0.37"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/crates/fyn-windows/README.md
+++ b/crates/fyn-windows/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-windows).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-windows).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn-workspace/Cargo.toml
+++ b/crates/fyn-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn-workspace"
-version = "0.0.36"
+version = "0.0.37"
 description = "This is an internal component crate of fyn"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn-workspace/README.md
+++ b/crates/fyn-workspace/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [fyn](https://crates.io/crates/fyn). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.36) is a component of [fyn 0.10.15](https://crates.io/crates/fyn/0.10.15). The
-source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn-workspace).
+This version (0.0.37) is a component of [fyn 0.10.16](https://crates.io/crates/fyn/0.10.16). The
+source can be found [here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn-workspace).
 
 See fyn's crate versioning policy for details on versioning.

--- a/crates/fyn/Cargo.toml
+++ b/crates/fyn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fyn"
-version = "0.10.15"
+version = "0.10.16"
 description = "A Python package and project manager"
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/fyn/README.md
+++ b/crates/fyn/README.md
@@ -9,8 +9,8 @@ See the [repository](https://github.com/duriantaco/fyn) for more information.
 This crate is the entry point to the fyn command-line interface. The Rust API exposed here is not
 considered public interface.
 
-This is version 0.10.15. The source can be found
-[here](https://github.com/duriantaco/fyn/blob/0.10.15/crates/fyn).
+This is version 0.10.16. The source can be found
+[here](https://github.com/duriantaco/fyn/blob/0.10.16/crates/fyn).
 
 The following fyn workspace members are also available:
 

--- a/docs/concepts/build-backend.md
+++ b/docs/concepts/build-backend.md
@@ -31,7 +31,7 @@ To use fyn as a build backend in an existing project, add `fyn_build` to the
 
 ```toml title="pyproject.toml"
 [build-system]
-requires = ["fyn_build>=0.10.15,<0.11.0"]
+requires = ["fyn_build>=0.10.16,<0.11.0"]
 build-backend = "fyn_build"
 ```
 

--- a/docs/concepts/projects/init.md
+++ b/docs/concepts/projects/init.md
@@ -113,7 +113,7 @@ dependencies = []
 example-pkg = "example_pkg:main"
 
 [build-system]
-requires = ["fyn_build>=0.10.15,<0.11.0"]
+requires = ["fyn_build>=0.10.16,<0.11.0"]
 build-backend = "fyn_build"
 ```
 
@@ -136,7 +136,7 @@ dependencies = []
 example-pkg = "example_pkg:main"
 
 [build-system]
-requires = ["fyn_build>=0.10.15,<0.11.0"]
+requires = ["fyn_build>=0.10.16,<0.11.0"]
 build-backend = "fyn_build"
 ```
 
@@ -197,7 +197,7 @@ requires-python = ">=3.11"
 dependencies = []
 
 [build-system]
-requires = ["fyn_build>=0.10.15,<0.11.0"]
+requires = ["fyn_build>=0.10.16,<0.11.0"]
 build-backend = "fyn_build"
 ```
 

--- a/docs/concepts/projects/workspaces.md
+++ b/docs/concepts/projects/workspaces.md
@@ -75,7 +75,7 @@ bird-feeder = { workspace = true }
 members = ["packages/*"]
 
 [build-system]
-requires = ["fyn_build>=0.10.15,<0.11.0"]
+requires = ["fyn_build>=0.10.16,<0.11.0"]
 build-backend = "fyn_build"
 ```
 
@@ -106,7 +106,7 @@ tqdm = { git = "https://github.com/tqdm/tqdm" }
 members = ["packages/*"]
 
 [build-system]
-requires = ["fyn_build>=0.10.15,<0.11.0"]
+requires = ["fyn_build>=0.10.16,<0.11.0"]
 build-backend = "fyn_build"
 ```
 
@@ -188,7 +188,7 @@ dependencies = ["bird-feeder", "tqdm>=4,<5"]
 bird-feeder = { path = "packages/bird-feeder" }
 
 [build-system]
-requires = ["fyn_build>=0.10.15,<0.11.0"]
+requires = ["fyn_build>=0.10.16,<0.11.0"]
 build-backend = "fyn_build"
 ```
 

--- a/docs/guides/integration/aws-lambda.md
+++ b/docs/guides/integration/aws-lambda.md
@@ -93,7 +93,7 @@ the second stage, we'll copy this directory over to the final image, omitting th
 other unnecessary files.
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/duriantaco/fyn:0.10.15 AS fyn
+FROM ghcr.io/duriantaco/fyn:0.10.16 AS fyn
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder
@@ -335,7 +335,7 @@ And confirm that opening http://127.0.0.1:8000/ in a web browser displays, "Hell
 Finally, we'll update the Dockerfile to include the local library in the deployment package:
 
 ```dockerfile title="Dockerfile"
-FROM ghcr.io/duriantaco/fyn:0.10.15 AS fyn
+FROM ghcr.io/duriantaco/fyn:0.10.16 AS fyn
 
 # First, bundle the dependencies into the task root.
 FROM public.ecr.aws/lambda/python:3.13 AS builder

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -31,7 +31,7 @@ $ docker run --rm -it ghcr.io/duriantaco/fyn:debian fyn --help
 The following distroless images are available:
 
 - `ghcr.io/duriantaco/fyn:latest`
-- `ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}`, e.g., `ghcr.io/duriantaco/fyn:0.10.15`
+- `ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}`, e.g., `ghcr.io/duriantaco/fyn:0.10.16`
 - `ghcr.io/duriantaco/fyn:{major}.{minor}`, e.g., `ghcr.io/duriantaco/fyn:0.8` (the latest patch
   version)
 
@@ -92,7 +92,7 @@ And the following derived images are available:
 
 As with the distroless image, each derived image is published with fyn version tags as
 `ghcr.io/duriantaco/fyn:{major}.{minor}.{patch}-{base}` and
-`ghcr.io/duriantaco/fyn:{major}.{minor}-{base}`, e.g., `ghcr.io/duriantaco/fyn:0.10.15-alpine`.
+`ghcr.io/duriantaco/fyn:{major}.{minor}-{base}`, e.g., `ghcr.io/duriantaco/fyn:0.10.16-alpine`.
 
 In addition, starting with `0.8` each derived image also sets `UV_TOOL_BIN_DIR` to `/usr/local/bin`
 to allow `fyn tool install` to work as expected with the default user.
@@ -132,7 +132,7 @@ Note this requires `curl` to be available.
 In either case, it is best practice to pin to a specific fyn version, e.g., with:
 
 ```dockerfile
-COPY --from=ghcr.io/duriantaco/fyn:0.10.15 /fyn /fynx /bin/
+COPY --from=ghcr.io/duriantaco/fyn:0.10.16 /fyn /fynx /bin/
 ```
 
 !!! tip
@@ -615,5 +615,5 @@ Verified OK
 !!! tip
 
     These examples use `latest`, but best practice is to verify the attestation for a specific
-    version tag, e.g., `ghcr.io/duriantaco/fyn:0.10.15`, or (even better) the specific image digest,
+    version tag, e.g., `ghcr.io/duriantaco/fyn:0.10.16`, or (even better) the specific image digest,
     such as `ghcr.io/duriantaco/fyn:0.5.27@sha256:5adf09a5a526f380237408032a9308000d14d5947eafa687ad6c6a2476787b4f`.

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -51,7 +51,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # Install a specific version of fyn.
-          version: "0.10.15"
+          version: "0.10.16"
 ```
 
 ## Setting up Python

--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -13,7 +13,7 @@ Select a variant that is suitable for your workflow.
 
 ```yaml title=".gitlab-ci.yml"
 variables:
-  UV_VERSION: "0.10.15"
+  UV_VERSION: "0.10.16"
   PYTHON_VERSION: "3.12"
   BASE_LAYER: trixie-slim
   # GitLab CI creates a separate mountpoint for the build directory,

--- a/docs/guides/integration/pre-commit.md
+++ b/docs/guides/integration/pre-commit.md
@@ -24,7 +24,7 @@ To make sure your `fyn.lock` file is up to date even if your `pyproject.toml` fi
 repos:
   - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
-    rev: 0.10.15
+    rev: 0.10.16
     hooks:
       - id: fyn-lock
 ```
@@ -35,7 +35,7 @@ To keep a `requirements.txt` file in sync with your `fyn.lock` file:
 repos:
   - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
-    rev: 0.10.15
+    rev: 0.10.16
     hooks:
       - id: fyn-export
 ```
@@ -46,7 +46,7 @@ To compile requirements files:
 repos:
   - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
-    rev: 0.10.15
+    rev: 0.10.16
     hooks:
       # Compile requirements
       - id: pip-compile
@@ -59,7 +59,7 @@ To compile alternative requirements files, modify `args` and `files`:
 repos:
   - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
-    rev: 0.10.15
+    rev: 0.10.16
     hooks:
       # Compile requirements
       - id: pip-compile
@@ -73,7 +73,7 @@ To run the hook over multiple files at the same time, add additional entries:
 repos:
   - repo: https://github.com/duriantaco/fyn-pre-commit
     # fyn version.
-    rev: 0.10.15
+    rev: 0.10.16
     hooks:
       # Compile requirements
       - id: pip-compile

--- a/fyn.lock
+++ b/fyn.lock
@@ -270,7 +270,7 @@ wheels = [
 
 [[package]]
 name = "fyn"
-version = "0.10.15"
+version = "0.10.16"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "fyn"
-version = "0.10.15"
+version = "0.10.16"
 description = "An extremely fast Python package and project manager, written in Rust."
 authors = [{ name = "fyn contributors" }]
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

Prepare the 0.10.16 release.

- bump fyn, fyn-build, and fyn-version to 0.10.16
- refresh internal workspace crate versions, lockfiles, generated READMEs, and schema
- generate the 0.10.16 changelog dated 2026-08-14
- include hardened release publishing and verification from #188
- include native transactional project dependency upgrades from #189

## Validation

- `scripts/release.sh --validate-release-tags`
- `scripts/release.sh`
- `python3 scripts/validate-release.py metadata --tag 0.10.16`
