### PR TITLE
test(python): refresh download list snapshot

### DIFF
--- a/crates/fyn/tests/it/python_list.rs
+++ b/crates/fyn/tests/it/python_list.rs
@@ -385,6 +385,7 @@ fn python_list_downloads() {
     exit_code: 0
     ----- stdout -----
     cpython-3.10.[LATEST]-[PLATFORM]    <download available>
+    cpython-3.10.20-[PLATFORM]    <download available>
     cpython-3.10.19-[PLATFORM]    <download available>
     cpython-3.10.18-[PLATFORM]    <download available>
     cpython-3.10.17-[PLATFORM]    <download available>


### PR DESCRIPTION
## Summary

  - Add CPython 3.10.20 to the `python_list_downloads` all-versions snapshot.
  - Align the expected output with the Python download metadata refreshed in #191.
